### PR TITLE
Support descending into deoptimized and non-deoptimized calls

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -179,9 +179,14 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
             end
             callsite = callsites[cid]
 
-            if callsite.info isa MultiCallInfo
+            if callsite.info isa Union{MultiCallInfo,DeoptimizedCallInfo}
+                callinfos = if callsite.info isa DeoptimizedCallInfo
+                    [callsite.info.accurate, callsite.info.deoptimized]
+                else
+                    callsite.info.callinfos
+                end
                 sub_callsites = let callsite=callsite
-                    map(ci->Callsite(callsite.id, ci), callsite.info.callinfos)
+                    map(ci->Callsite(callsite.id, ci), callinfos)
                 end
                 if isempty(sub_callsites)
                     @warn "Expected multiple callsites, but found none. Please fill an issue with a reproducing example" callsite.info

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -103,7 +103,7 @@ function find_callsites(CI::Core.CodeInfo, mi::Core.MethodInstance, slottypes; p
                             isa(a, Const) || return a
                             a = a.val
                         elseif isa(a, SlotOrArgument)
-                            a = CI.slottypes[_id(a)]
+                            a = slottypes[_id(a)]
                             isa(a, Const) || return a
                             a = a.val
                         end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -111,7 +111,10 @@ function find_callsites(CI::Core.CodeInfo, mi::Core.MethodInstance, slottypes; p
                     end
                     sig_ssa = Tuple{Base.tuple_type_head(mi.def.sig), argtypes_ssa...}
                     if sig_ssa !== mi.def.sig
-                        callsite = Callsite(id, DeoptimizedCallInfo(callinfo(sig_ssa, rt), callsite.info))
+                        sig_callinfo = callinfo(sig_ssa, rt)
+                        if get_mi(sig_callinfo) !== mi
+                            callsite = Callsite(id, DeoptimizedCallInfo(sig_callinfo, callsite.info))
+                        end
                     end
                 end
             elseif c.head === :call

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -18,8 +18,11 @@ end
 
 function show_as_line(el)
     reduced_displaysize = displaysize(stdout) .- (0, 3)
-    buf = IOBuffer()
-    show(IOContext(buf, :limit=>true, :displaysize=>reduced_displaysize), el)
+    buf = ctx = IOBuffer()
+    if (color = get(stdout, :color, nothing)) !== nothing
+        ctx = IOContext(ctx, :color=>color)
+    end
+    show(IOContext(ctx, :limit=>true, :displaysize=>reduced_displaysize), el)
     String(take!(buf))
 end
 


### PR DESCRIPTION
Update: In response to @vchuravy's comment https://github.com/JuliaDebug/Cthulhu.jl/pull/98#issuecomment-718813884, this PR now lets the user decide the method to descend into. So, it's possible to look at the method that would be available in the current released version.

---


Sometimes, `julia` decides ("deoptimize") not use the full type information available. As a result, the `MethodInstance` in the `:invoke` instruction has less accurate signature than the one available through `CI.ssavaluetypes`. I suggest to use more accurate signature whenever possible during descend.

When combining this PR with #97, we can descend into the loop body of `Threads.@threads`. For example, with

```julia
f() = Threads.@threads for i in 1:10; noinline(); end
@noinline noinline() = read("/dev/null")
```

`@descend f()` now shows

```
 • %23  = deoptimized getindex(::Tuple{},::Int64)::Union{}
   %34  = deoptimized threading_run(::var"#1856#threadsfor_fun#28"{UnitRange{Int64}})::Any
   ↩
```

while before it was

```
 • %23  = invoke getindex(::Tuple,::Int64)::Union{}
   %34  = invoke threading_run(::Function)::Any
   ↩
```
