### PR TITLE
Support user-choice of MethodInstance

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -251,7 +251,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
 end
 
 function _descend(@nospecialize(F), @nospecialize(TT); params=current_params(), kwargs...)
-    mi = first_method_instance(F, TT; params=params)
+    mi = choose_method_instance(F, TT; params=params)
     _descend(mi; params=params, kwargs...)
 end
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -267,6 +267,11 @@ function first_method_instance(@nospecialize(sig); params=current_params())
     end
 end
 
+function choose_method_instance(@nospecialize(F), @nospecialize(TT); params=current_params())
+    sig = Base.signature_type(F, TT)
+    choose_method_instance(sig; params=params)
+end
+
 function callinfo(sig, rt, max=-1; params=current_params())
     methds = Base._methods_by_ftype(sig, -1, params.world)
     (methds === false || length(methds) < 1) && return FailedCallInfo(sig, rt)

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -123,3 +123,18 @@ function TerminalMenus.writeLine(buf::IOBuffer, menu::CthulhuMenu, idx::Int, cur
 
     print(buf, line)
 end
+
+function choose_method_instance(@nospecialize(sig); params=current_params())
+    ci = callinfo(sig, Any, 1, params=params)
+    ci isa MICallInfo && return get_mi(ci)
+    ci isa Union{GeneratedCallInfo, FailedCallInfo} && return nothing
+    if ci isa MultiCallInfo
+        options = string.(ci.callinfos)
+        menu = has_treemenu ? RadioMenu(options; charset=:unicode) : RadioMenu(options)
+        chosen = request("Choose call to analyze:", menu)
+        if chosen != -1
+            return get_mi(ci.callinfos[chosen])
+        end
+    end
+    error("unexpected callinfo ", ci)
+end


### PR DESCRIPTION
`descend` fails when there are multiple MethodInstances that could be called. This presents the user with a menu to choose.