### PR TITLE
handle pure callsites as special callinfo

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -295,7 +295,7 @@ function _descend(interp::CthulhuInterpreter, mi::MethodInstance; override::Unio
             # forcibly enter and inspect the frame, although the native interpreter gave up
             if info isa UncachedCallInfo || info isa TaskCallInfo
                 next_interp = CthulhuInterpreter()
-                next_mi = get_mi(info)
+                next_mi = get_mi(info)::MethodInstance
                 do_typeinf!(next_interp, next_mi)
                 _descend(next_interp, next_mi;
                          params, optimize, iswarn, debuginfo=debuginfo_key, interruptexc, verbose, kwargs...)
@@ -373,7 +373,7 @@ function _descend(interp::CthulhuInterpreter, mi::MethodInstance; override::Unio
     end
 end
 
-function do_typeinf!(interp, mi)
+function do_typeinf!(interp::CthulhuInterpreter, mi::MethodInstance)
     result = InferenceResult(mi)
     frame = InferenceState(result, true, interp)
     Core.Compiler.typeinf(interp, frame)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -63,8 +63,14 @@ isordered(::Type{T}) where {T<:AbstractDict} = false
     @test isempty(callsites)
 
     callsites = find_callsites_by_ftt(iterate, Tuple{SVector{3,Int}, Tuple{SOneTo{3}}}; optimize=false)
-    @test occursin("< pure, uncached >", string(callsites[1]))
+    @test occursin("< pure >", string(callsites[1]))
     @test occursin(r"< constprop > getindex\(::.*Const.*,::.*Const\(1\)\)::.*Const\(1\)", string(callsites[2]))
+
+    # handle pure
+    callsites = @eval find_callsites_by_ftt(; optimize=false) do
+        length($(QuoteNode(Core.svec(0,1,2))))
+    end
+    @test occursin("< pure >", string(callsites[1]))
 
     # Some weird methods get inferred
     callsites = find_callsites_by_ftt(iterate, (Base.IdSet{Any}, Union{}); optimize=false)


### PR DESCRIPTION
Follows up #180.

@timholy What do you think on this ? I don't think it hurts if we can't recurse into a pure callsite (just because inference doesn't really recurse into it)