### PR TITLE
Add option to omit stable code when using descend_warn_type

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -147,7 +147,7 @@ const descend = descend_code_typed
 # src/reflection.jl has the tools to discover methods
 # src/ui.jl provides the user facing interface to which _descend responds
 ##
-function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), optimize::Bool=true, interruptexc::Bool=true, stable_code::Bool=true, kwargs...)
+function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), optimize::Bool=true, interruptexc::Bool=true, verbose=true, kwargs...)
     debuginfo = true
     if :debuginfo in keys(kwargs)
         selected = kwargs[:debuginfo]
@@ -162,7 +162,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
         preprocess_ci!(CI, mi, optimize, CONFIG)
         callsites = find_callsites(CI, mi, slottypes; params=params, kwargs...)
 
-        display_CI && cthulu_typed(stdout, debuginfo_key, CI, rt, mi, iswarn, stable_code)
+        display_CI && cthulu_typed(stdout, debuginfo_key, CI, rt, mi, iswarn, verbose)
         display_CI = true
 
         TerminalMenus.config(cursor = '•', scroll = :wrap)
@@ -213,6 +213,8 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
 
         elseif toggle === :warn
             iswarn ⊻= true
+        elseif toggle === :verbose
+            verbose ⊻= true
         elseif toggle === :optimize
             optimize ⊻= true
         elseif toggle === :debuginfo

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -251,7 +251,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             #Handle Standard alternative view, e.g. :native, :llvm
             view_cmd = get(codeviews, toggle, nothing)
             if view_cmd !== nothing
-                view_cmd(stdout, mi, optimize, debuginfo, params, stable_code, CONFIG)
+                view_cmd(stdout, mi, optimize, debuginfo, params, CONFIG)
                 display_CI = false
             else
                 error("Unknown option $toggle")

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -209,7 +209,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             end
 
             _descend(next_mi; params=params, optimize=optimize,
-                     iswarn=iswarn, debuginfo=debuginfo_key, interruptexc=interruptexc, stable_code=stable_code, kwargs...)
+                     iswarn=iswarn, debuginfo=debuginfo_key, interruptexc=interruptexc, verbose=verbose, kwargs...)
 
         elseif toggle === :warn
             iswarn ⊻= true

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -147,7 +147,7 @@ const descend = descend_code_typed
 # src/reflection.jl has the tools to discover methods
 # src/ui.jl provides the user facing interface to which _descend responds
 ##
-function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), optimize::Bool=true, interruptexc::Bool=true, kwargs...)
+function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), optimize::Bool=true, interruptexc::Bool=true, stable_code::Bool=true, kwargs...)
     debuginfo = true
     if :debuginfo in keys(kwargs)
         selected = kwargs[:debuginfo]
@@ -162,7 +162,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
         preprocess_ci!(CI, mi, optimize, CONFIG)
         callsites = find_callsites(CI, mi, slottypes; params=params, kwargs...)
 
-        display_CI && cthulu_typed(stdout, debuginfo_key, CI, rt, mi, iswarn)
+        display_CI && cthulu_typed(stdout, debuginfo_key, CI, rt, mi, iswarn, stable_code)
         display_CI = true
 
         TerminalMenus.config(cursor = '•', scroll = :wrap)
@@ -209,7 +209,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             end
 
             _descend(next_mi; params=params, optimize=optimize,
-                     iswarn=iswarn, debuginfo=debuginfo_key, interruptexc=interruptexc, kwargs...)
+                     iswarn=iswarn, debuginfo=debuginfo_key, interruptexc=interruptexc, stable_code=stable_code, kwargs...)
 
         elseif toggle === :warn
             iswarn ⊻= true
@@ -249,7 +249,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             #Handle Standard alternative view, e.g. :native, :llvm
             view_cmd = get(codeviews, toggle, nothing)
             if view_cmd !== nothing
