### PR TITLE
Workaround an issue with spawn

### DIFF
--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -131,6 +131,7 @@ function __show_limited(limiter, name, tt, rt)
     print(limiter, ")")
 
     # If we have space for the return type, print it
+    rt === nothing && return
     rts = string(rt)
     if has_space(limiter, textwidth(rts)+2)
         print(limiter, string("::", rts))


### PR DESCRIPTION
In Julia 1.3.0-alpha.38, I noticed that `@spawn` breaks `@descend`.  Apparently `rt` can be a `nothing` so `string(rt)` throws.  This PR implements a stupid-simple workaround.

```julia
julia> f() = Threads.@spawn f()
f (generic function with 1 method)

julia> @descend f()

│ ─ %-1  = invoke f()::Task
CodeInfo(
    @ REPL[2]:1 within `f'
   ┌ @ threadingconstructs.jl:123 within `macro expansion'
1 ─│ %1 = %new(Main.:(##3#4))::Core.Compiler.Const(getfield(Main, Symbol("##3#4"))(), false)
│  │┌ @ task.jl:5 within `Task' @ task.jl:5
│  ││┌ @ condition.jl:68 within `GenericCondition'
│  │││┌ @ linked_list.jl:7 within `InvasiveLinkedList'
│  ││││ %2 = %new(Base.InvasiveLinkedList{Task}, nothing, nothing)::Base.InvasiveLinkedList{Task}
│  │││└
│  │││┌ @ locks-mt.jl:33 within `SpinLock'
│  ││││ %3 = Base.Threads.SpinLock::Type{Base.Threads.SpinLock}
│  ││││┌ @ atomics.jl:67 within `Atomic'
│  │││││ %4 = %new(Base.Threads.Atomic{Int64}, 0)::Base.Threads.Atomic{Int64}
│  ││││└
│  ││││ %5 = %new(%3, %4)::Base.Threads.SpinLock
│  │││└
│  │││ %6 = %new(Base.GenericCondition{Base.Threads.SpinLock}, %2, %5)::Base.GenericCondition{Base.Threads.SpinLock}
│  ││└
│  ││┌ @ boot.jl:386 within `_Task'
│  │││ %7 = $(Expr(:foreigncall, :(:jl_new_task), Ref{Task}, svec(Any, Any, Int64), :(:ccall), 3, :(%1), :(%6), 0, 0))::Task
│  │└└
│  │ @ threadingconstructs.jl:124 within `macro expansion'
│  │┌ @ Base.jl:21 within `setproperty!'
│  ││      Base.setfield!(%7, :sticky, false)::Bool
│  │└
│  │ @ threadingconstructs.jl:125 within `macro expansion'
│  │ %9 = $(Expr(:isdefined, :(Main.:(##sync#72))))::Bool
└──│      goto #3 if not %9
   │ @ threadingconstructs.jl:126 within `macro expansion'
2 ─│      Base.Threads.push!(Main.:(##sync#72), %7)::Any
   │ @ threadingconstructs.jl:128 within `macro expansion'
   │┌ @ task.jl:461 within `schedule'
3 ┄││      invoke Base.enq_work(%7::Task)::Task
│  └└
└──      return %7
)
ERROR: ArgumentError: `nothing` should not be printed; use `show`, `repr`, or custom output instead.
Stacktrace:
 [1] print(::Base.GenericIOBuffer{Array{UInt8,1}}, ::Nothing) at ./show.jl:593
 [2] print_to_string(::Nothing) at ./strings/io.jl:129
 [3] string(::Nothing) at ./strings/io.jl:168
 [4] __show_limited(::Cthulhu.TextWidthLimiter, ::Symbol, ::Core.SimpleVector, ::Nothing) at /home/takafumi/.julia/dev/Cthulhu/src/callsite.jl:134
 [5] show_callinfo(::Cthulhu.TextWidthLimiter, ::Cthulhu.FailedCallInfo) at /home/takafumi/.julia/dev/Cthulhu/src/callsite.jl:158
 [6] show(::IOContext{Base.GenericIOBuffer{Array{UInt8,1}}}, ::Cthulhu.Callsite) at /home/takafumi/.julia/dev/Cthulhu/src/callsite.jl:178
 [7] show_as_line(::Cthulhu.Callsite) at /home/takafumi/.julia/dev/Cthulhu/src/ui.jl:16
 [8] iterate at ./generator.jl:47 [inlined]
 [9] _collect(::Array{Cthulhu.Callsite,1}, ::Base.Generator{Array{Cthulhu.Callsite,1},typeof(Cthulhu.show_as_line)}, ::Base.EltypeUnknown, ::Base.HasShape{1}) at ./array.jl:633
 [10] collect_similar at ./array.jl:562 [inlined]
 [11] map at ./abstractarray.jl:2073 [inlined]
 [12] #CthulhuMenu#29(::Int64, ::Bool, ::Type{Cthulhu.CthulhuMenu}, ::Array{Cthulhu.Callsite,1}) at /home/takafumi/.julia/dev/Cthulhu/src/ui.jl:22
 [13] CthulhuMenu at /home/takafumi/.julia/dev/Cthulhu/src/ui.jl:22 [inlined]
 [14] #_descend#38(::Bool, ::Core.Compiler.Params, ::Bool, ::Base.Iterators.Pairs{Union{},Union{},Tuple{},NamedTuple{(),Tuple{}}}, ::typeof(Cthulhu._descend), ::Core.MethodInstance) at /home/takafumi/.julia/dev/Cthulhu/src/Cthulhu.jl:142
 [15] #_descend at ./none:0 [inlined]
 [16] #_descend#43(::Core.Compiler.Params, ::Base.Iterators.Pairs{Symbol,Bool,Tuple{Symbol},NamedTuple{(:iswarn,),Tuple{Bool}}}, ::typeof(Cthulhu._descend), ::Any, ::Any) at /home/takafumi/.julia/dev/Cthulhu/src/Cthulhu.jl:211
 [17] #_descend at ./none:0 [inlined]
 [18] #_descend_with_error_handling#37(::Base.Iterators.Pairs{Symbol,Bool,Tuple{Symbol},NamedTuple{(:iswarn,),Tuple{Bool}}}, ::typeof(Cthulhu._descend_with_error_handling), ::Function, ::Any) at /home/takafumi/.julia/dev/Cthulhu/src/Cthulhu.jl:88
 [19] #_descend_with_error_handling at ./none:0 [inlined]
 [20] #descend_code_typed#35 at /home/takafumi/.julia/dev/Cthulhu/src/Cthulhu.jl:62 [inlined]
 [21] descend_code_typed(::Function, ::Any) at /home/takafumi/.julia/dev/Cthulhu/src/Cthulhu.jl:62
 [22] top-level scope at REPL[3]:1
```
