### PR TITLE
Add newline after dump_params

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -199,6 +199,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
         elseif toggle === :dump_params
             @info "Dumping inference cache"
             Core.show(map(((i, x),) -> (i, x.result, x.linfo), enumerate(params.cache)))
+            Core.println()
             display_CI = false
         else
             error("Unknown option $toggle")


### PR DESCRIPTION
Missing newline made it hard to read.

was before:
```
[ Info: Dumping inference cache
Array{Tuple{Int64, Any, Core.MethodInstance}, (0,)}[]Select a call to descend into or ↩ to ascend. [q]uit.
```

After this should be:
```
[ Info: Dumping inference cache
Array{Tuple{Int64, Any, Core.MethodInstance}, (0,)}[]
Select a call to descend into or ↩ to ascend. [q]uit.
```