### PR TITLE
Support MethodInstance in descend

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -142,6 +142,8 @@ Shortcut for [`descend_code_typed`](@ref).
 """
 const descend = descend_code_typed
 
+descend(mi::MethodInstance; kwargs...) = _descend(mi; iswarn=false, interruptexc=false, kwargs...)
+
 ##
 # _descend is the main driver function.
 # src/reflection.jl has the tools to discover methods


### PR DESCRIPTION
MethodInstances are becoming more of a user-visible object, with
MethodAnalysis returning them and soon the new "deep"snooping
capabilities of Julia & SnoopCompile. We might as well make it
easier to  descend into them.