### PR TITLE
Fix 'b' key (bookmark)

### DIFF
--- a/src/ui.jl
+++ b/src/ui.jl
@@ -86,6 +86,7 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
         return true
     elseif key == UInt32('b')
         m.toggle = :bookmark
+        return true
     elseif key == UInt32('r') || key == UInt32('R')
         m.toggle = :revise
         return true


### PR DESCRIPTION
It looks like `return true` was accidentally "removed" while merging `master` branch to my branch in #71:

https://github.com/JuliaDebug/Cthulhu.jl/commit/89033c6f6dc3badc75c3147acba08cdee696a811#diff-16c932708f8620a55cc46eb1e704f5a9d54f1bba9a4141eaf7e787d39a89adefR87
