### PR TITLE
Minimal fix for change in CostCallInfo

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -76,7 +76,6 @@ function find_callsites(CI::Union{Core.CodeInfo, IRCode}, stmt_info::Union{Vecto
                     elseif isa(info, ConstCallInfo)
                         if length(info.results) == 1
                             result = info.results[1]
-                            @assert length(info.results) == 1
                             return [ConstPropCallInfo(MICallInfo(result.linfo, rt), result)]
                         else
                             vcat(process_info(info.call),

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -74,8 +74,15 @@ function find_callsites(CI::Union{Core.CodeInfo, IRCode}, stmt_info::Union{Vecto
                         # we ignore any implicit iterate calls.
                         return process_info(info.call)
                     elseif isa(info, ConstCallInfo)
-                        result = info.result
-                        return [ConstPropCallInfo(MICallInfo(result.linfo, rt), result)]
+                        if length(info.results) == 1
+                            result = info.results[1]
+                            @assert length(info.results) == 1
+                            return [ConstPropCallInfo(MICallInfo(result.linfo, rt), result)]
+                        else
+                            vcat(process_info(info.call),
+                                map(result->ConstPropCallInfo(MICallInfo(result.linfo, rt), result),
+                                    filter(!isnothing, info.results)))
+                        end
                     elseif isdefined(Compiler, :OpaqueClosureCallInfo) && isa(info, Compiler.OpaqueClosureCallInfo)
                         return [OCCallInfo(Core.Compiler.specialize_method(info.match), rt)]
                     elseif isdefined(Compiler, :OpaqueClosureCreateInfo) && isa(info, Compiler.OpaqueClosureCreateInfo)


### PR DESCRIPTION
This is just the general fix to try and get tests to pass again and Cthulhu somewhat working, I don't think it's optimal, but it's also not clear to me how to tell from the new design of ConstCallInfo, what to do if the result is `nothing`, i.e. what choices to present to the user there, so we may have to take another look at how this info is computed in Base. @aviatesk could you think about what needs to be done here?