### PR TITLE
Allow _descend on signature tuple type

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -179,7 +179,11 @@ function find_callsites(interp::CthulhuInterpreter, CI::Union{Core.CodeInfo, IRC
 end
 
 function dce!(ci, mi)
-    argtypes = Core.Compiler.matching_cache_argtypes(mi, nothing)[1]
+    if VERSION >= v"1.7.0-DEV.705"
+        argtypes = Core.Compiler.matching_cache_argtypes(mi, nothing, false)[1]
+    else
+        argtypes = Core.Compiler.matching_cache_argtypes(mi, nothing)[1]
+    end
     ir = Compiler.inflate_ir(ci, sptypes_from_meth_instance(mi),
                              argtypes)
     dce!(ir, mi)


### PR DESCRIPTION
Makes it easier to decend if you can't (or its hard to) construct
an object of the function type, but you do have the signature.

Also, while I'm at it, fix a 1.7 compatibility issue.