### PR TITLE
NFC: simplify CodeInfo warntype printing

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -73,8 +73,9 @@ function cthulhu_warntype(io::IO, src, rettype, debuginfo, stable_code)
         show(io, src)
         # XXX this doesn't properly show warntype
     else
-        ir_printer = stable_code ? Base.IRShow.show_ir : show_ir
-        ir_printer(lambda_io, src, lineprinter(src), InteractiveUtils.warntype_type_printer)
+        print_stmt = stable_code ? (_, _, _) -> true : is_type_unstable
+        show_ir(lambda_io, src, lineprinter(src), InteractiveUtils.warntype_type_printer;
+                print_stmt)
     end
     return nothing
 end
@@ -186,107 +187,38 @@ InteractiveUtils.code_native(io::IO, b::Bookmark; optimize = true, debuginfo = :
     cthulhu_native(io, b.mi, optimize, debuginfo == :source, b.params, config)
 
 @nospecialize
-using Base.IRShow: compute_basic_blocks, scan_ssa_use!, should_print_ssa_type, print_stmt, GotoIfNot, GotoNode, PhiNode, block_for_inst
-function show_ir(io::IO, code::Core.CodeInfo, line_info_preprinter, line_info_postprinter)
-    cols = displaysize(io)[2]
-    used = BitSet()
+
+using Base.IRShow: _stmt, _type, should_print_ssa_type, statementidx_lineinfo_printer,
+    default_expr_type_printer, compute_basic_blocks, scan_ssa_use!, show_ir_stmt
+
+function is_type_unstable(code::CodeInfo, idx::Int, used::BitSet)
+    stmt = _stmt(code, idx)
+    type = _type(code, idx)
+    should_print_ssa_type(stmt) || return false
+    return (idx in used) && type isa Type && (!Base.isdispatchelem(type) || type == Core.Box)
+end
+
+function show_ir(io::IO, code::CodeInfo, line_info_preprinter=statementidx_lineinfo_printer(code), line_info_postprinter=default_expr_type_printer; print_stmt = (_, _, _) -> true)
     stmts = code.code
-    types = code.ssavaluetypes
+    used = BitSet()
     cfg = compute_basic_blocks(stmts)
-    max_bb_idx_size = length(string(length(cfg.blocks)))
     for stmt in stmts
         scan_ssa_use!(push!, used, stmt)
     end
     bb_idx = 1
 
-    if isempty(used)
-        maxlength_idx = 0
-    else
-        maxused = maximum(used)
-        maxlength_idx = length(string(maxused))
+    for idx in 1:length(stmts)
+        if print_stmt(code, idx, used)
+            bb_idx = show_ir_stmt(io, code, idx, line_info_preprinter, line_info_postprinter, used, cfg, bb_idx)
+        # this is the only functionality added vs base
+        elseif bb_idx <= length(cfg.blocks) && idx == cfg.blocks[bb_idx].stmts.stop
+            bb_idx += 1
+        end
     end
-    for idx in eachindex(stmts)
-        if !isassigned(stmts, idx)
-            # This is invalid, but do something useful rather
-            # than erroring, to make debugging easier
-            printstyled(io, "#UNDEF\n", color=:red)
-            continue
-        end
-        stmt = stmts[idx]
-        show_type = types isa Vector{Any} && should_print_ssa_type(stmt)
-        if types isa Vector{Any} # ignore types for pre-inference code
-            if isassigned(types, idx) && show_type
-                typ = types[idx]
-                if (idx in used) && typ isa Type && (!Base.isdispatchelem(typ) || typ == Core.Box)
-                else
-                    continue
-                end
-            else
-                continue
-            end
-        end
-        # Compute BB guard rail
-        if bb_idx > length(cfg.blocks)
-            # If invariants are violated, print a special leader
-            linestart = " "^(max_bb_idx_size + 2) # not inside a basic block bracket
-            inlining_indent = line_info_preprinter(io, linestart, idx)
-            printstyled(io, "!!! ", "─"^max_bb_idx_size, color=:light_black)
-        else
-            bbrange = cfg.blocks[bb_idx].stmts
-            bbrange = bbrange.start:bbrange.stop
-            # Print line info update
-            linestart = idx == first(bbrange) ? "  " : sprint(io -> printstyled(io, "│ ", color=:light_black), context=io)
-            linestart *= " "^max_bb_idx_size
-            inlining_indent = line_info_preprinter(io, linestart, idx)
-            if idx == first(bbrange)
-                bb_idx_str = string(bb_idx)
-                bb_pad = max_bb_idx_size - length(bb_idx_str)
-                bb_type = length(cfg.blocks[bb_idx].preds) <= 1 ? "─" : "┄"
-                printstyled(io, bb_idx_str, " ", bb_type, "─"^bb_pad, color=:light_black)
-            elseif idx == last(bbrange) # print separator
-                printstyled(io, "└", "─"^(1 + max_bb_idx_size), color=:light_black)
-            else
-                printstyled(io, "│ ", " "^max_bb_idx_size, color=:light_black)
-            end
-            if idx == last(bbrange)
-                bb_idx += 1
-            end
-        end
-        print(io, inlining_indent, " ")
-        # convert statement index to labels, as expected by print_stmt
-        if stmt isa Expr
-            if stmt.head === :gotoifnot && length(stmt.args) == 2 && stmt.args[2] isa Int
-                stmt = GotoIfNot(stmt.args[1], block_for_inst(cfg, stmt.args[2]::Int))
-            elseif stmt.head === :enter && length(stmt.args) == 1 && stmt.args[1] isa Int
-                stmt = Expr(:enter, block_for_inst(cfg, stmt.args[1]::Int))
-            end
-        elseif isa(stmt, GotoIfNot)
-            stmt = GotoIfNot(stmt.cond, block_for_inst(cfg, stmt.dest))
-        elseif stmt isa GotoNode
-            stmt = GotoNode(block_for_inst(cfg, stmt.label))
-        elseif stmt isa PhiNode
-            e = stmt.edges
-            stmt = PhiNode(Int32[block_for_inst(cfg, Int(e[i])) for i in 1:length(e)], stmt.values)
-        end
-        print_stmt(io, idx, stmt, used, maxlength_idx, true, show_type)
-        if types isa Vector{Any} # ignore types for pre-inference code
-            if !isassigned(types, idx)
-                # This is an error, but can happen if passes don't update their type information
-                printstyled(io, "::#UNDEF", color=:red)
-            elseif show_type
-                typ = types[idx]
-                if typ isa Union && Base.is_expected_union(typ)
-                    Base.emphasize(io, "::$typ", Base.warn_color()) # more mild user notification
-                else
-                    Base.emphasize(io, "::$typ")
-                end
-            end
-        end
-        println(io)
-    end
-    let linestart = " "^(max_bb_idx_size + 2)
-        line_info_preprinter(io, linestart, 0)
-    end
+
+    max_bb_idx_size = length(string(length(cfg.blocks)))
+    line_info_preprinter(io, " "^(max_bb_idx_size + 2), 0)
     nothing
 end
+
 @specialize


### PR DESCRIPTION
Now that we require Julia 1.6. I think we can close #131 with this. We could discuss moving the functionality in `show_ir` into Base, but not sure the little remaining duplication here is worth it.