### PR TITLE
Fix #132

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -272,12 +272,17 @@ function do_typeinf!(interp, mi)
     return nothing
 end
 
-function _descend(@nospecialize(F), @nospecialize(TT); params=current_params(), kwargs...)
+function do_typeinf(@nospecialize(F), @nospecialize(TT))
     ci = CthulhuInterpreter()
     sigt = Base.signature_type(F, TT)
     match = Base._which(sigt)
     mi = Core.Compiler.specialize_method(match)
     do_typeinf!(ci, mi)
+    return ci, mi
+end
+
+function _descend(@nospecialize(F), @nospecialize(TT); params=current_params(), kwargs...)
+    ci, mi = do_typeinf(F, TT)
     _descend(ci, mi; params=params, kwargs...)
 end
 

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -46,6 +46,7 @@ Core.Compiler.setindex!(a::Dict, b, c) = setindex!(a, b, c)
 Core.Compiler.may_optimize(ei::CthulhuInterpreter) = true
 Core.Compiler.may_compress(ei::CthulhuInterpreter) = false
 Core.Compiler.may_discard_trees(ei::CthulhuInterpreter) = false
+Core.Compiler.verbose_stmt_info(ni::CthulhuInterpreter) = true
 
 function Core.Compiler.add_remark!(ei::CthulhuInterpreter, sv::InferenceState, msg)
     push!(get!(ei.msgs, sv.linfo, Tuple{Int, String}[]),

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -297,6 +297,11 @@ tree = Cthulhu.treelist(fst5(1.0))
 child = tree.children[1]
 @test match(r" fst4 at .*:\d+ => fst5\(::Float64\) at .*:\d+", child.data.callstr) !== nothing
 
+# issue #132
+f132(w, dim) = [i == dim ? w[i]/2 : w[i]/1 for i in eachindex(w)]
+ci, mi = Cthulhu.do_typeinf(f132, (Vector{Int}, Int))
+@test isa(mi, Core.MethodInstance)   # just check that the above succeeded
+
 ##
 # Cthulhu config test
 ##


### PR DESCRIPTION
Note this adds a more testable call, `do_typeinf`,
for checking on compiler-related issues.

I'm just guessing that Cthulhu is one of the intended targets of `verbose_stmt_info`, so I set the value to `true`. Happy to be corrected by those who know more.

This passes tests when Julia is compiled at 621ee2aca670e28a7a318b39f5be88d1d9d5fecf, but on nightly it fails due to #133.