### PR TITLE
Trying to support Opaque Closure

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -220,6 +220,13 @@ function find_callsites(CI::Core.CodeInfo, mi::Core.MethodInstance, slottypes; p
                         callsite = Callsite(id, TaskCallInfo(callinfo(sig, nothing, params=params)), c.head)
                     end
                 end
+            elseif c.head === :new_opaque_closure
+                length(c.args) < 5 && continue  # malformed?
+                m = c.args[5]
+                m isa Method || continue
+                atypes = Base.tuple_type_cons(Any, c.args[1])
+                mi = Core.Compiler.specialize_method(m, atypes, Core.svec())
+                callsite = Callsite(id, MICallInfo(mi, c.args[4]), c.head)
             end
 
             if callsite !== nothing

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -208,7 +208,7 @@ function find_callsites(CI::Core.CodeInfo, mi::Core.MethodInstance, slottypes; p
                     end
                     callsite = Callsite(id, ci, c.head)
                 end
-            else c.head === :foreigncall
+            elseif c.head === :foreigncall
                 # special handling of jl_new_task
                 length(c.args) > 0 || continue
                 if c.args[1] isa QuoteNode


### PR DESCRIPTION
I thought something like this PR might work, but:

```
julia> f(x) = Base.Experimental.@opaque () -> x
f (generic function with 1 method)

julia> @descend f(1)

│ ─ %-1  = invoke f(::Int64)::Core.OpaqueClosure{Tuple{}, T} where T
CodeInfo(
    @ REPL[2]:1 within `f'
1 ─ %1 = $(Expr(:new_opaque_closure, Tuple{}, false, Union{}, :(Core.Any), opaque closure @0x00007f8313a47920 in Main, Core.Argument(2)))::Core.OpaqueClosure{Tuple{}, T} where T
└──      return %1
)
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [v]erbose printing for warntype code, [d]ebuginfo, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %1  = new_opaque_closure opaque closure()::Core.Any
   ↩
ERROR: KeyError: key MethodInstance for (::Any)() not found
Stacktrace:
 [1] getindex
   @ ./dict.jl:482 [inlined]
 [2] _descend(interp::Cthulhu.CthulhuInterpreter, mi::Core.MethodInstance; iswarn::Bool, params::Core.Compiler.NativeInterpreter, optimize::Bool, interruptexc::Bool, verbose::Bool, kwargs::Base.Iterators.Pairs{Symbol, Symbol, Tuple{Symbol}, NamedTuple{(:debuginfo,), Tuple{Symbol}}})
   @ Cthulhu ~/.julia/dev/Cthulhu/src/Cthulhu.jl:160
 [3] _descend(interp::Cthulhu.CthulhuInterpreter, mi::Core.MethodInstance; iswarn::Bool, params::Core.Compiler.NativeInterpreter, optimize::Bool, interruptexc::Bool, verbose::Bool, kwargs::Base.Iterators.Pairs{Union{}, Union{}, Tuple{}, NamedTuple{(), Tuple{}}})
   @ Cthulhu ~/.julia/dev/Cthulhu/src/Cthulhu.jl:216
 [4] _descend(F::Any, TT::Any; params::Core.Compiler.NativeInterpreter, kwargs::Base.Iterators.Pairs{Symbol, Bool, Tuple{Symbol}, NamedTuple{(:iswarn,), Tuple{Bool}}})
   @ Cthulhu ~/.julia/dev/Cthulhu/src/Cthulhu.jl:281
 [5] _descend_with_error_handling(::Any, ::Vararg{Any}; kwargs::Any)
   @ Cthulhu ~/.julia/dev/Cthulhu/src/Cthulhu.jl:124
 [6] #descend_code_typed#44
   @ ~/.julia/dev/Cthulhu/src/Cthulhu.jl:96 [inlined]
 [7] descend_code_typed(f::Function, tt::Any)
   @ Cthulhu ~/.julia/dev/Cthulhu/src/Cthulhu.jl:96
 [8] top-level scope
   @ REPL[3]:1
```

It looks like this is because the opaque closure's method instance is not in `interp.opt`. With

```diff
diff --git a/src/Cthulhu.jl b/src/Cthulhu.jl
index a6c0b10..dc5d619 100644
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -156,6 +156,7 @@ function _descend(interp::CthulhuInterpreter, mi::MethodInstance; iswarn::Bool,

     display_CI = true
     while true
+        @info "_descend:" keys(interp.opt)
         debuginfo_key = debuginfo ? :source : :none
         codeinf = copy(optimize ? interp.opt[mi].inferred : interp.unopt[mi].src)
         rt = optimize ? interp.opt[mi].rettype : interp.unopt[mi].rt
```

I get:

```
 • %1  = new_opaque_closure opaque closure()::Core.Any
   ↩
┌ Info: _descend:
│   keys(interp.opt) =
│    KeySet for a Dict{Core.MethodInstance, Core.CodeInstance} with 1 entry. Keys:
└      MethodInstance for f(::Int64)
ERROR: KeyError: key MethodInstance for (::Any)() not found
```

Is this patch an OK direction? What's the best way to make it work?

cc @Keno 