### PR TITLE
Add special handling for return_type

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -124,7 +124,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
 
         if display_CI
             println()
-            println("│ ─ $(string(Callsite(-1, mi, rt)))")
+            println("│ ─ $(string(Callsite(-1, MICallInfo(mi, rt))))")
 
             debuginfo_key = debuginfo ? :source : :none
             if iswarn
@@ -153,7 +153,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             callsite = callsites[cid]
 
             # recurse
-            _descend(callsite.mi; params=params, optimize=optimize, iswarn=iswarn, debuginfo=debuginfo_key, kwargs...)
+            _descend(get_mi(callsite); params=params, optimize=optimize, iswarn=iswarn, debuginfo=debuginfo_key, kwargs...)
         elseif toggle === :warn
             iswarn ⊻= true
         elseif toggle === :optimize

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -37,6 +37,13 @@ end
 callsites = find_callsites_by_ftt(foo_callsite_assign, Tuple{}; optimize=false)
 @test length(callsites) == 1
 
+@eval function call_rt()
+    S = $(Core.Compiler.return_type)(+, Tuple{Int, Int})
+end
+let callsites = find_callsites_by_ftt(call_rt, Tuple{}; optimize=false)
+    @test length(callsites) == 1
+end
+
 if VERSION >= v"1.1.0-DEV.215" && Base.JLOptions().check_bounds == 0
 Base.@propagate_inbounds function f(x)
     @boundscheck error()
@@ -44,11 +51,11 @@ end
 g(x) = @inbounds f(x)
 h(x) = f(x)
 
-let CI, _, _, _ = process(g, Tuple{Vector{Float64}})
+let (CI, _, _, _) = process(g, Tuple{Vector{Float64}})
     @test length(CI.code) == 3
 end
 
-let CI, _, _, _ = process(h, Tuple{Vector{Float64}})
+let (CI, _, _, _) = process(h, Tuple{Vector{Float64}})
     @test length(CI.code) == 2
 end
 end


### PR DESCRIPTION
The idea is that the user will generally want to descend into
function that we're querying the return type of. However,
to differentiate this from a regular function call, I add a
special kind of callsite info to indicate this kind of call site
such that we may print it specially.