### PR TITLE
Implement a FoldingTree menu for `ascend`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "1.1.2"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+FoldingTrees = "1eca21be-9b9b-4ed8-839a-6d8ae26b1781"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
@@ -12,6 +13,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
 [compat]
 CodeTracking = "0.5, 1"
+FoldingTrees = "1"
 julia = "1"
 
 [extras]

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -146,7 +146,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
     if :debuginfo in keys(kwargs)
         selected = kwargs[:debuginfo]
         # TODO: respect default
-        debuginfo = selected == :source
+        debuginfo = selected === :source
     end
 
     display_CI = true

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -201,7 +201,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             end
 
             _descend(next_mi; params=params, optimize=optimize,
-                     iswarn=iswarn, debuginfo=debuginfo_key, kwargs...)
+                     iswarn=iswarn, debuginfo=debuginfo_key, interruptexc=interruptexc, kwargs...)
 
         elseif toggle === :warn
             iswarn ⊻= true
@@ -261,16 +261,79 @@ descend_code_typed(b::Bookmark; kw...) =
 descend_code_warntype(b::Bookmark; kw...) =
     _descend_with_error_handling(b.mi; iswarn = true, params = b.params, kw...)
 
-function ascend(mi::MethodInstance)
-    calls, mis = treelist(mi)
-    menu = TerminalMenus.RadioMenu(calls)
-    choice = 1
-    while choice != -1
-        choice = TerminalMenus.request("Choose a call for analysis (q to quit):", menu)
-        if choice != -1
-            # The main application of `ascend` is finding cases of non-inferability, so the
-            # warn highlighting is useful.
-            _descend(mis[choice], iswarn=true, optimize=false, interruptexc=false)
+if has_treemenu
+    FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.writeoption(buf, data.callstr, charsused)
+
+    function ascend(mi)
+        root = treelist(mi)
+        menu = TreeMenu(root)
+        choice = menu.current
+        while choice !== nothing
+            menu.chosen = false
+            choice = TerminalMenus.request("Choose a call for analysis (q to quit):", menu; cursor=menu.currentidx)
+            browsecodetyped = true
+            if choice !== nothing
+                node = menu.current
+                mi = instance(node.data.nd)
+                if !isroot(node)
+                    # Help user find the sites calling the parent
+                    miparent = instance(node.parent.data.nd)
+                    params = current_params()
+                    locs = []
+                    for optimize in (true,)
+                        (CI, rt, slottypes) = do_typeinf_slottypes(mi, optimize, params)
+                        preprocess_ci!(CI, mi, optimize, CONFIG)
+                        callsites = find_callsites(CI, mi, slottypes; params=params)
+                        callsites = filter(cs->is_callsite(cs, miparent), callsites)
+                        append!(locs, CI.linetable[CI.codelocs[(cs->cs.id).(callsites)]])
+                    end
+                    if !isempty(locs)
+                        ulocs = Dict{Tuple{Symbol,Symbol},Vector{Int}}()
+                        for loc in locs
+                            lines = get!(Vector{Int}, ulocs, (loc.method, loc.file))
+                            line = loc.line
+                            if line ∉ lines
+                                push!(lines, line)
+                            end
+                        end
+                        vlocs = collect(ulocs)
+                        strlocs = [string('"', k[2], "\", ", k[1], ": lines ", v) for (k, v) in ulocs]
+                        perm = sortperm(strlocs)
+                        strlocs, vlocs = strlocs[perm], vlocs[perm]
+                        push!(strlocs, "Browse typed code")
+                        linemenu = TerminalMenus.RadioMenu(strlocs)
+                        browsecodetyped = false
+                        choice2 = 1
+                        while choice2 != -1
+                            choice2 = TerminalMenus.request("\nChoose caller of $miparent or proceed to typed code:", linemenu; cursor=choice2)
+                            if 0 < choice2 < length(strlocs)
+                                loc = vlocs[choice2]
+                                edit(String(loc[1][2]), first(loc[2]))
+                            elseif choice2 == length(strlocs)
+                                browsecodetyped = true
+                                break
+                            end
+                        end
+                    end
+                end
+                # The main application of `ascend` is finding cases of non-inferrability, so the
+                # warn highlighting is useful.
+                browsecodetyped && _descend(mi, iswarn=true, optimize=false, interruptexc=false)
+            end
+        end
+    end
+else
+    function ascend(mi)
+        calls, mis = treelist(mi)
+        menu = TerminalMenus.RadioMenu(calls)
+        choice = 1
+        while choice != -1
+            choice = TerminalMenus.request("Choose a call for analysis (q to quit):", menu)
+            if choice != -1
+                # The main application of `ascend` is finding cases of non-inferrability, so the
+                # warn highlighting is useful.
+                _descend(instance(mis[choice]), iswarn=true, optimize=false, interruptexc=false)
+            end
         end
     end
 end

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -15,7 +15,7 @@ struct FailedCallInfo <: CallInfo
     rt
 end
 
