### PR TITLE
Add "bookmark" UI: save method for later introspection

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -216,9 +216,11 @@ function preprocess_ci!(ci, mi, optimize, config::CthulhuConfig)
 end
 
 if :trace_inference_limits in fieldnames(Core.Compiler.Params)
-    current_params() = Core.Compiler.CustomParams(ccall(:jl_get_world_counter, UInt, ()); trace_inference_limits=true)
+    const CompilerParams = Core.Compiler.CustomParams
+    current_params() = CompilerParams(ccall(:jl_get_world_counter, UInt, ()); trace_inference_limits=true)
 else
-    current_params() = Core.Compiler.Params(ccall(:jl_get_world_counter, UInt, ()))
+    const CompilerParams = Core.Compiler.Params
+    current_params() = CompilerParams(ccall(:jl_get_world_counter, UInt, ()))
 end
 
 function first_method_instance(@nospecialize(F), @nospecialize(TT); params=current_params())

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -41,7 +41,7 @@ TerminalMenus.cancel(m::CthulhuMenu) = m.selected = -1
 function TerminalMenus.header(m::CthulhuMenu)
     m.sub_menu && return ""
     """
-    Select a call to descend into or ↩ to ascend. [q]uit.
+    Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
     Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
     Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
     Advanced: dump [P]arams cache.
@@ -76,6 +76,9 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
         return true
     elseif key == UInt32('P')
         m.toggle = :dump_params
+        return true
+    elseif key == UInt32('b')
+        m.toggle = :bookmark
         return true
     end
     return false


### PR DESCRIPTION
This PR adds a simple "bookmarking" UI/API to Cthulhu.jl.

During descent, you can type <kbd>b</kbd> to store a `Cthulhu.Bookmark` object recording current method to `Cthulhu.BOOKMARKS`.  This is simply defined as

```julia
struct Bookmark
    mi::MethodInstance
    params::Core.Compiler.Params  # or Core.Compiler.CustomParams
end
```

This object exposes the following API:

> A `Cthulhu.Bookmark` remembers a method marked by `b` key during a descent.
> It can be used with the following functions:
>
> * `descend(::Bookmark)`, `descend_code_typed(::Bookmark)`, `descend_code_warntype(::Bookmark)`: continue the descent.
> * `code_typed(::Bookmark)`, `code_warntype([::IO,] ::Bookmark)`: show typed IR
> * `code_llvm([::IO,] ::Bookmark)`: pretty-print LLVM IR
> * `code_native([::IO,] ::Bookmark)`: pretty-print native code

My motivation for this is to use [`TmuxDisplays.tmuxdisplay`](https://github.com/tkf/TmuxDisplays.jl) to compare IRs of different methods:

```julia
code_llvm(IO(tmuxdisplay()), Cthulhu.BOOKMARKS[end])
code_llvm(IO(tmuxdisplay(split=true)), Cthulhu.BOOKMARKS[end-1])
```

Once TypedCodeUtils integration is finished, you might want to use `TypedCodeUtils.Reflection` instead of `Cthulhu.Bookmark`.  But I think this addition is simple and useful enough to do this before integrating TypedCodeUtils.
