### PR TITLE
more control over optimized debuginfo

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -22,7 +22,8 @@ function cthulhu_llvm(io::IO, mi, optimize, debuginfo, params, config::CthulhuCo
         mi, params.world,
         #=wrapper=# false, #=strip_ir_metadata=# true,
         dump_module,
-        optimize, debuginfo > 0 ? :source : :none, Base.CodegenParams())
+        optimize, debuginfo != DInfo.none ? :source : :none,
+        Base.CodegenParams())
     highlight(io, dump, "llvm", config)
 end
 
@@ -30,7 +31,7 @@ function cthulhu_native(io::IO, mi, optimize, debuginfo, params, config::Cthulhu
     dump = InteractiveUtils._dump_function_linfo_native(
         mi, params.world,
         #=wrapper=# false, #=syntax=# config.asm_syntax,
-        debuginfo > 0 ? :source : :none)
+        debuginfo != DInfo.none ? :source : :none)
     highlight(io, dump, "asm", config)
 end
 

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -110,11 +110,13 @@ function cthulu_typed(io::IO, debuginfo, src, rt, mi, iswarn, stable_code)
     println(io)
     println(io, "│ ─ $(string(Callsite(-1, MICallInfo(mi, rettype), :invoke)))")
 
-    iswarn && cthulhu_warntype(io, src, rettype, debuginfo, stable_code)
-
-    bb_color = (src isa IRCode && debuginfo === :compact) ? :normal : :light_black
-    irshow_config = IRShowConfig(lineprinter(src); bb_color)
-    show_ir(io, src, irshow_config)
+    if iswarn
+        cthulhu_warntype(io, src, rettype, debuginfo, stable_code)
+    else
+        bb_color = (src isa IRCode && debuginfo === :compact) ? :normal : :light_black
+        irshow_config = IRShowConfig(lineprinter(src); bb_color)
+        show_ir(io, src, irshow_config)
+    end
     println(io)
 end
 
@@ -208,4 +210,3 @@ InteractiveUtils.code_native(b::Bookmark; kw...) =
 InteractiveUtils.code_native(io::IO, b::Bookmark; optimize = true, debuginfo = :source,
                              config = CONFIG) =
     cthulhu_native(io, b.mi, optimize, debuginfo == :source, b.params, config)
-


### PR DESCRIPTION
This introduces three levels of debuginfo: `none`, `compact`, which is
equivalent to `source` for unoptimized code, but for optimized code
gives the same compact lineinfo printing as in previous Cthulhu
versions, and `source` which now always uses the same printing.

depends on https://github.com/JuliaLang/julia/pull/40459
closes #149, closes #150