### PR TITLE
Fix is_callsite for WrappedCallInfos

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,9 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+      - name: Bounds check
+        if: ${{ matrix.os == 'ubuntu-latest' }}
+        run: julia --project -e 'using Pkg; Pkg.test("Cthulhu"; coverage=true, julia_args=["--check-bounds=no"])'
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+Manifest.toml
+*.jl.cov
+*.jl.*.cov
+*.jl.mem

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -270,8 +270,7 @@ _wrapped_callinfo(limiter, ::UncachedCallInfo) = print(limiter, "uncached")
 
 is_callsite(cs::Callsite, mi::MethodInstance) = is_callsite(cs.info, mi)
 is_callsite(info::MICallInfo, mi::MethodInstance) = get_mi(info) === mi
-is_callsite(info::LimitedCallInfo, mi::MethodInstance) = is_callsite(info.ci, mi)
-is_callsite(info::UncachedCallInfo, mi::MethodInstance) = is_callsite(info.ci, mi)
+is_callsite(info::WrappedCallInfo, mi::MethodInstance) = is_callsite(get_wrapped(info), mi)
 is_callsite(info::ConstPropCallInfo, mi::MethodInstance) = is_callsite(info.mi, mi)
 is_callsite(info::TaskCallInfo, mi::MethodInstance) = is_callsite(info.ci, mi)
 is_callsite(info::InvokeCallInfo, mi::MethodInstance) = is_callsite(info.ci, mi)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -97,20 +97,20 @@ let callsites = find_callsites_by_ftt(call_by_apply, Tuple{Tuple{Int}}; optimize
     @test length(callsites) == 1
 end
 
-if Base.JLOptions().check_bounds == 0
-Base.@propagate_inbounds function f(x)
-    @boundscheck error()
-end
-g(x) = @inbounds f(x)
-h(x) = f(x)
+if Base.JLOptions().check_bounds ∈ (0, 2)
+    @testset "DCE & boundscheck" begin
+        Base.@propagate_inbounds function f(x)
+            @boundscheck error()
+        end
+        g(x) = @inbounds f(x)
+        h(x) = f(x)
 
-let (_,CI, _, _, _, _) = process(g, Tuple{Vector{Float64}})
-    @test length(CI.stmts) == 3
-end
+        (_,CI, _, _, _, _) = process(g, Tuple{Vector{Float64}})
+        @test_broken length(CI.stmts) == 3
 
-let (_,CI, _, _, _, _) = process(h, Tuple{Vector{Float64}})
-    @test length(CI.stmts) == 2
-end
+        (_,CI, _, _, _, _) = process(h, Tuple{Vector{Float64}})
+        @test_broken length(CI.stmts) == 2
+    end
 end
 
 # Something with many methods, but enough to be under the match limit

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,6 +138,7 @@ end
         @test length(callsites) == 1
         ci = first(callsites).info
         @test isa(ci, Cthulhu.UncachedCallInfo)
+        @test Cthulhu.is_callsite(ci, ci.wrapped.mi)
 
         # TODO do some test with `LimitedCallInfo`, but they happen at deeper callsites
     end


### PR DESCRIPTION
This also:
- ensures that the DCE test runs on CI
- marks the DCE tests as broken (is this a Julia bug?)
- adds a `.gitignore`

Here's the DCE result:
```julia
julia> Base.@propagate_inbounds function f(x)
           @boundscheck error()
       end
f (generic function with 1 method)

julia> g(x) = @inbounds f(x)
g (generic function with 1 method)

julia> h(x) = f(x)
h (generic function with 1 method)

julia> function process(@nospecialize(f), @nospecialize(TT); optimize=true)
           (interp, mi) = Cthulhu.mkinterp(f, TT)
           (ci, rt, infos, slottypes) = Cthulhu.lookup(interp, mi, optimize)
           Cthulhu.preprocess_ci!(ci, mi, optimize, Cthulhu.CthulhuConfig(dead_code_elimination=true))
           interp, ci, infos, mi, rt, slottypes
       end
process (generic function with 1 method)

julia> (_,CI, _, _, _, _) = process(g, Tuple{Vector{Float64}});

julia> CI
1 1 ─     goto #3 if not false                                                                                                                                                                      │╻ f
  2 ─     invoke Main.error()::Union{}                                                                                                                                                              ││
  └──     unreachable                                                                                                                                                                               ││
  3 ─     goto #4                                                                                                                                                                                   ││
  4 ─     return nothing                                                                                                                                                                            │ 
```
I would have thought that more of the `goto`s would have been resolved.