-                view_cmd(stdout, mi, optimize, debuginfo, params, CONFIG)
+                view_cmd(stdout, mi, optimize, debuginfo, params, stable_code, CONFIG)
                 display_CI = false
             else
                 error("Unknown option $toggle")

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -71,7 +71,7 @@ function cthulhu_source(io::IO, mi, optimize, debuginfo, params, config::Cthulhu
 end
 
 cthulhu_warntype(args...) = cthulhu_warntype(stdout, args...)
-function cthulhu_warntype(io::IO, src, rettype, debuginfo)
+function cthulhu_warntype(io::IO, src, rettype, debuginfo, stable_code)
     if VERSION < v"1.1.0-DEV.762"
     elseif VERSION < v"1.2.0-DEV.229"
         lineprinter = Base.IRShow.debuginfo[debuginfo]
@@ -91,19 +91,21 @@ function cthulhu_warntype(io::IO, src, rettype, debuginfo)
     println(io)
     if VERSION < v"1.1.0-DEV.762"
         Base.IRShow.show_ir(lambda_io, src, InteractiveUtils.warntype_type_printer)
+
     else
-        show_ir(lambda_io, src, lineprinter(src), InteractiveUtils.warntype_type_printer)
+        ir_printer = stable_code ? Base.IRShow.show_ir : show_ir
+        ir_printer(lambda_io, src, lineprinter(src), InteractiveUtils.warntype_type_printer)
     end
     return nothing
 end
 
 
-function cthulu_typed(io::IO, debuginfo_key, CI, rettype, mi, iswarn)
+function cthulu_typed(io::IO, debuginfo_key, CI, rettype, mi, iswarn, stable_code)
     println(io)
     println(io, "│ ─ $(string(Callsite(-1, MICallInfo(mi, rettype))))")
 
     if iswarn
-        cthulhu_warntype(io, CI, rettype, debuginfo_key)
+        cthulhu_warntype(io, CI, rettype, debuginfo_key, stable_code)
     elseif VERSION >= v"1.1.0-DEV.762"
         show(io, CI, debuginfo = debuginfo_key)
     else

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -92,7 +92,7 @@ function cthulhu_warntype(io::IO, src, rettype, debuginfo)
     if VERSION < v"1.1.0-DEV.762"
         Base.IRShow.show_ir(lambda_io, src, InteractiveUtils.warntype_type_printer)
     else
-        Base.IRShow.show_ir(lambda_io, src, lineprinter(src), InteractiveUtils.warntype_type_printer)
+        show_ir(lambda_io, src, lineprinter(src), InteractiveUtils.warntype_type_printer)
     end
     return nothing
 end
@@ -202,3 +202,101 @@ InteractiveUtils.code_native(b::Bookmark; kw...) =
 InteractiveUtils.code_native(io::IO, b::Bookmark; optimize = true, debuginfo = :source,
                              config = CONFIG) =
     cthulhu_native(io, b.mi, optimize, debuginfo == :source, b.params, config)
+
+@nospecialize
+using Base.IRShow: compute_basic_blocks, scan_ssa_use!, should_print_ssa_type, print_stmt, GotoIfNot, GotoNode, PhiNode, block_for_inst
+function show_ir(io::IO, code::Core.CodeInfo, line_info_preprinter, line_info_postprinter)
+    cols = displaysize(io)[2]
+    used = BitSet()
+    stmts = code.code
+    types = code.ssavaluetypes
+    cfg = compute_basic_blocks(stmts)
+    max_bb_idx_size = length(string(length(cfg.blocks)))
+    for stmt in stmts
+        scan_ssa_use!(push!, used, stmt)
+    end
+    bb_idx = 1
+
+    if isempty(used)
+        maxlength_idx = 0
+    else
+        maxused = maximum(used)
+        maxlength_idx = length(string(maxused))
+    end
+    for idx in eachindex(stmts)
+        if !isassigned(stmts, idx)
+            # This is invalid, but do something useful rather
+            # than erroring, to make debugging easier
+            printstyled(io, "#UNDEF\n", color=:red)
+            continue
+        end
+        stmt = stmts[idx]
+        # Compute BB guard rail
+        if bb_idx > length(cfg.blocks)
+            # If invariants are violated, print a special leader
+            linestart = " "^(max_bb_idx_size + 2) # not inside a basic block bracket
+            inlining_indent = line_info_preprinter(io, linestart, code.codelocs[idx])
+            printstyled(io, "!!! ", "─"^max_bb_idx_size, color=:light_black)
+        else
+            bbrange = cfg.blocks[bb_idx].stmts
+            bbrange = bbrange.start:bbrange.stop
+            # Print line info update
+            linestart = idx == first(bbrange) ? "  " : sprint(io -> printstyled(io, "│ ", color=:light_black), context=io)
+            linestart *= " "^max_bb_idx_size
+            inlining_indent = line_info_preprinter(io, linestart, code.codelocs[idx])
+            if idx == first(bbrange)
+                bb_idx_str = string(bb_idx)
+                bb_pad = max_bb_idx_size - length(bb_idx_str)
+                bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
+                printstyled(io, bb_idx_str, " ", bb_type, "─"^bb_pad, color=:light_black)
+            elseif idx == last(bbrange) # print separator
+                printstyled(io, "└", "─"^(1 + max_bb_idx_size), color=:light_black)
+            else
+                printstyled(io, "│ ", " "^max_bb_idx_size, color=:light_black)
+            end
+            if idx == last(bbrange)
+                bb_idx += 1
+            end
+        end
+        print(io, inlining_indent, " ")
+        # convert statement index to labels, as expected by print_stmt
+        if stmt isa Expr
+            if stmt.head === :gotoifnot && length(stmt.args) == 2 && stmt.args[2] isa Int
+                stmt = GotoIfNot(stmt.args[1], block_for_inst(cfg, stmt.args[2]::Int))
+            elseif stmt.head === :enter && length(stmt.args) == 1 && stmt.args[1] isa Int
+                stmt = Expr(:enter, block_for_inst(cfg, stmt.args[1]::Int))
+            end
+        elseif isa(stmt, GotoIfNot)
+            stmt = GotoIfNot(stmt.cond, block_for_inst(cfg, stmt.dest))
+        elseif stmt isa GotoNode
+            stmt = GotoNode(block_for_inst(cfg, stmt.label))
+        elseif stmt isa PhiNode
+            e = stmt.edges
+            stmt = PhiNode(Any[block_for_inst(cfg, e[i]) for i in 1:length(e)], stmt.values)
+        end
+        show_type = types isa Vector{Any} && should_print_ssa_type(stmt)
+        print_stmt(io, idx, stmt, used, maxlength_idx, true, show_type)
+        if types isa Vector{Any} # ignore types for pre-inference code
+            if !isassigned(types, idx)
+                # This is an error, but can happen if passes don't update their type information
+                printstyled(io, "::#UNDEF", color=:red)
+            elseif show_type
+                ty = typ = types[idx]
+                #line_info_postprinter(io, typ, idx in used)
+                if (idx in used) && ty isa Type && (!Base.isdispatchelem(ty) || ty == Core.Box)
+                    if ty isa Union && Base.is_expected_union(ty)
+                        Base.emphasize(io, "::$ty", Base.warn_color()) # more mild user notification
+                    else
+                        Base.emphasize(io, "::$ty")
+                    end
+                end
+            end
+        end
+        println(io)
+    end
+    let linestart = " "^(max_bb_idx_size + 2)
+        line_info_preprinter(io, linestart, typemin(Int32))
+    end
+    nothing
+end
+@specialize

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -48,7 +48,7 @@ function TerminalMenus.header(m::CthulhuMenu)
     m.sub_menu && return ""
     """
     Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
-    Toggles: [o]ptimize, [w]arn, [v]bose printing for warntype code, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
+    Toggles: [o]ptimize, [w]arn, [v]erbose printing for warntype code, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
     Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
     Actions: [E]dit source code, [R]evise and redisplay
     Advanced: dump [P]arams cache.

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -48,7 +48,7 @@ function TerminalMenus.header(m::CthulhuMenu)
     m.sub_menu && return ""
     """
     Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
-    Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
+    Toggles: [o]ptimize, [w]arn, [v]bose printing for warntype code, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
     Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
     Actions: [E]dit source code, [R]evise and redisplay
     Advanced: dump [P]arams cache.
@@ -59,6 +59,9 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
     m.sub_menu && return false
     if key == UInt32('w')
         m.toggle = :warn
+        return true
+    elseif key == UInt32('v')
+        m.toggle = :verbose
         return true
     elseif key == UInt32('o')
         m.toggle = :optimize

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -258,3 +258,20 @@ if VERSION >= v"1.1-"
         end
     end
 end
+
+###
+### Printer test:
+###
+if VERSION >= v"1.1.0-DEV.762"
+    function foo()
+        T = rand() > 0.5 ? Int64 : Float64
+        sum(rand(T, 100))
+    end
+    ci, mi, rt, st = process(foo, Tuple{});
+    io = IOBuffer()
+    Cthulhu.cthulu_typed(io, :none, ci, rt, mi, true, false)
+    str = String(take!(io))
+    print(str)
+    # test by bounding the number of lines printed
+    @test count(isequal('\n'), str) <= 50
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -133,7 +133,7 @@ end
     src, rettype = code_typed(identity, (Any,); optimize=false)[1]
     io = IOBuffer()
     ioctx = IOContext(io, :color=>true)
-    Cthulhu.cthulhu_warntype(ioctx, src, rettype, :none)
+    Cthulhu.cthulhu_warntype(ioctx, src, rettype, :none, true)
     str = String(take!(io))
     VERSION >= v"1.2" && @test occursin("x\e[91m\e[1m::Any\e[22m\e[39m", str)
 end


### PR DESCRIPTION
We have
```julia
julia> function foo()
           T = rand() > 0.5 ? Int64 : Float64
           sum(rand(T, 100))
       end
foo (generic function with 1 method)

julia> @descend_code_warntype verbose=false foo()

│ ─ %-1  = invoke foo()::Union{Float64, Int64}
Variables
  #self#::Core.Compiler.Const(foo, false)
  T::Union{Type{Float64}, Type{Int64}}
  @_3::Union{Type{Float64}, Type{Int64}}

Body::Union{Float64, Int64}
│    @ REPL[6]:2 within `foo'
│    %35  = φ (#10 => %32, #11 => %34)::Union{Type{Float64}, Type{Int64}}
│    @ REPL[6]:3 within `foo'
│    %36  = Main.rand(%35, 100)::Union{Array{Float64,1}, Array{Int64,1}}
│    %129 = φ (#30 => %73, #49 => %118)::Union{Float64, Int64}

Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [v]bose printing for warntype code, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.

 • %4  = invoke default_rng(::Int64)::Random.MersenneTwister
   %15  = invoke dsfmt_fill_array_close1_open2!(::Random.DSFMT.DSFMT_state,::Ptr{Float64},::Int64)::Any
   %36  = invoke rand(::Union{Type{Float64}, Type{Int64}},::Int64)::Union{Array{Float64,1}, Array{Int64,1}}
   %71  = invoke mapreduce_impl(::typeof(identity),::typeof(Base.add_sum),::Array{Float64,1},::Int64,::Int64,::Int64)
   %116  = invoke mapreduce_impl(::typeof(identity),::typeof(Base.add_sum),::Array{Int64,1},::Int64,::Int64,::Int64)
   ↩
```