### PR TITLE
Add dump_module option to code_llvm(::IO, ::Bookmark)

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -15,18 +15,19 @@ function highlight(io, x, lexer, config::CthulhuConfig)
     end
 end
 
-function cthulhu_llvm(io::IO, mi, optimize, debuginfo, params, config::CthulhuConfig)
+function cthulhu_llvm(io::IO, mi, optimize, debuginfo, params, config::CthulhuConfig,
+                      dump_module = false)
     @static if VERSION >= v"1.5.0-DEV.393"
         dump = InteractiveUtils._dump_function_linfo_llvm(
             mi, params.world,
             #=wrapper=# false, #=strip_ir_metadata=# true,
-            #=dump_module=# false,
+            dump_module,
             optimize, debuginfo ? :source : :none, Base.CodegenParams())
     else
         dump = InteractiveUtils._dump_function_linfo(
             mi, params.world, #=native=# false,
             #=wrapper=# false, #=strip_ir_metadata=# true,
-            #=dump_module=# false, #=syntax=# config.asm_syntax,
+            dump_module, #=syntax=# config.asm_syntax,
             optimize, debuginfo ? :source : :none)
     end
     highlight(io, dump, "llvm", config)
@@ -194,8 +195,8 @@ end
 
 InteractiveUtils.code_llvm(b::Bookmark) = InteractiveUtils.code_llvm(stdout, b)
 InteractiveUtils.code_llvm(io::IO, b::Bookmark; optimize = true, debuginfo = :source,
-                           config = CONFIG) =
-    cthulhu_llvm(io, b.mi, optimize, debuginfo == :source, b.params, config)
+                           dump_module = false, config = CONFIG) =
+    cthulhu_llvm(io, b.mi, optimize, debuginfo == :source, b.params, config, dump_module)
 
 InteractiveUtils.code_native(b::Bookmark; kw...) =
     InteractiveUtils.code_native(stdout, b; kw...)


### PR DESCRIPTION
This PR adds keyword option `dump_module` to `cthulhu_llvm(...)` and `code_llvm(io, bookmark)` so that the latter behaves like stdlib's `code_llvm(f, sig)`.

With this PR and https://github.com/tkf/CodeX.jl/compare/cthulhu, we can do, for example,

```julia
c = CodeX.llvm(Cthulhu.BOOKMARKS[END])
c.cfg_only         # view CFG
c.godbolt()        # open LLVM in godbolt
c.native.godbolt() # open ASM in godbolt
```
