### PR TITLE
README.md: Explain the difference between `invoke` and `call` statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ descend(f, tt)
 ```
 
 Given a function and a tuple-type, interactively explore the output of
-`code_typed` by descending into `invoke` statements. Type enter to select an
-`invoke` to descend into, select ↩  to ascend, and press q or control-c to
-quit.
+`code_typed` by descending into `invoke` and `call` statements. (`invoke`
+statements correspond to static dispatch, whereas `call` statements correspond
+to dynamic dispatch.) Press enter to select an `invoke` or `call` to descend
+into, select ↩  to ascend, and press q or control-c to quit.
 
 ## Usage
 


### PR DESCRIPTION
@vchuravy explained to me on Slack that `invoke` corresponds to a statically dispatched call site, whereas `call` corresponds to a dynamically dispatched call site.

This pull request adds a sentence to `README.md` explaining the difference between `invoke` and `call`.