### PR TITLE
Unwrap `QuoteNode` arguments.

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -50,7 +50,7 @@ else
         if isa(a, Const)
             a = Core.Typeof(a.val)
         elseif isa(a, Core.Compiler.PartialStruct)
-            a = Core.Typeof(a.typ)
+            a = a.typ
         end
         return a
     end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -122,6 +122,8 @@ function find_callsites(CI::Core.CodeInfo, mi::Core.MethodInstance, slottypes; p
                         elseif isa(a, SlotOrArgument)
                             a = slottypes[_id(a)]
                             return unwrapconst(a)
+                        elseif isa(a, QuoteNode)
+                            return Core.Typeof(a.value)
                         end
                         Core.Typeof(a)
                     end


### PR DESCRIPTION
Fixes #116 
That is, it fixes it assuming that the current behavior is incorrect and the new behavior correct.
```julia
julia> using Cthulhu

julia> @noinline function mysumvalarg(x, ::Val{N}) where {N}
           s = zero(eltype(x)); N
           @inbounds @simd for i ∈ eachindex(x)
               s += x[i]
           end
           s
       end
mysumvalarg (generic function with 1 method)

julia> mysumval(x) = mysumvalarg(x, Val(4))
mysumval (generic function with 1 method)

julia> x = rand(10);

julia> @descend mysumval(x)

│ ─ %-1  = invoke mysumval(::Vector{Float64})::Float64
CodeInfo(
    @ REPL[3]:1 within `mysumval'
1 ─ %1 = invoke Main.mysumvalarg(_2::Vector{Float64}, $(QuoteNode(Val{4}()))::Val{4})::Float64
└──      return %1
)
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [v]erbose printing for warntype code, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %1  = invoke mysumvalarg(::Vector{Float64},::Val{4})::Float64
   ↩
```