### PR TITLE
Pass `params` through descend calls and add option to dump the cache

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -153,7 +153,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             callsite = callsites[cid]
 
             # recurse
-            _descend(callsite.mi; optimize=optimize, iswarn=iswarn, debuginfo=debuginfo_key, kwargs...)
+            _descend(callsite.mi; params=params, optimize=optimize, iswarn=iswarn, debuginfo=debuginfo_key, kwargs...)
         elseif toggle === :warn
             iswarn ⊻= true
         elseif toggle === :optimize
@@ -165,6 +165,10 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             display_CI = false
         elseif toggle === :native
             cthulhu_native()
+            display_CI = false
+        elseif toggle === :dump_params
+            @info "Dumping inference cache"
+            Core.show(map(((i, x),) -> (i, x.result, x.linfo), enumerate(params.cache)))
             display_CI = false
         else
             error("Unknown option $toggle")

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -41,6 +41,7 @@ function TerminalMenus.header(m::CthulhuMenu)
     """
     Select a call to descend into or ↩ to ascend. [q]uit.
     Toggles: [o]ptimize, [w]arn, [d]ebuginfo.
+    Advanced: dump [P]arams cache. 
     """
 #    Display: [L] for code_llvm, [N] for code_native
 end
@@ -60,6 +61,8 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
         return true
     elseif key == UInt32('N')
         m.toggle = :native
+    elseif key == UInt32('P')
+        m.toggle = :dump_params
         return true
     end
     return false


### PR DESCRIPTION
Very helpful for debugging Cassette issues (cc: @jrevels )

@Keno do you forsee any issue with re-use the params cache? I was thinking about creating a deepcopy before each descend so that one can go up, without potentially poisoning the cache.