-function get_mi(ci::FailedCallInfo) 
+function get_mi(ci::FailedCallInfo)
     @error "MethodInstance extraction failed" ci.sig ci.rt
     return nothing
 end
@@ -25,7 +25,7 @@ struct GeneratedCallInfo <: CallInfo
     sig
     rt
 end
-function get_mi(genci::GeneratedCallInfo) 
+function get_mi(genci::GeneratedCallInfo)
     @error "Can't extract MethodInstance from call to generated functions" genci.sig genci.rt
     return nothing
 end
@@ -185,3 +185,16 @@ function Base.show(io::IO, c::Callsite)
         print(limiter, " >")
     end
 end
+
+is_callsite(cs::Callsite, mi::MethodInstance) = is_callsite(cs.info, mi)
+is_callsite(info::MICallInfo, mi::MethodInstance) = info.mi == mi
+is_callsite(info::TaskCallInfo, mi::MethodInstance) = is_callsite(info.ci, mi)
+is_callsite(info::ReturnTypeCallInfo, mi::MethodInstance) = is_callsite(info.called_mi, mi)
+is_callsite(info::CuCallInfo, mi::MethodInstance) = is_callsite(info.cumi, mi)
+function is_callsite(info::MultiCallInfo, mi::MethodInstance)
+    for csi in info.callinfos
+        is_callsite(csi, mi) && return true
+    end
+    return false
+end
+is_callsite(::CallInfo, mi::MethodInstance) = false

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -82,7 +82,7 @@ function find_callsites(CI, mi, slottypes; params=current_params(), kwargs...)
                     callsite = Callsite(id, MICallInfo(c.args[1], rt))
                 end
                 mi = get_mi(callsite)
-                if nameof(mi.def.module) == :CUDAnative && mi.def.name == :cufunction
+                if nameof(mi.def.module) === :CUDAnative && mi.def.name === :cufunction
                     callsite = transform(Val(:CuFunction), callsite, c, CI, mi, slottypes; params=params, kwargs...)
                 end
             elseif c.head === :call
@@ -147,7 +147,7 @@ function find_callsites(CI, mi, slottypes; params=current_params(), kwargs...)
                 else
                     ft = Base.unwrap_unionall(types[1])
                     name = ft.name
-                    ci = if nameof(name.module) == :CUDAnative && name.name == Symbol("#kw##cufunction")
+                    ci = if nameof(name.module) === :CUDAnative && name.name === Symbol("#kw##cufunction")
                         ft = types[4]
                         # XXX: Simplify
                         tt = types[5].parameters[1].parameters

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -1,5 +1,11 @@
-import REPL.TerminalMenus
+using REPL.TerminalMenus
 import REPL.TerminalMenus: request
+
+const has_treemenu = isdefined(TerminalMenus, :ConfiguredMenu)
+
+if has_treemenu
+    using FoldingTrees
+end
 
 mutable struct CthulhuMenu <: TerminalMenus.AbstractMenu
     options::Vector{String}


