### PR TITLE
fix #168: no types shown in unoptimized IR

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -90,7 +90,7 @@ function cthulhu_typed(io::IO, debuginfo, src, rt, mi, iswarn, stable_code, inli
     if isa(src, Core.CodeInfo)
         # we're working on pre-optimization state, need to ignore `LimitedAccuracy`
         src = copy(src)
-        src.ssavaluetypes = ignorelimited.(src.ssavaluetypes::Vector{Any})
+        src.ssavaluetypes = Base.mapany(ignorelimited, src.ssavaluetypes::Vector{Any})
         src.rettype = ignorelimited(src.rettype)
 
         if src.slotnames !== nothing


### PR DESCRIPTION
Perhaps this should be changed in Base, so that it doesn't matter what
element type `src.ssavaluetypes` has, but this fixes the issue.