### PR TITLE
Add ability to show souce code and AST

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
+CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 Crayons = "a8cc5b0e-0ffa-5ad4-8c14-923d3ee1735f"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
@@ -15,6 +16,7 @@ julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 
 [targets]
-test = ["Test"]
+test = ["Test", "Revise"]

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -109,14 +109,8 @@ const descend = descend_code_typed
 # src/reflection.jl has the tools to discover methods
 # src/ui.jl provides the user facing interface to which _descend responds
 ##
-function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), optimize::Bool=true, kwargs...)
+function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), optimize::Bool=true, debuginfo=true, kwargs...)
     display_CI = true
-    debuginfo = true
-    if :debuginfo in keys(kwargs)
-        selected = kwargs[:debuginfo]
-        # TODO: respect default
-        debuginfo = selected == :source
-    end
 
     while true
         (CI, rt, slottypes) = do_typeinf_slottypes(mi, optimize, params)
@@ -162,8 +156,9 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             if next_mi === nothing
                 continue
             end
+             
             _descend(next_mi; params=params, optimize=optimize,
-                     iswarn=iswarn, debuginfo=debuginfo_key, kwargs...)
+                     iswarn=iswarn, debuginfo=debuginfo, kwargs...)
 
         elseif toggle === :warn
             iswarn ⊻= true

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -164,18 +164,13 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             end
             _descend(next_mi; params=params, optimize=optimize,
                      iswarn=iswarn, debuginfo=debuginfo_key, kwargs...)
+
         elseif toggle === :warn
             iswarn ⊻= true
         elseif toggle === :optimize
             optimize ⊻= true
         elseif toggle === :debuginfo
             debuginfo ⊻= true
-        elseif toggle === :llvm
-            cthulhu_llvm(stdout, mi, optimize, debuginfo, params, CONFIG)
-            display_CI = false
-        elseif toggle === :native
-            cthulhu_native(stdout, mi, optimize, debuginfo, params, CONFIG)
-            display_CI = false
         elseif toggle === :highlighter
             CONFIG.enable_highlighter ⊻= true
             if CONFIG.enable_highlighter
@@ -190,7 +185,14 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             Core.println()
             display_CI = false
         else
-            error("Unknown option $toggle")
+            #Handle Standard alternative view, e.g. :native, :llvm
+            view_cmd = get(codeviews, toggle, nothing)
+            if view_cmd !== nothing
+                view_cmd(stdout, mi, optimize, debuginfo, params, CONFIG)
+                display_CI = false
+            else
+                error("Unknown option $toggle")
+            end
         end
     end
 end

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -1,5 +1,6 @@
 module Cthulhu
 
+using CodeTracking: definition
 using InteractiveUtils
 
 using Core: MethodInstance
@@ -122,20 +123,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
         preprocess_ci!(CI, mi, optimize)
         callsites = find_callsites(CI, mi, slottypes; params=params, kwargs...)
 
