### PR TITLE
fix #152, no more `AssertionError` from `argextype`

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -465,6 +465,21 @@ let config = Cthulhu.CthulhuConfig(
     end
 end
 
+# https://github.com/JuliaDebug/Cthulhu.jl/issues/152
+let callsites = @find_callsites_by_ftt optimize=false replace("s", "a"=>"b")
+    @test !isempty(callsites)
+end
+function issue152_another(t)
+    s = 0
+    for a in t
+        s += a
+    end
+    return s
+end
+let callsites = find_callsites_by_ftt(issue152_another, (Tuple{Float64,Vararg{Float64}},); optimize=false)
+    @test !isempty(callsites)
+end
+
 ###
 ### Printer test:
 ###


### PR DESCRIPTION
On the nightly build, I couldn't reproduce the reported error, but here
is another example to reproduce it:
```julia
julia> descend((Tuple{Float64,Vararg{Float64}},); optimize=false) do itr
           s = 0
           for a in itr
               s += a
           end
           return s
       end
ERROR: AssertionError: argextype only works on argument-position values
Stacktrace:
  [1] argextype(x::Any, src::Core.CodeInfo, sptypes::Vector{Any}, slottypes::Vector{Any})
    @ Core.Compiler ./compiler/utilities.jl:229
```

It turns out that this error came from `slot = x` statements in an
unoptimized IR, which `argextype` doesn't handle (because it's supposed
to only work on optimized ones).

This PR special cases such statements when working on unoptimized IRs,
and it seems to fix the error.