### PR TITLE
ascend for backtraces: print final file:line

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ end
 descend(foo, Tuple{})
 @descend foo()
 ```
+
 ## Methods: descend
 
 - `@descend_code_typed`
@@ -68,7 +69,7 @@ Choose a call for analysis (q to quit):
            union(::Set{Symbol}, ::Set{Symbol})
 ```
 You use the up/down arrows to navigate this menu, enter to select a call to `descend` into,
-and your space bar to "fold" a branch of the tree.
+and your space bar to toggle branch-folding.
 
 It also works on stacktraces:
 
@@ -81,11 +82,11 @@ julia> bt = try
 
 julia> ascend(bt)
 Choose a call for analysis (q to quit):
- >   throw_complex_domainerror(::Symbol, ::Float64)
-       sqrt at ./math.jl:582 => sqrt at ./math.jl:608 => iterate at ./generator.jl:47 => collect_to! at ./array.jl:710 => collect_to_with_first!(::Vector{Float64}, ::Float64, ::Base.Generator{Vector{Int64}, typeof(sqrt)}, ::Int64)
-         collect(::Base.Generator{Vector{Int64}, typeof(sqrt)})
-           eval(::Module, ::Any)
-             eval_user_input(::Any, ::REPL.REPLBackend)
+ >   throw_complex_domainerror(::Symbol, ::Float64) at ./math.jl:33
+       sqrt at ./math.jl:582 => sqrt at ./math.jl:608 => iterate at ./generator.jl:47 => collect_to! at ./array.jl:710 => collect_to_with_first!(::Vector{Float64}, ::Float64, ::Base.Generator{Vector{Int64}, typeof(sqrt)}, ::Int64) at ./array.jl:688
+         collect(::Base.Generator{Vector{Int64}, typeof(sqrt)}) at ./array.jl:669
+           eval(::Module, ::Any) at ./boot.jl:360
+             eval_user_input(::Any, ::REPL.REPLBackend) at /home/tim/src/julia-master/usr/share/julia/stdlib/v1.6/REPL/src/REPL.jl:139
 ...
 ```
 

--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -100,7 +100,8 @@ function callstring(io, sfs::Vector{StackTraces.StackFrame})
         sf = sfs[i]
         print(io, sf.func, " at ", sf.file, ':', sf.line, " => ")
     end
-    return callstring(io, instance(sfs))
+    sf = sfs[end]
+    return callstring(io, instance(sfs)) * string(" at ", sf.file, ':', sf.line)
 end
 callstring(io, ipframes::Vector{IPFrames}) = callstring(io, ipframes[1].sfs)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,14 +224,14 @@ fst1(x) = backtrace()
 fst5(x) = fst4(x)
 tree = Cthulhu.treelist(fst5(1.0))
 if isdefined(REPL.TerminalMenus, :ConfiguredMenu)
-    @test match(r"fst1 at .*:\d+ => fst2 at .*:\d+ => fst3\(::Float64\)", tree.data.callstr) !== nothing
+    @test match(r"fst1 at .*:\d+ => fst2 at .*:\d+ => fst3\(::Float64\) at .*:\d+", tree.data.callstr) !== nothing
     @test length(tree.children) == 1
     child = tree.children[1]
-    @test match(r" fst4 at .*:\d+ => fst5\(::Float64\)", child.data.callstr) !== nothing
+    @test match(r" fst4 at .*:\d+ => fst5\(::Float64\) at .*:\d+", child.data.callstr) !== nothing
 else
     treestrings = tree[1]
-    @test match(r"fst1 at .*:\d+ => fst2 at .*:\d+ => fst3\(::Float64\)", treestrings[1]) !== nothing
-    @test match(r" fst4 at .*:\d+ => fst5\(::Float64\)", treestrings[2]) !== nothing
+    @test match(r"fst1 at .*:\d+ => fst2 at .*:\d+ => fst3\(::Float64\) at .*:\d+", treestrings[1]) !== nothing
+    @test match(r" fst4 at .*:\d+ => fst5\(::Float64\) at .*:\d+", treestrings[2]) !== nothing
 end
 
 ##


### PR DESCRIPTION
All elements of the stacktrace exept for the MethodInstance that will
be descended into had file:line info, but there's no reason to exclude
such helpful information for that entry.