### PR TITLE
Minimal switch to AbstractInterpreter

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,12 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'
-          - '1.1'
-          - '1.2'
-          - '1.3'
-          - '1.4'
-          - '1.5'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 CodeTracking = "0.5, 1"
 FoldingTrees = "1"
-julia = "1"
+julia = "1.7"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -1,0 +1,63 @@
+using Core.Compiler: AbstractInterpreter, NativeInterpreter, InferenceState,
+    OptimizationState, CodeInfo, CodeInstance, InferenceResult
+
+struct InferredSource
+    src::CodeInfo
+    stmt_infos::Vector{Any}
+    rt::Any
+end
+
+mutable struct CthulhuInterpreter <: AbstractInterpreter
+    native::NativeInterpreter
+
+    unopt::Dict{MethodInstance, InferredSource}
+    opt::Dict{MethodInstance, CodeInstance}
+
+    msgs::Dict{MethodInstance, Vector{Pair{Int, String}}}
+end
+
+CthulhuInterpreter() = CthulhuInterpreter(
+    NativeInterpreter(),
+    Dict{MethodInstance, CodeInfo}(),
+    Dict{MethodInstance, CodeInfo}(),
+    Dict{MethodInstance, Vector{Tuple{Int, String}}}()
+)
+
+import Core.Compiler: InferenceParams, OptimizationParams, get_world_counter,
+    get_inference_cache, code_cache,
+    WorldView, lock_mi_inference, unlock_mi_inference, InferenceState
+
+InferenceParams(ei::CthulhuInterpreter) = InferenceParams(ei.native)
+OptimizationParams(ei::CthulhuInterpreter) = OptimizationParams(ei.native)
+get_world_counter(ei::CthulhuInterpreter) = get_world_counter(ei.native)
+get_inference_cache(ei::CthulhuInterpreter) = get_inference_cache(ei.native)
+
+# No need to do any locking since we're not putting our results into the runtime cache
+lock_mi_inference(ei::CthulhuInterpreter, mi::MethodInstance) = nothing
+unlock_mi_inference(ei::CthulhuInterpreter, mi::MethodInstance) = nothing
+
+code_cache(ei::CthulhuInterpreter) = ei.opt
+Core.Compiler.get(a::Dict, b, c) = Base.get(a,b,c)
+Core.Compiler.get(a::WorldView{<:Dict}, b, c) = Base.get(a.cache,b,c)
+Core.Compiler.haskey(a::Dict, b) = Base.haskey(a, b)
+Core.Compiler.haskey(a::WorldView{<:Dict}, b) =
+    Core.Compiler.haskey(a.cache, b)
+Core.Compiler.setindex!(a::Dict, b, c) = setindex!(a, b, c)
+Core.Compiler.may_optimize(ei::CthulhuInterpreter) = true
+Core.Compiler.may_compress(ei::CthulhuInterpreter) = false
+Core.Compiler.may_discard_trees(ei::CthulhuInterpreter) = false
+
+function Core.Compiler.add_remark!(ei::CthulhuInterpreter, sv::InferenceState, msg)
+    push!(get!(ei.msgs, sv.linfo, Tuple{Int, String}[]),
+        sv.currpc => msg)
+end
+
+function Core.Compiler.finish(state::InferenceState, ei::CthulhuInterpreter)
+    r = invoke(Core.Compiler.finish, Tuple{InferenceState, AbstractInterpreter}, state, ei)
+    ei.unopt[state.linfo] = InferredSource(
+        copy(isa(state.src, OptimizationState) ?
+            state.src.src : state.src),
+        copy(state.stmt_info),
+        state.result.result)
+    return r
+end


### PR DESCRIPTION
This is the minimal work required to switch Cthulhu to AbstractInterpreter.
There are several things I would like to build on top of this:
    - Read callsites out of statement info rather than reconstructing it
    - Support for Opaque Closures
    - More consistent use of AbstractInterpreter throughout the API
    - Expose inference remarks

I would like to propose that we make a codebase break at Julia 1.6
for Cthulhu, moving the current master to a branch and requiring
Julia 1.7 on Cthulhu master. That gives us the rest of the 1.7 cycle
to update Cthulhu and figure out what the right interfaces between
Cthulhu and Base are.

Fixes #124

cc @maleadt