### PR TITLE
add descend string macro

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -37,7 +37,7 @@ include("reflection.jl")
 include("ui.jl")
 include("codeview.jl")
 
-export descend, @descend, descend_code_typed, descend_code_warntype, @descend_code_typed, @descend_code_warntype
+export descend, @descend, descend_code_typed, descend_code_warntype, @descend_code_typed, @descend_code_warntype, @descend_str
 
 """
     @descend_code_typed
@@ -232,6 +232,22 @@ end
 function _descend(@nospecialize(F), @nospecialize(TT); params=current_params(), kwargs...)
     mi = first_method_instance(F, TT; params=params)
     _descend(mi; params=params, kwargs...)
+end
+
+macro descend_str(abstract_call)
+    r = findfirst("(", abstract_call)
+    if r === nothing
+        error("Does not contain a '('")
+    end
+    fname = abstract_call[1:(first(r)-1)]
+    sig   = abstract_call[first(r):end]
+    sig   = replace(sig, "::" => "")
+    sig   = Meta.parse(sig)
+    func  = Meta.parse(fname)
+
+    quote
+        $descend($func, $Tuple{$sig...})
+    end
 end
 
 end


### PR DESCRIPTION
This allows for users to take a stacktrace like:

```
julia> wait(kernel!(a, b, c, ndrange=size(c)))ERROR: TaskFailedException:MethodError: no method matching __index_Global_Cartesian(::CartesianIndex{2})Stacktrace:
 [1] __index_Global_NTuple at /home/vchuravy/src/KernelAbstractions/src/KernelAbstractions.jl:291 [inlined]
 [2] cpu_matmul_kernel! at /home/vchuravy/src/KernelAbstractions/src/macros.jl:229 [inlined]
 [3] __thread_run(::Int64, ::Int64, ::Int64, ::KernelAbstractions.Kernel{CPU,KernelAbstractions.NDIteration.StaticSize{(4,)},KernelAbstractions.NDIteratio
n.DynamicSize,typeof(cpu_matmul_kernel!)}, ::Tuple{Int64,Int64}, ::KernelAbstractions.NDIteration.NDRange{2,KernelAbstractions.NDIteration.DynamicSize,Ker
nelAbstractions.NDIteration.StaticSize{(4, 1)},CartesianIndices{2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},Nothing}, ::Tuple{Array{Float64,2},Array{Flo
at64,2},Array{Float64,2}}, ::KernelAbstractions.NDIteration.NoDynamicCheck) at /home/vchuravy/src/KernelAbstractions/src/backends/cpu.jl:148
 [4] __run(::KernelAbstractions.Kernel{CPU,KernelAbstractions.NDIteration.StaticSize{(4,)},KernelAbstractions.NDIteration.DynamicSize,typeof(cpu_matmul_ke
rnel!)}, ::Tuple{Int64,Int64}, ::KernelAbstractions.NDIteration.NDRange{2,KernelAbstractions.NDIteration.DynamicSize,KernelAbstractions.NDIteration.Static
Size{(4, 1)},CartesianIndices{2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},Nothing}, ::Tuple{Array{Float64,2},Array{Float64,2},Array{Float64,2}}, ::Kerne
lAbstractions.NDIteration.NoDynamicCheck) at /home/vchuravy/src/KernelAbstractions/src/backends/cpu.jl:121
 [5] (::KernelAbstractions.var"#30#31"{Nothing,Nothing,typeof(KernelAbstractions.__run),Tuple{KernelAbstractions.Kernel{CPU,KernelAbstractions.NDIteration.StaticSize{(4,)},KernelAbstractions.NDIteration.DynamicSize,typeof(cpu_matmul_kernel!)},Tuple{Int64,Int64},KernelAbstractions.NDIteration.NDRange{2,KernelAbstractions.NDIteration.DynamicSize,KernelAbstractions.NDIteration.StaticSize{(4, 1)},CartesianIndices{2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},Nothing},Tuple{Array{Float64,2},Array{Float64,2},Array{Float64,2}},KernelAbstractions.NDIteration.NoDynamicCheck}})() at /home/vchuravy/src/KernelAbstractions/src/backends/cpu.jl:20
Stacktrace:
 [1] wait at ./task.jl:267 [inlined]
 [2] wait at /home/vchuravy/src/KernelAbstractions/src/backends/cpu.jl:63 [inlined]
 [3] wait at /home/vchuravy/src/KernelAbstractions/src/backends/cpu.jl:27 [inlined] (repeats 2 times)
 [4] top-level scope at REPL[30]:1
```

And invoke:

```
descend"KernelAbstractions.__thread_run(::Int64, ::Int64, ::Int64, ::KernelAbstractions.Kernel{CPU,KernelAbstractions.NDIteration.StaticSize{(4,)},KernelAbstractions.NDIteratio
n.DynamicSize,typeof(cpu_matmul_kernel!)}, ::Tuple{Int64,Int64}, ::KernelAbstractions.NDIteration.NDRange{2,KernelAbstractions.NDIteration.DynamicSize,Ker
nelAbstractions.NDIteration.StaticSize{(4, 1)},CartesianIndices{2,Tuple{Base.OneTo{Int64},Base.OneTo{Int64}}},Nothing}, ::Tuple{Array{Float64,2},Array{Flo
at64,2},Array{Float64,2}}, ::KernelAbstractions.NDIteration.NoDynamicCheck)"
```