### PR TITLE
Fix handling of MethodResultPure

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -295,7 +295,7 @@ function _descend(interp::CthulhuInterpreter, mi::MethodInstance; override::Unio
             # forcibly enter and inspect the frame, although the native interpreter gave up
             if info isa UncachedCallInfo || info isa TaskCallInfo
                 next_interp = CthulhuInterpreter()
-                next_mi = get_mi(info)
+                next_mi = get_mi(info)::MethodInstance
                 do_typeinf!(next_interp, next_mi)
                 _descend(next_interp, next_mi;
                          params, optimize, iswarn, debuginfo=debuginfo_key, interruptexc, verbose, kwargs...)
@@ -373,7 +373,7 @@ function _descend(interp::CthulhuInterpreter, mi::MethodInstance; override::Unio
     end
 end
 
-function do_typeinf!(interp, mi)
+function do_typeinf!(interp::CthulhuInterpreter, mi::MethodInstance)
     result = InferenceResult(mi)
     frame = InferenceState(result, true, interp)
     Core.Compiler.typeinf(interp, frame)

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -33,6 +33,14 @@ struct UncachedCallInfo <: WrappedCallInfo
     wrapped::CallInfo
 end
 
+struct PureCallInfo <: CallInfo
+    argtypes::Vector{Any}
+    rt
+    PureCallInfo(argtypes::Vector{Any}, @nospecialize(rt)) =
+        new(argtypes, rt)
+end
+get_mi(::PureCallInfo) = nothing
+
 # Failed
 struct FailedCallInfo <: CallInfo
     sig
@@ -202,6 +210,13 @@ function show_callinfo(limiter, ci::Union{MultiCallInfo, FailedCallInfo, Generat
     __show_limited(limiter, name, tt, rt)
 end
 
+function show_callinfo(limiter, (; argtypes, rt)::PureCallInfo)
+    ft, tt... = argtypes
+    f = Compiler.argtype_to_function(ft)
+    name = isnothing(f) ? "unknown" : nameof(f)
+    __show_limited(limiter, name, tt, rt)
+end
+
 function show_callinfo(limiter, ci::ConstPropCallInfo)
     # XXX: The first argument could be const-overriden too
     name = ci.result.linfo.def.name
@@ -222,6 +237,9 @@ function Base.show(io::IO, c::Callsite)
     elseif isa(info, WrappedCallInfo)
         wrapped_callinfo(limiter, info)
         show_callinfo(limiter, ignorewrappers(info))
+    elseif isa(info, PureCallInfo)
+        print(limiter, " = < pure > ")
+        show_callinfo(limiter, info)
     elseif info isa MultiCallInfo
         print(limiter, " = call ")
         show_callinfo(limiter, info)


### PR DESCRIPTION
Formerly Cthulhu tried to ignore statements whose `info` was
 `MethodResultPure` . This was marked as an annotation TODO
 but also didn't quite work:

```julia
julia> using Cthulhu, StaticArrays

# Using `find_callsites_by_ftt from the tests
julia> callsites = find_callsites_by_ftt(iterate, Tuple{SVector{3,Int}, Tuple{SOneTo{3}}}; optimize=false)
CI = CodeInfo(
    @ abstractarray.jl:1142 within `iterate`
1 ─       (y = Core._apply_iterate(Base.iterate, Base.iterate, state))::Core.Const((1, 1))
│   @ abstractarray.jl:1143 within `iterate`
│   %2  = (y::Core.Const((1, 1)) === Base.nothing)::Core.Const(false)
└──       goto #2 if not %2
    @ abstractarray.jl:1144 within `iterate`
2 ─ %4  = Base.getindex(y::Core.Const((1, 1)), 1)::Core.Const(1)
│   %5  = Base.getindex(A, %4)::Int64
│   %6  = Base.getindex(state, 1)::Core.Const(SOneTo(3))
│   %7  = Core.tuple(%6)::Core.Const((SOneTo(3),))
│   %8  = Base.tail(y::Core.Const((1, 1)))::Core.Const((1,))
│   %9  = Core._apply_iterate(Base.iterate, Core.tuple, %7, %8)::Core.Const((SOneTo(3), 1))
│   %10 = Core.tuple(%5, %9)::Core.PartialStruct(Tuple{Int64, Tuple{SOneTo{3}, Int64}}, Any[Int64, Core.Const((SOneTo(3), 1))])
└──       return %10
)
c = :(_4 = Core._apply_iterate(Base.iterate, Base.iterate, _3))
info = Core.Compiler.MethodResultPure(Core.Compiler.MethodMatchInfo(Core.Compiler.MethodLookupResult(Any[Core.MethodMatch(Tuple{typeof(iterate), SOneTo{3}}, svec(3), iterate(::SOneTo{n}) where n in StaticArrays at /home/tim/.julia/packages/StaticArrays/gBeIF/src/SOneTo.jl:41, true)], Core.Compiler.WorldRange(0x00000000000079d9, 0xffffffffffffffff), false)))
```
There error here comes from https://github.com/JuliaDebug/Cthulhu.jl/blob/349fb73e0b701d2bfb014224c19227c59d6b745b/src/reflection.jl#L106-L109

It turns out this happens because the compiler introduced a `MethodResultPure`
wrapped in a `UnionSplitApplyCallInfo`, and our logic for bailing out from pure
happened outside of the `mapreduce` call used in handling `UnionSplitApplyCallInfo`.

This fixes it by defining a new `WrappedCallInfo` subtype for marking these `info`s.
On this branch, here's what you now get:
```
julia> callsites = find_callsites_by_ftt(iterate, Tuple{SVector{3,Int}, Tuple{SOneTo{3}}}; optimize=false)
5-element Vector{Cthulhu.Callsite}:
 %1  = < pure, uncached > iterate(::SOneTo{3})::Core.Const((1, 1))
...
```
