### PR TITLE
Improve treatment of types-as-arguments & specialization heuristics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,9 +17,10 @@ FoldingTrees = "1"
 julia = "1"
 
 [extras]
+MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
 Revise = "295af30f-e4ad-537b-8983-00126c2a3abe"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Revise", "StaticArrays"]
+test = ["Test", "MethodAnalysis", "Revise", "StaticArrays"]


### PR DESCRIPTION
On current master, using test functions https://github.com/JuliaDebug/Cthulhu.jl/blob/4c28b946d6e1c434d66c951c1c1cdd3920a71bf6/test/runtests.jl#L142-L150

one gets
```julia
julia> @descend hsplat1([1,2,3])

│ ─ %-1  = invoke hsplat1(::Vector{Int64})::Int64
CodeInfo(
    @ REPL[3]:1 within `hsplat1'
1 ─ %1 = Core.tuple(Int64)::Core.Const((Int64,))
│   %2 = Core._apply_iterate(Base.iterate, Main.gsplat1, %1, A)::Int64
└──      return %2
)
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.

 • %2  = invoke gsplat1(::DataType,::Vararg{Int64, N} where N)::Int64
```
There's something a bit weird here: in the `call` section, in the `gsplat1` call, the first argument is annotated `::DataType` even though at %1 it's `Const((Int64,))`. This does not reflect some deep understanding that `gsplat1` does not specialze on its first argument, because the same holds for
```julia
gsplat2(::Type{T}, a...) where T = fsplat(T, a...)
hsplat2(A) = gsplat2(eltype(A), A...)
```
which does force specialization.

This PR changes the result to
```julia
julia> @descend hsplat1([1,2,3])

│ ─ %-1  = invoke hsplat1(::Vector{Int64})::Int64
CodeInfo(
    @ REPL[3]:1 within `hsplat1'
1 ─ %1 = Core.tuple(Int64)::Core.Const((Int64,))
│   %2 = Core._apply_iterate(Base.iterate, Main.gsplat1, %1, A)::Int64
└──      return %2
)
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.

 • %2  = invoke gsplat1(::Type{Int64},::Vararg{Int64, N} where N)::Int64
   ↩
```

The reason I've marked this WIP is that this version *also* doesn't distinguish between `hsplat1` and `hsplat2`: instead of `::DataType` for both it's `::Type{Int}` for both. Yet they clearly differ:
```julia
julia> using BenchmarkTools

julia> @btime hsplat1([1,2,3])
  847.803 ns (6 allocations: 336 bytes)
6

julia> @btime hsplat2([1,2,3])
  314.957 ns (4 allocations: 176 bytes)
6
```
I confess I'm not sure how this should be fixed. Any ideas?