-        debuginfo_key = debuginfo ? :source : :none
-        if display_CI
-            println()
-            println("│ ─ $(string(Callsite(-1, MICallInfo(mi, rt))))")
-
-            if iswarn
-                cthulhu_warntype(stdout, CI, rt, debuginfo_key)
-            elseif VERSION >= v"1.1.0-DEV.762"
-                show(stdout, CI, debuginfo = debuginfo_key)
-            else
-                display(CI=>rt)
-            end
-            println()
-        end
+        display_CI && cthulu_typed(stdout, debuginfo, CI, rt, mi, iswarn)
         display_CI = true
 
         TerminalMenus.config(cursor = '•', scroll = :wrap)

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -54,6 +54,8 @@ function cthulhu_native(io::IO, mi, optimize, debuginfo, params, config::Cthulhu
     highlight(io, dump, "asm", config)
 end
 
+#function cthulhu_ast(io::IO, 
+
 cthulhu_warntype(args...) = cthulhu_warntype(stdout, args...)
 function cthulhu_warntype(io::IO, src, rettype, debuginfo)
     if VERSION < v"1.1.0-DEV.762"
@@ -94,3 +96,12 @@ function cthulu_typed(io::IO, debuginfo, CI, rettype, mi, iswarn)
     end
     println()
 end
+
+# These are standard code views that don't need any special handling,
+# This named tuple maps toggle::Symbol to function
+const codeviews = (;
+    llvm=cthulhu_llvm,
+    native=cthulhu_native,
+   # ast=cthulhu_ast,
+    #source=cthulhu_source,
+)

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -99,8 +99,7 @@ function cthulhu_warntype(io::IO, src, rettype, debuginfo)
 end
 
 
-function cthulu_typed(io::IO, debuginfo, CI, rettype, mi, iswarn)
-    debuginfo_key = debuginfo ? :source : :none
+function cthulu_typed(io::IO, debuginfo_key, CI, rettype, mi, iswarn)
     println()
     println("│ ─ $(string(Callsite(-1, MICallInfo(mi, rettype))))")
 

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -78,3 +78,19 @@ function cthulhu_warntype(io::IO, src, rettype, debuginfo)
     end
     return nothing
 end
+
+
+function cthulu_typed(io::IO, debuginfo, CI, rettype, mi, iswarn)
+    debuginfo_key = debuginfo ? :source : :none
+    println()
+    println("│ ─ $(string(Callsite(-1, MICallInfo(mi, rettype))))")
+
+    if iswarn
+        cthulhu_warntype(stdout, CI, rettype, debuginfo_key)
+    elseif VERSION >= v"1.1.0-DEV.762"
+        show(stdout, CI, debuginfo = debuginfo_key)
+    else
+        display(CI=>rt)
+    end
+    println()
+end

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -54,7 +54,24 @@ function cthulhu_native(io::IO, mi, optimize, debuginfo, params, config::Cthulhu
     highlight(io, dump, "asm", config)
 end
 
-#function cthulhu_ast(io::IO, 
+function cthulhu_ast(io::IO, mi, optimize, debuginfo, params, config::CthulhuConfig)
+    meth = mi.def
+    ast = definition(Expr, meth)
+    if ast!==nothing
+        dump(io, ast; maxdepth=typemax(Int))
+        # Or should use: ?
+        #Meta.show_expr(io, ast)
+        # Could even highlight the above as some kind-of LISP
+    else
+        @info "Could not retrieve AST. AST display requires Revise.jl to be loaded." meth
+    end
+end
+
+function cthulhu_source(io::IO, mi, optimize, debuginfo, params, config::CthulhuConfig)
+    meth = mi.def
+    src, line = definition(String, meth)
+    highlight(io, src, "julia", config)
+end
 
 cthulhu_warntype(args...) = cthulhu_warntype(stdout, args...)
 function cthulhu_warntype(io::IO, src, rettype, debuginfo)
@@ -98,10 +115,10 @@ function cthulu_typed(io::IO, debuginfo, CI, rettype, mi, iswarn)
 end
 
 # These are standard code views that don't need any special handling,
-# This named tuple maps toggle::Symbol to function
+# This namedtuple maps toggle::Symbol to function
 const codeviews = (;
     llvm=cthulhu_llvm,
     native=cthulhu_native,
-   # ast=cthulhu_ast,
-    #source=cthulhu_source,
+    ast=cthulhu_ast,
+    source=cthulhu_source,
 )

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -42,8 +42,8 @@ function TerminalMenus.header(m::CthulhuMenu)
     m.sub_menu && return ""
     """
     Select a call to descend into or ↩ to ascend. [q]uit.
-    Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for LLVM/Native.
-    Show: [L]LVM IR, [N]ative code
+    Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
+    Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
     Advanced: dump [P]arams cache.
     """
 end
@@ -61,6 +61,12 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
         return true
     elseif key == UInt32('s')
         m.toggle = :highlighter
+        return true
+   elseif key == UInt32('S')
+        m.toggle = :source
+        return true
+   elseif key == UInt32('A')
+        m.toggle = :ast
         return true
     elseif key == UInt32('L')
         m.toggle = :llvm


### PR DESCRIPTION
Close #47 

It also reorganizes some of the displaying things code.
idk if it is actually an improvement.
At some point someone should think about how to do Model+ViewController seperation in julia.
If you hate it, can always just cut this back to the minimal changes needed for just displaying source / AST

Screenshouts:

Source:
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/5127634/62936294-55f57c00-bdc1-11e9-9081-c98f2a170b90.png">

AST:
<img width="1128" alt="image" src="https://user-images.githubusercontent.com/5127634/62939364-03b85900-bdc9-11e9-90fa-3ce925d3a1b7.png">


idk if that is the best way to render the AST.
See commments in code.


TODO: Tests

@TimHoly may find this of interest.