### PR TITLE
Support arrays in splatting

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,8 @@ julia = "1"
 
 [extras]
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Revise"]
+test = ["Test", "Revise", "StaticArrays"]

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -113,7 +113,19 @@ function find_callsites(CI::Core.CodeInfo, mi::Core.MethodInstance, slottypes; p
                     if types[1] === typeof(Core._apply_iterate)
                         ok = true
                         new_types = Any[types[3]]
-                        for t in types[4:end]
+                        for i = 4:length(types)
+                            t = types[i]
+                            if t <: AbstractArray
+                                if hasmethod(length, (Type{t},))
+                                    for i = 1:length(t)
+                                        push!(new_types, eltype(t))
+                                    end
+                                else
+                                    push!(new_types, Vararg{eltype(t)})
+                                    i == length(types) || (ok = false)
+                                end
+                                continue
+                            end
                             if !(t <: Tuple) || t isa Union
                                 ok = false
                                 break

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -152,11 +152,13 @@ for (Atype, haslen) in ((Tuple{Tuple{Int,Int,Int}}, true),
                         (Tuple{Vector{Int}}, false),
                         (Tuple{SVector{3,Int}}, true))
     let callsites = find_callsites_by_ftt(hsplat1, Atype; optimize=false)
-        @test !isempty(callsites)
-        cs = callsites[end]
-        @test cs isa Cthulhu.Callsite
-        mi = cs.info.mi
-        @test mi.specTypes.parameters[end] === (haslen ? Int : Vararg{Int})
+        if VERSION >= v"1.4.0-DEV.304"
+            @test !isempty(callsites)
+            cs = callsites[end]
+            @test cs isa Cthulhu.Callsite
+            mi = cs.info.mi
+            @test mi.specTypes.parameters[end] === (haslen ? Int : Vararg{Int})
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using Cthulhu
 using REPL
 using InteractiveUtils
 using Test
+using StaticArrays
 
 function process(@nospecialize(f), @nospecialize(TT); optimize=true)
     mi = Cthulhu.first_method_instance(f, TT)
@@ -134,6 +135,28 @@ let callsites = find_callsites_by_ftt(toggler, Tuple{Bool})
         @test any(mi->mi.def.name == :sin, mis)
     else
         @test all(cs->cs.info isa Cthulhu.MICallInfo, callsites)
+    end
+end
+
+# Splatting
+function fsplat(::Type{Int}, a...)
+    z = zero(Int)
+    for v in a
+        z += v
+    end
+    return z
+end
+gsplat1(T::Type, a...) = fsplat(T, a...)   # does not force specialization
+hsplat1(A) = gsplat1(eltype(A), A...)
+for (Atype, haslen) in ((Tuple{Tuple{Int,Int,Int}}, true),
+                        (Tuple{Vector{Int}}, false),
+                        (Tuple{SVector{3,Int}}, true))
+    let callsites = find_callsites_by_ftt(hsplat1, Atype; optimize=false)
+        @test !isempty(callsites)
+        cs = callsites[end]
+        @test cs isa Cthulhu.Callsite
+        mi = cs.info.mi
+        @test mi.specTypes.parameters[end] === (haslen ? Int : Vararg{Int})
     end
 end
 


### PR DESCRIPTION
Demo:
```julia
julia> function fsplat(::Type{Int}, a...)
           z = zero(Int)
           for v in a
               z += v
           end
           return z
       end
fsplat (generic function with 1 method)

julia> gsplat1(T::Type, a...) = fsplat(T, a...)   # does not force specialization
gsplat1 (generic function with 1 method)

julia> hsplat1(A) = gsplat1(eltype(A), A...)
hsplat1 (generic function with 1 method)

julia> using Cthulhu

julia> @descend hsplat1([1,2,3])

│ ─ %-1  = invoke hsplat1(::Vector{Int64})::Int64
CodeInfo(
    @ REPL[3]:1 within `hsplat1'
1 ─ %1 = Core.tuple(Int64)::Core.Const((Int64,))
│   %2 = Core._apply_iterate(Base.iterate, Main.gsplat1, %1, A)::Int64
└──      return %2
)
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.

 • %2  = invoke gsplat1(::DataType,::Vararg{Int64, N} where N)::Int64
```

Without this PR you can't descend into `gsplat1`.

Note this isn't quite perfect: the first argument's type is `DataType` despite the `Core.Const((Int64,))` annotation of `%1`, but that will be the subject of a later PR. The other aspect that is not perfect, but which I'm not sure how to solve, is that doing something like `foo([1,2,3]..., 4)` is perfectly legal julia code, it's just that julia won't know how long the vararg is. I guess the best answer might be to `typejoin` or `Union` the type in `Vararg`, but that's not implemented here.

EDIT: only works on Julia 1.4+. Presumably one could do something similar for earlier Julia versions, but meh.