### PR TITLE
Vanquish evil with thine eyes fixed on the heavens

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "1.0.2"
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -1,7 +1,8 @@
 module Cthulhu
 
-using CodeTracking: definition
+using CodeTracking: definition, whereis
 using InteractiveUtils
+using UUIDs
 
 using Core: MethodInstance
 const Compiler = Core.Compiler
@@ -218,6 +219,17 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             Core.show(map(((i, x),) -> (i, x.result, x.linfo), enumerate(params.cache)))
             Core.println()
             display_CI = false
+        elseif toggle === :revise
+            # Call Revise.revise() without introducing a dependency on Revise
+            id = Base.PkgId(UUID("295af30f-e4ad-537b-8983-00126c2a3abe"), "Revise")
+            mod = get(Base.loaded_modules, id, nothing)
+            if mod !== nothing
+                revise = getfield(mod, :revise)
+                revise()
+                mi = first_method_instance(mi.specTypes)
+            end
+        elseif toggle === :edit
+            edit(whereis(mi.def)...)
         else
             #Handle Standard alternative view, e.g. :native, :llvm
             view_cmd = get(codeviews, toggle, nothing)

--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -1,0 +1,77 @@
+# A lightly-modified version of the same function in Base
+# Highlights argument types with color specified by highlighter(typ)
+function show_tuple_as_call(@nospecialize(highlighter), io::IO, name::Symbol, sig::Type, demangle=false, kwargs=nothing)
+    if sig === Tuple
+        print(io, demangle ? Base.demangle_function_name(name) : name, "(...)")
+        return
+    end
+    tv = Any[]
+    env_io = io
+    while isa(sig, UnionAll)
+        push!(tv, sig.var)
+        env_io = IOContext(env_io, :unionall_env => sig.var)
+        sig = sig.body
+    end
+    sig = sig.parameters
+
+    ft = sig[1]
+    uw = Base.unwrap_unionall(ft)
+    if ft <: Function && isa(uw,DataType) && isempty(uw.parameters) &&
+            isdefined(uw.name.module, uw.name.mt.name) &&
+            ft == typeof(getfield(uw.name.module, uw.name.mt.name))
+        print(env_io, (demangle ? demangle_function_name : identity)(uw.name.mt.name))
+    elseif isa(ft, DataType) && ft.name === Type.body.name && !Core.Compiler.has_free_typevars(ft)
+        f = ft.parameters[1]
+        print(env_io, f)
+    else
+        print(env_io, "(::", ft, ")")
+    end
+
+    first = true
+    print(io, "(")
+    for i = 2:length(sig)  # fixme (iter): `eachindex` with offset?
+        first || print(io, ", ")
+        first = false
+        printstyled(env_io, "::", sig[i], color=highlighter(sig[i]))
+    end
+    if kwargs !== nothing
+        print(io, "; ")
+        first = true
+        for (k, t) in kwargs
+            first || print(io, ", ")
+            first = false
+            print(io, k, "::")
+            show(io, t)
+        end
+    end
+    print(io, ")")
+    Base.show_method_params(io, tv)
+    nothing
+end
+
+function stripType(@nospecialize(typ))
+    if isa(typ, UnionAll)
+        typ = Base.unwrap_unionall(typ)
+    elseif isa(typ, TypeVar)
+        return typ
+    end
+    return typ <: Type ? typ.parameters[1] : typ
+end
+nonconcrete_red(@nospecialize(typ)) = isconcretetype(stripType(typ)) ? :nothing : :red
+
+treelist(mi::MethodInstance) = treelist!(String[], MethodInstance[], IOBuffer(), mi, "", Base.IdSet{MethodInstance}())
+
+function treelist!(strs, mis, io::IO, mi::MethodInstance, indent::AbstractString, visited::Base.IdSet)
+    mi ∈ visited && return strs, mis
+    push!(visited, mi)
+    show_tuple_as_call(nonconcrete_red, IOContext(io, :color=>true), mi.def.name, mi.specTypes)
+    push!(strs, indent * String(take!(io)))
+    push!(mis, mi)
+    if isdefined(mi, :backedges)
+        indent *= " "
+        for edge in mi.backedges
+            treelist!(strs, mis, io, edge, indent, visited)
+        end
+    end
+    return strs, mis
+end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -77,6 +77,12 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
     elseif key == UInt32('P')
         m.toggle = :dump_params
         return true
+    elseif key == UInt32('r')
+        m.toggle = :revise
+        return true
+    elseif key == UInt32('e')
+        m.toggle = :edit
+        return true
     end
     return false
 end


### PR DESCRIPTION
This PR aims to rise from the depths, and adds a new function `ascend`. It seeks to compensate for the heathen `descend`, which explores the very pits of codepravity. In its purity, it has a single (in)vocation: `ascend(mi::MethodInstance)`. Pray, you ask, where do such MethodInstances hail from? Verily, they emerge from the great invalidation quest, and `ascend` is a new weapon in our most noble battle against them.

I beg your indulgence for this pittance of a demonstration:

![image](https://user-images.githubusercontent.com/1525481/81949163-267dd500-95c8-11ea-8dbe-e345b4ba565f.png)

The indentation allows one to follow the infernal logic of the heinous backedges; the red coloration symbolizes evil, which one must strive to vanquish.

(It also adds "r = Revise" to update code, and "e" to open the file in an editor.)

CC @KristofferC