### PR TITLE
Change TerminalMenus.jl to REPL.TerminalMenus

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,13 +6,12 @@ version = "1.0.0"
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
-TerminalMenus = "dc548174-15c3-5faf-af27-7997cfbde655"
+REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
-julia = "1"
 CodeTracking = "0.5"
-TerminalMenus = "0.1"
+julia = "1"
 
 [extras]
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -1,5 +1,5 @@
-import TerminalMenus
-import TerminalMenus: request
+import REPL.TerminalMenus
+import REPL.TerminalMenus: request
 
 mutable struct CthulhuMenu <: TerminalMenus.AbstractMenu
     options::Vector{String}


### PR DESCRIPTION
TerminalMenus.jl is deprecated since this was added to the REPL. But using the deprecated version blocks Compat 3, so:

```julia
(@v1.4) pkg> add CuArrays@2 Compat@3
  Resolving package versions...
ERROR: Unsatisfiable requirements detected for package Cthulhu [f68482b8]:
 Cthulhu [f68482b8] log:
 ├─possible versions are: [0.1.0-0.1.2, 1.0.0] or uninstalled
 ├─restricted by compatibility requirements with TerminalMenus [dc548174] to versions: uninstalled
 │ └─TerminalMenus [dc548174] log:
 │   ├─possible versions are: 0.1.0 or uninstalled
 │   └─restricted by compatibility requirements with Compat [34da2185] to versions: uninstalled
 │     └─Compat [34da2185] log:
 │       ├─possible versions are: [1.0.0-1.0.1, 1.1.0, 1.2.0, 1.3.0, 1.4.0, 1.5.0-1.5.1, 2.0.0, 2.1.0, 2.2.0, 3.0.0, 3.1.0, 3.2.0, 3.3.0-3.3.1, 3.4.0, 3.5.0, 3.6.0, 3.7.0, 3.8.0] or uninstalled
 │       └─restricted to versions 3 by an explicit requirement, leaving only versions [3.0.0, 3.1.0, 3.2.0, 3.3.0-3.3.1, 3.4.0, 3.5.0, 3.6.0, 3.7.0, 3.8.0]
 └─restricted by compatibility requirements with CUDAnative [be33ccc6] to versions: 1.0.0 — no versions left
   └─CUDAnative [be33ccc6] log:
     ├─possible versions are: [0.7.0, 0.8.0-0.8.10, 0.9.0-0.9.1, 0.10.0-0.10.1, 1.0.0-1.0.1, 2.0.0-2.0.1, 2.1.0-2.1.3, 2.2.0-2.2.1, 2.3.0-2.3.1, 2.4.0, 2.5.0-2.5.5, 2.6.0, 2.7.0, 2.8.0-2.8.1, 2.9.0-2.9.1, 2.10.0-2.10.2, 3.0.0-3.0.2] or uninstalled
     └─restricted by compatibility requirements with CuArrays [3a865a2d] to versions: 3.0.0-3.0.2
       └─CuArrays [3a865a2d] log:
         ├─possible versions are: [0.2.1, 0.3.0, 0.4.0, 0.5.0, 0.6.0-0.6.2, 0.7.0-0.7.3, 0.8.0-0.8.1, 0.9.0-0.9.1, 1.0.0-1.0.2, 1.1.0, 1.2.0-1.2.1, 1.3.0, 1.4.0-1.4.7, 1.5.0, 1.6.0, 1.7.0-1.7.3, 2.0.0-2.0.1] or uninstalled       
         └─restricted to versions 2.0.1 by an explicit requirement, leaving only versions 2.0.1
```

Cthulhu like this causes odd problems when it shows up as a dependency to the GPU stack.