### PR TITLE
Allow `descend_code_warntype` to accept keyword arguments

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -80,8 +80,8 @@ end
 descend_code_warntype(foo, Tuple{})
 ```
 """
-descend_code_warntype(f, @nospecialize(tt)) =
-    _descend_with_error_handling(f, tt; iswarn=true)
+descend_code_warntype(f, @nospecialize(tt); kwargs...) =
+    _descend_with_error_handling(f, tt; iswarn=true, kwargs...)
 
 function _descend_with_error_handling(f, @nospecialize(tt); kwargs...)
     try


### PR DESCRIPTION
This brings the behavior of `descend_code_warntype` in line with `descend` and `descend_code_typed`.

Fixes #49 
