### PR TITLE
Request: Syntax-highlight for LLVM IR and native code

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -183,10 +183,18 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
         elseif toggle === :debuginfo
             debuginfo ⊻= true
         elseif toggle === :llvm
-            cthulhu_llvm(stdout, mi, optimize, debuginfo, params)
+            cthulhu_llvm(stdout, mi, optimize, debuginfo, params, CONFIG)
             display_CI = false
         elseif toggle === :native
-            cthulhu_native(stdout, mi, optimize, debuginfo, params)
+            cthulhu_native(stdout, mi, optimize, debuginfo, params, CONFIG)
+            display_CI = false
+        elseif toggle === :highlighter
+            CONFIG.enable_highlighter ⊻= true
+            if CONFIG.enable_highlighter
+                @info "Using syntax highlighter $(CONFIG.highlighter)"
+            else
+                @info "Turned off syntax highlighter for LLVM and native code."
+            end
             display_CI = false
         elseif toggle === :dump_params
             @info "Dumping inference cache"

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -2,8 +2,7 @@ const asm_syntax = Ref(:att)
 
 function highlight(io, lexer, x)
     Sys.which("pygmentize") === nothing && return print(io, x)
-    open(pipeline(`pygmentize -f terminal256 -O style=lovelace -l $lexer`;
-                  stdout=io, stderr=stderr), "w") do io
+    open(pipeline(`pygmentize -l $lexer`; stdout=io, stderr=stderr), "w") do io
         print(io, x)
     end
 end

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -1,28 +1,57 @@
+Base.@kwdef mutable struct CthulhuConfig
+    enable_highlighter::Bool = false
+    highlighter::Cmd = `pygmentize -l`
+end
+
+highlighter_exists(config::CthulhuConfig) =
+    Sys.which(config.highlighter.exec[1]) !== nothing
+
+@init begin
+    CONFIG.enable_highlighter = highlighter_exists(CONFIG)
+end
+
+"""
+    Cthulhu.CONFIG
+
+# Options
+- `enable_highlighter::Bool`: Use command line `highlighter` to syntax highlight
+  LLVM and native code.  Set to `true` if `highlighter` exists at the import
+  time.
+- `highlighter::Cmd`: A command line program that receives "llvm" or "asm" as
+  an argument and the code as stdin.  Defaults to `$(CthulhuConfig().highlighter)`.
+"""
+const CONFIG = CthulhuConfig()
+
 const asm_syntax = Ref(:att)
 
-function highlight(io, lexer, x)
-    Sys.which("pygmentize") === nothing && return print(io, x)
-    open(pipeline(`pygmentize -l $lexer`; stdout=io, stderr=stderr), "w") do io
+function highlight(io, x, lexer, config::CthulhuConfig)
+    config.enable_highlighter || return print(io, x)
+    if !highlighter_exists(config)
+        @warn "Highlighter command $(config.highlighter.exec[1]) does not exist."
+        return print(io, x)
+    end
+    cmd = `$(config.highlighter) $lexer`
+    open(pipeline(cmd; stdout=io, stderr=stderr), "w") do io
         print(io, x)
     end
 end
 
-function cthulhu_llvm(io::IO, mi, optimize, debuginfo, params)
+function cthulhu_llvm(io::IO, mi, optimize, debuginfo, params, config::CthulhuConfig)
     dump = InteractiveUtils._dump_function_linfo(
         mi, params.world, #=native=# false,
         #=wrapper=# false, #=strip_ir_metadata=# true,
         #=dump_module=# false, #=syntax=# asm_syntax[],
         optimize, debuginfo ? :source : :none)
-    highlight(io, "llvm", dump)
+    highlight(io, dump, "llvm", config)
 end
 
-function cthulhu_native(io::IO, mi, optimize, debuginfo, params)
+function cthulhu_native(io::IO, mi, optimize, debuginfo, params, config::CthulhuConfig)
     dump = InteractiveUtils._dump_function_linfo(
         mi, params.world, #=native=# true,
         #=wrapper=# false, #=strip_ir_metadata=# true,
         #=dump_module=# false, #=syntax=# asm_syntax[],
         optimize, debuginfo ? :source : :none)
-    highlight(io, "asm", dump)
+    highlight(io, dump, "asm", config)
 end
 
 cthulhu_warntype(args...) = cthulhu_warntype(stdout, args...)

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -1,12 +1,20 @@
 const asm_syntax = Ref(:att)
 
+function highlight(io, lexer, x)
+    Sys.which("pygmentize") === nothing && return print(io, x)
+    open(pipeline(`pygmentize -f terminal256 -O style=lovelace -l $lexer`;
+                  stdout=io, stderr=stderr), "w") do io
+        print(io, x)
+    end
+end
+
 function cthulhu_llvm(io::IO, mi, optimize, debuginfo, params)
     dump = InteractiveUtils._dump_function_linfo(
         mi, params.world, #=native=# false,
         #=wrapper=# false, #=strip_ir_metadata=# true,
         #=dump_module=# false, #=syntax=# asm_syntax[],
         optimize, debuginfo ? :source : :none)
-    print(io, dump)
+    highlight(io, "llvm", dump)
 end
 
 function cthulhu_native(io::IO, mi, optimize, debuginfo, params)
@@ -15,7 +23,7 @@ function cthulhu_native(io::IO, mi, optimize, debuginfo, params)
         #=wrapper=# false, #=strip_ir_metadata=# true,
         #=dump_module=# false, #=syntax=# asm_syntax[],
         optimize, debuginfo ? :source : :none)
-    print(io, dump)
+    highlight(io, "asm", dump)
 end
 
 cthulhu_warntype(args...) = cthulhu_warntype(stdout, args...)

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -42,7 +42,7 @@ function TerminalMenus.header(m::CthulhuMenu)
     m.sub_menu && return ""
     """
     Select a call to descend into or ↩ to ascend. [q]uit.
-    Toggles: [o]ptimize, [w]arn, [d]ebuginfo.
+    Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for LLVM/Native.
     Show: [L]LVM IR, [N]ative code
     Advanced: dump [P]arams cache.
     """
@@ -58,6 +58,9 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
         return true
     elseif key == UInt32('d')
         m.toggle = :debuginfo
+        return true
+    elseif key == UInt32('s')
+        m.toggle = :highlighter
         return true
     elseif key == UInt32('L')
         m.toggle = :llvm


### PR DESCRIPTION
Cthulhu is a very useful tool to look at generated LLVM IR and native code but one thing I'm missing is syntax highlighting.

So, I wrote this simple patch to use [`pygmentize`](http://pygments.org/docs/cmdline/) to highlight LLVM IR and ASM if it is available.  Is there any chance something like this can be merged to Cthulhu?

If hard-coding `pygmentize` usage in Cthulhu is not a good idea, one option would be to write a thin Julia wrapper for `pygmentize`. I think I can write one as I've been using my unregistered package [ColorfulCodeGen.jl](https://github.com/tkf/ColorfulCodeGen.jl) which has most of the code needed to do this.  Of course, it would be nice if there is a pure Julia solution.  But I couldn't find any generic code highlighter in Julia.