### PR DESCRIPTION
This enhances `ascend` by leveraging [FoldingTrees](https://github.com/JuliaCollections/FoldingTrees.jl) to implement a foldable menu for browsing the backedges of a `MethodInstance` with `ascend`. As you scroll through the tree of backedges, you can hit space bar to toggle folding of a given node. Some invalidation trees are huge (thousands of MethodInstances) and often you can fix problems on a given branch fairly near the root, so collapsing all the descendents greatly improves usability.

Before leaping to the `code_typed`, this also presents an intermediate menu summarizing the line numbers at which calls to the parent occur; often, just by inspecting the source code you can find ways to make the needed fixes. For example, the second commit here fixes some invalidations in this package that occur from specializing `==(::Any, ::SomeType)`, and for `Symbol` comparisons it's as easy as changing `a == :sym` to `a === :sym`.

Below is a demo. To make this work, you need a very recent build of Julia-master.  `InvalidationFixer` is *almost* just `Cthulhu`; the difference will be elaborated below:

```
## This first part is just SnoopCompile

julia> using SnoopCompile, InvalidationFixer

julia> trees = invalidation_trees(@snoopr using FixedPointNumbers)
5-element Array{SnoopCompile.MethodInvalidations,1}:
 insert promote_rule(::Type{T}, ::Type{Tf}) where {T<:Normed, Tf<:AbstractFloat} in FixedPointNumbers at /home/tim/.julia/packages/FixedPointNumbers/w2pxG/src/normed.jl:310 invalidated:
   backedges: 1: superseding promote_rule(::Type{var"#s847"} where var"#s847"<:AbstractIrrational, ::Type{T}) where T<:Real in Base at irrationals.jl:42 with MethodInstance for promote_rule(::Type{Union{}}, ::Type{Float64}) (1 children) ambiguous
              2: superseding promote_rule(::Type{var"#s91"} where var"#s91", ::Type{var"#s90"} where var"#s90") in Base at promotion.jl:235 with MethodInstance for promote_rule(::Type{S} where S<:Integer, ::Type{Float64}) (1 children) more specific
   1 mt_cache

 insert one(::Type{X}) where X<:FixedPoint in FixedPointNumbers at /home/tim/.julia/packages/FixedPointNumbers/w2pxG/src/FixedPointNumbers.jl:94 invalidated:
   mt_backedges: 1: signature Tuple{typeof(one),Type{T} where T<:AbstractChar} triggered MethodInstance for oneunit(::Type{T} where T<:AbstractChar) (1 children) ambiguous
                 2: signature Tuple{typeof(one),Type{Union{}}} triggered MethodInstance for oneunit(::Type{Union{}}) (5 children) less specific
   3 mt_cache

 insert promote_rule(::Type{T}, ::Type{Ti}) where {T<:Normed, Ti<:Union{Signed, Unsigned}} in FixedPointNumbers at /home/tim/.julia/packages/FixedPointNumbers/w2pxG/src/normed.jl:312 invalidated:
   backedges: 1: superseding promote_rule(::Type{var"#s91"} where var"#s91", ::Type{var"#s90"} where var"#s90") in Base at promotion.jl:235 with MethodInstance for promote_rule(::Type{T} where T<:Unsigned, ::Type{UInt64}) (2 children) more specific
              2: superseding promote_rule(::Type{var"#s847"} where var"#s847"<:AbstractIrrational, ::Type{T}) where T<:Real in Base at irrationals.jl:42 with MethodInstance for promote_rule(::Type{Union{}}, ::Type{UInt64}) (9 children) ambiguous

 insert sizeof(::Type{X}) where X<:FixedPoint in FixedPointNumbers at /home/tim/.julia/packages/FixedPointNumbers/w2pxG/src/FixedPointNumbers.jl:100 invalidated:
   backedges: 1: superseding sizeof(x) in Base at essentials.jl:449 with MethodInstance for sizeof(::Type{T} where T) (1 children) more specific
              2: superseding sizeof(x) in Base at essentials.jl:449 with MethodInstance for sizeof(::Type) (4 children) more specific
              3: superseding sizeof(x) in Base at essentials.jl:449 with MethodInstance for sizeof(::DataType) (26 children) more specific
   1 mt_cache

 insert (::Type{X})(x::Real) where X<:FixedPoint in FixedPointNumbers at /home/tim/.julia/packages/FixedPointNumbers/w2pxG/src/FixedPointNumbers.jl:51 invalidated:
   mt_backedges: 1: signature Tuple{Type{T} where T<:Int64,Int64} triggered MethodInstance for length(::Base.OneTo{T}) where T<:Int64 (0 children) ambiguous
                 2: signature Tuple{Type{var"#s136"} where var"#s136"<:Sockets.IPAddr,Int64} triggered MethodInstance for bind_client_port(::Sockets.TCPSocket, ::Type{var"#s136"} where var"#s136"<:Sockets.IPAddr) (0 children) ambiguous
                 3: signature Tuple{Type{T} where T<:Int64,Int64} triggered MethodInstance for convert(::Type{T}, ::Int64) where T<:Int64 (1 children) ambiguous
   backedges: 1: superseding (::Type{T})(x::Number) where T<:AbstractChar in Base at char.jl:48 with MethodInstance for (::Type{T} where T<:AbstractChar)(::Int32) (153 children) ambiguous
              2: superseding (::Type{T})(x::Number) where T<:AbstractChar in Base at char.jl:48 with MethodInstance for (::Type{T} where T<:AbstractChar)(::UInt32) (305 children) ambiguous
   16 mt_cache


julia> node = trees[4].backedges[3]
MethodInstance for sizeof(::DataType) at depth 0 with 26 children

## Here is the new Cthulhu stuff. Here the menu is quite short, and I navigated to the second item
## and hit enter, but if it were a huge menu I could collapse branches by hitting space bar
## (a + would be displayed in front of the item)

julia> ascend(node)
Choose a call for analysis (q to quit):
     sizeof(::DataType)
 >     Base.CyclePadding(::DataType)
         array_subpadding(::Type{UInt32}, ::Any)
           reinterpret(::Type{UInt32}, ::AbstractArray{S,N} where S where N)
             reinterpret(::Type{UInt32}, ::Base.ReinterpretArray)
               reinterpret(::Type{UInt32}, ::Base.ReinterpretArray)
         array_subpadding(::Type{Char}, ::Any)
           reinterpret(::Type{Char}, ::AbstractArray{S,N} where S where N)
             reinterpret(::Type{Char}, ::Base.ReinterpretArray)
v              reinterpret(::Type{Char}, ::Base.ReinterpretArray)

# This is what happened when I hit enter (this is a RadioMenu)

Choose caller of MethodInstance for sizeof(::DataType) or proceed to typed code:
 > "reinterpretarray.jl", CyclePadding: lines [300]
   Browse typed code

# Selecting the first option opened the code to line 300 in my editor
# But now let's say I want to see the typed code:

Choose caller of MethodInstance for sizeof(::DataType) or proceed to typed code:
   "reinterpretarray.jl", CyclePadding: lines [300]
 > Browse typed code

│ ─ %-1  = invoke CyclePadding(::DataType)::Base.CyclePadding{Array{Base.Padding,1}}
Variables
  #self#::Type{Base.CyclePadding}
  T::DataType
  a::Int64
  s::Any
  as::Any
  pad::Array{Base.Padding,1}

Body::Base.CyclePadding{Array{Base.Padding,1}}
    @ reinterpretarray.jl:300 within `CyclePadding'
1 ─ %1  = Base.datatype_alignment(T)::Int64
│   %2  = Base.sizeof(T)::Any
│         (a = %1)
│         (s = %2)
│   @ reinterpretarray.jl:301 within `CyclePadding'
│   %5  = s::Any
│   %6  = a::Int64
│   %7  = (s % a)::Any
│   %8  = (%6 - %7)::Any
│   %9  = (%8 % a)::Any
│         (as = %5 + %9)
│   @ reinterpretarray.jl:302 within `CyclePadding'
│         (pad = Base.padding(T))
│   @ reinterpretarray.jl:303 within `CyclePadding'
│   %12 = (s != as)::Any
└──       goto #3 if not %12
2 ─ %14 = pad::Array{Base.Padding,1}
│   %15 = s::Any
│   %16 = (as - s)::Any
│   %17 = Base.Padding(%15, %16)::Base.Padding
│         Base.push!(%14, %17)
└──       goto #3
    @ reinterpretarray.jl:304 within `CyclePadding'
3 ┄ %20 = Base.CyclePadding(pad, as)::Base.CyclePadding{Array{Base.Padding,1}}
└──       return %20

Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Advanced: dump [P]arams cache.

 • %1  = invoke datatype_alignment(::DataType)::Int64
   %2  = call #sizeof(::DataType)::Any
   %7  = call #rem(::Any,::Int64)::Any
   %8  = call #-(::Int64,::Any)::Any
   %9  = call #rem(::Any,::Int64)::Any
   %10  = call #+(::Any,::Any)::Any
   %11  = invoke padding(::DataType)::Array{Base.Padding,1}
   %12  = call #!=(::Any,::Any)::Any
   %16  = call #-(::Any,::Any)::Any
v  %17  = call Type(::Any,::Any)::Base.Padding

# I can do all the normal Cthulhu stuff. I can also hit `q` twice and go back to the invalidation tree,
# collapse the current branch, and move on to solving the next problems
```

So, what is `InvalidationFixer`? The entire source code is

```julia
module InvalidationFixer

using Reexport

@reexport using SnoopCompile
@reexport using Cthulhu
using REPL
using REPL.TerminalMenus

using SnoopCompile: InstanceTree, countchildren

Cthulhu.backedges(node::InstanceTree) = sort(node.children; by=countchildren, rev=true)
Cthulhu.method(node::InstanceTree) = Cthulhu.method(node.mi)
Cthulhu.specTypes(node::InstanceTree) = Cthulhu.specTypes(node.mi)
Cthulhu.instance(node::InstanceTree) = node.mi

end # module
```

Basically, it just glues `Cthulhu` and `SnoopCompile` together. Why is this useful? The issue is something I failed to anticipate: `ascend` works well *before* invalidation occurs, but invalidation changes `mi.backedges`, and so once you observe an invalidation it's too late to navigate the raw `MethodInstace` backedge trees. SnoopCompile gets around this by capturing the record from the invalidation itself, which outputs the entire invalidated tree. If you knew what you were looking for, you wouldn't need SnoopCompile at all: all the info is there in the original `MethodInstance` backedges. But currently there's no good way of finding them without intercepting invalidations.

Making `InvalidationFixer` a serious package is not my favorite path forward, but it's frankly a little unclear how we should handle this. Some options:

- we could make SnoopCompile a dependency of Cthulhu
- we would make Cthulhu a dependency of SnoopCompile
- we could use Requires to define those 4 additional methods in Cthulhu when SnoopCompile is loaded
- we could make InvalidationFixer a real package
- we could remove `ascend` from Cthulhu and put it in InvalidationFixer

I'd be interested in folks' thoughts.