### PR TITLE
Preserve the Expr head when printing callsites

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -168,7 +168,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
         display_CI = true
 
         TerminalMenus.config(cursor = '•', scroll = :wrap)
-        menu = CthulhuMenu(callsites)
+        menu = CthulhuMenu(callsites, optimize)
         cid = request(menu)
         toggle = menu.toggle
 
@@ -188,7 +188,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
                     callsite.info.callinfos
                 end
                 sub_callsites = let callsite=callsite
-                    map(ci->Callsite(callsite.id, ci), callinfos, callsite.head)
+                    map(ci->Callsite(callsite.id, ci, callsite.head), callinfos)
                 end
                 if isempty(sub_callsites)
                     @warn "Expected multiple callsites, but found none. Please fill an issue with a reproducing example" callsite.info

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -194,7 +194,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
                     @warn "Expected multiple callsites, but found none. Please fill an issue with a reproducing example" callsite.info
                     continue
                 end
-                menu = CthulhuMenu(sub_callsites, sub_menu=true)
+                menu = CthulhuMenu(sub_callsites, optimize; sub_menu=true)
                 cid = request(menu)
                 if cid == length(sub_callsites) + 1
                     continue

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -188,7 +188,7 @@ function _descend(mi::MethodInstance; iswarn::Bool, params=current_params(), opt
                     callsite.info.callinfos
                 end
                 sub_callsites = let callsite=callsite
-                    map(ci->Callsite(callsite.id, ci), callinfos)
+                    map(ci->Callsite(callsite.id, ci), callinfos, callsite.head)
                 end
                 if isempty(sub_callsites)
                     @warn "Expected multiple callsites, but found none. Please fill an issue with a reproducing example" callsite.info

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -64,6 +64,7 @@ get_mi(gci::CuCallInfo) = get_mi(gci.cumi)
 struct Callsite
     id::Int # ssa-id
     info::CallInfo
+    head::Symbol
 end
 get_mi(c::Callsite) = get_mi(c.info)
 
@@ -168,7 +169,7 @@ function Base.show(io::IO, c::Callsite)
     limiter = TextWidthLimiter(io, cols)
     print(limiter, string("%", c.id, " "))
     if isa(c.info, MICallInfo)
-        print(limiter, " = invoke ")
+        print(limiter, string(" = ", c.head, ' '))
         show_callinfo(limiter, c.info)
     elseif c.info isa MultiCallInfo
         print(limiter, " = call ")

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -164,12 +164,13 @@ function show_callinfo(limiter, ci::Union{MultiCallInfo, FailedCallInfo, Generat
 end
 
 function Base.show(io::IO, c::Callsite)
-    limit = get(io, :limit, false)
-    cols = limit ? displaysize(io)[2] : typemax(Int)
+    limit = get(io, :limit, false)::Bool
+    cols = limit ? (displaysize(io)::Tuple{Int,Int})[2] : typemax(Int)
+    optimize = get(io, :optimize, true)::Bool
     limiter = TextWidthLimiter(io, cols)
     print(limiter, string("%", c.id, " "))
     if isa(c.info, MICallInfo)
-        print(limiter, string(" = ", c.head, ' '))
+        optimize ? print(limiter, string(" = ", c.head, ' ')) : print(limiter, " = ")
         show_callinfo(limiter, c.info)
     elseif c.info isa MultiCallInfo
         print(limiter, " = call ")

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -103,7 +103,7 @@ end
 
 function cthulu_typed(io::IO, debuginfo_key, CI, rettype, mi, iswarn, stable_code)
     println(io)
-    println(io, "│ ─ $(string(Callsite(-1, MICallInfo(mi, rettype))))")
+    println(io, "│ ─ $(string(Callsite(-1, MICallInfo(mi, rettype), :invoke)))")
 
     if iswarn
         cthulhu_warntype(io, CI, rettype, debuginfo_key, stable_code)
@@ -174,7 +174,7 @@ function Base.show(io::IO, ::MIME"text/plain", b::Bookmark;
                    optimize = false, debuginfo = :none, iswarn=false)
     CI, rt = InteractiveUtils.code_typed(b, optimize = optimize)
     if get(io, :typeinfo, Any) === Bookmark  # a hack to check if in Vector etc.
-        print(io, Callsite(-1, MICallInfo(b.mi, rt)))
+        print(io, Callsite(-1, MICallInfo(b.mi, rt)), :invoke)
         print(io, " (world: ", b.params.world, ")")
         return
     end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -16,19 +16,19 @@ mutable struct CthulhuMenu <: TerminalMenus.AbstractMenu
     sub_menu::Bool
 end
 
-function show_as_line(el)
-    reduced_displaysize = displaysize(stdout) .- (0, 3)
+function show_as_line(el, optimize::Bool)
+    reduced_displaysize = displaysize(stdout)::Tuple{Int,Int} .- (0, 3)
     buf = ctx = IOBuffer()
     if (color = get(stdout, :color, nothing)) !== nothing
         ctx = IOContext(ctx, :color=>color)
     end
-    show(IOContext(ctx, :limit=>true, :displaysize=>reduced_displaysize), el)
+    show(IOContext(ctx, :limit=>true, :displaysize=>reduced_displaysize, :optimize=>optimize), el)
     String(take!(buf))
 end
 
 
-function CthulhuMenu(callsites; pagesize::Int=10, sub_menu = false)
-    options = vcat(map(show_as_line, callsites), ["↩"])
+function CthulhuMenu(callsites, optimize::Bool; pagesize::Int=10, sub_menu = false)
+    options = vcat(map(site->show_as_line(site, optimize), callsites), ["↩"])
     length(options) < 1 && error("CthulhuMenu must have at least one option")
 
     # if pagesize is -1, use automatic paging

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,22 +34,26 @@ let callsites = find_callsites_by_ftt(test, Tuple{}; optimize=false)
     @test length(callsites) == 4
 end
 
-# Check that the Expr head (:invoke or :call) is preserved
-@noinline twice(x::Real) = 2x
-calltwice(c) = twice(c[1])
-let callsites = find_callsites_by_ftt(calltwice, Tuple{Vector{Float64}})
+@testset "Expr heads" begin
+    # Check that the Expr head (:invoke or :call) is preserved
+    @noinline twice(x::Real) = 2x
+    calltwice(c) = twice(c[1])
+
+    callsites = find_callsites_by_ftt(calltwice, Tuple{Vector{Float64}})
     @test length(callsites) == 1 && callsites[1].head === :invoke
     io = IOBuffer()
     print(io, callsites[1])
     @test occursin("invoke twice(::Float64)::Float64", String(take!(io)))
-end
-let callsites = find_callsites_by_ftt(calltwice, Tuple{Vector{AbstractFloat}})
+
+    callsites = find_callsites_by_ftt(calltwice, Tuple{Vector{AbstractFloat}})
     @test length(callsites) == 1 && callsites[1].head === :call
     io = IOBuffer()
     print(io, callsites[1])
     @test occursin("call twice(::AbstractFloat)", String(take!(io)))
-end
 
+    # Note the failure of `callinfo` to properly handle specialization
+    @test_broken Cthulhu.callinfo(Tuple{typeof(twice), AbstractFloat}) isa Cthulhu.MultiCallInfo
+end
 
 # Check that we see callsites that are the rhs of assignments
 @noinline bar_callsite_assign() = nothing


### PR DESCRIPTION
It's useful to be able to distinguish between compile-time and
run-time dispatch. Internally Julia does this with the `:invoke`/`:call`
distinction, but Cthulhu has historically used `:invoke` for both,
only using `:call` when multiple MethodInstances might apply.
Unfortunately, the multi-MI analysis does not take full account of
specialization, and so does not fully replicate the original pattern.

Here, we directly preserve the original head, which should make it
more robust to mistakes or changes in how Julia does things.

## Demo

On the current `master` branch,
```julia
julia> @noinline twice(x::Real) = 2x
twice (generic function with 1 method)

julia> calltwice(c) = twice(c[1])
calltwice (generic function with 1 method)

julia> c64, cabs = [1.0], AbstractFloat[1.0f0]
([1.0], AbstractFloat[1.0f0])

julia> @code_typed calltwice(c64)
CodeInfo(
1 ─ %1 = Base.arrayref(true, c, 1)::Float64
│   %2 = invoke Main.twice(%1::Float64)::Float64
└──      return %2
) => Float64

julia> @code_typed calltwice(cabs)
CodeInfo(
1 ─ %1 = Base.arrayref(true, c, 1)::AbstractFloat
│   %2 = Main.twice(%1)::Any
└──      return %2
) => Any
```
From the lack of `invoke` in `%2` in the latter, you know this one is a `:call` Expr:
```julia
julia> ans.first.code[2].head
:call
```

Now let's see how the `master` branch of Cthulhu handles this:
```julia
julia> using Cthulhu
[ Info: Precompiling Cthulhu [f68482b8-f384-11e8-15f7-abe071a5a75f]

julia> @descend calltwice(cabs)

│ ─ %-1  = invoke calltwice(::Vector{AbstractFloat})::Any
CodeInfo(
    @ REPL[2]:1 within `calltwice'
   ┌ @ array.jl:787 within `getindex'
1 ─│ %1 = Base.arrayref(true, c, 1)::AbstractFloat
│  └
│   %2 = Main.twice(%1)::Any
└──      return %2
)
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [v]erbose printing for warntype code, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %2  = invoke twice(::AbstractFloat)::Any
   ↩

```
It prints it with `invoke`. 

On this branch:
```julia
julia> @descend calltwice(cabs)

│ ─ %-1  = invoke calltwice(::Vector{AbstractFloat})::Any
CodeInfo(
    @ REPL[2]:1 within `calltwice'
   ┌ @ array.jl:787 within `getindex'
1 ─│ %1 = Base.arrayref(true, c, 1)::AbstractFloat
│  └
│   %2 = Main.twice(%1)::Any
└──      return %2
)
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [v]erbose printing for warntype code, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %2  = call twice(::AbstractFloat)::Any
   ↩
``` 

This mirrors the actual `MethodInstances`: in a fresh session,
```julia
julia> using MethodAnalysis

julia> calltwice(cabs)
2.0f0

julia> methodinstances(twice)
2-element Vector{Core.MethodInstance}:
 MethodInstance for twice(::AbstractFloat)
 MethodInstance for twice(::Float32)
```
so in reality there *are* two `MethodInstance`s. The problem is that `Cthulhu.callinfo` is based on Methods, and there is only a single Method that applies, but Julia will generate specializations. I am guessing there must be a Core.Compiler method that will return all the relevant specializations, but off the top of my head I don't know what it is.

I've added a `@test_broken` to capture this failure to properly handle specialization.

