### PR TITLE
Fix jl_new_task handling

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -180,9 +180,10 @@ function find_callsites(CI::Core.CodeInfo, mi::Core.MethodInstance, slottypes; p
                 if c.args[1] isa QuoteNode
                     cfunc = c.args[1].value
                     if cfunc === :jl_new_task
-                        func = c.args[7]
+                        func = c.args[6]
                         ftype = widenconst(argextype(func, CI, sptypes, slottypes))
-                        callsite = Callsite(id, TaskCallInfo(callinfo(ftype, nothing, params=params)))
+                        sig = Tuple{ftype}
+                        callsite = Callsite(id, TaskCallInfo(callinfo(sig, nothing, params=params)))
                     end
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -95,7 +95,9 @@ end
 # tasks
 ftask() = @sync @async show(io, "Hello")
 let callsites = find_callsites_by_ftt(ftask, Tuple{})
-    @test !isempty(filter(c->c.info isa Cthulhu.TaskCallInfo, callsites))
+    task_callsites = filter(c->c.info isa Cthulhu.TaskCallInfo, callsites)
+    @test !isempty(task_callsites)
+    @test filter(c -> c.info.ci isa Cthulhu.FailedCallInfo, task_callsites) == []
 end
 
 ##


### PR DESCRIPTION
...and improve the test by making sure that `TaskCallInfo` does not wrap a `FailedCallInfo`.