### PR TITLE
RFC: add terminal tests and add a bit of UI polish

### DIFF
--- a/test/FakeTerminals.jl
+++ b/test/FakeTerminals.jl
@@ -1,0 +1,31 @@
+module FakeTerminals
+
+import REPL
+using Test
+
+export fake_terminal
+
+function fake_terminal(f; options::REPL.Options=REPL.Options(confirm_exit=false))
+    # Use pipes so we can easily do blocking reads
+    # In the future if we want we can add a test that the right object
+    # gets displayed by intercepting the display
+    input = Pipe()
+    output = Pipe()
+    err = Pipe()
+    Base.link_pipe!(input, reader_supports_async=true, writer_supports_async=true)
+    Base.link_pipe!(output, reader_supports_async=true, writer_supports_async=true)
+    Base.link_pipe!(err, reader_supports_async=true, writer_supports_async=true)
+
+    term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")
+    term = REPL.Terminals.TTYTerminal(term_env, input.out, IOContext(output.in, :color=>true), err.in)
+    f(term, input.in, output.out)
+    t = @async begin
+        close(input.in)
+        close(output.in)
+        close(err.in)
+    end
+    @test read(err.out, String) == ""
+    wait(t)
+end
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,8 @@ using Test
 using Random
 using StaticArrays
 
+@test isempty(detect_ambiguities(Cthulhu))
+
 function firstassigned(specializations::Core.SimpleVector)
     # the methodinstance may not be first (annoying)
     for i = 1:length(specializations)
@@ -669,3 +671,5 @@ print(str)
         @test code_native(devnull, b) isa Any
     end
 end
+
+include("terminal.jl")

--- a/test/terminal.jl
+++ b/test/terminal.jl
@@ -1,0 +1,115 @@
+using Test
+using Cthulhu
+using Revise
+
+if !isdefined(@__MODULE__, :fake_terminal)
+    @eval begin
+        includet(joinpath(@__DIR__, "FakeTerminals.jl"))   # FIXME change to include
+        using .FakeTerminals
+    end
+end
+
+cread(io) = readuntil(io, '↩'; keep=true) * readuntil(io, '↩'; keep=true)
+
+@testset "Terminal" begin
+    # Write a file that we track with Revise. Creating it programmatically allows us to rewrite it with
+    # different content
+    fn = tempname()
+    open(fn, "w") do io
+        println(io,
+        """
+        function simplef(a, b)
+            z = a*a
+            return z + b
+        end
+        """)
+    end
+    includet(fn)
+
+    CONFIG = deepcopy(Cthulhu.CONFIG)
+
+    try
+        fake_terminal() do term, in, out
+            @async begin
+                Cthulhu._descend(term, simplef, Tuple{Float32, Int32}; interruptexc=false, iswarn=false)
+            end
+            lines = cread(out)
+            @test occursin("invoke simplef(::Float32,::Int32)::Float32", lines)
+            @test occursin(r"Base\.mul_float\(.*, .*\)\u001B\[36m::Float32\u001B\[39m", lines)
+            @test_broken occursin("\nSelect a call to descend into", lines)   # beginning of the line
+            @test occursin('•', lines)
+            write(in, 'o')            # switch to unoptimized
+            lines = cread(out)
+            @test occursin("invoke simplef(::Float32,::Int32)::Float32", lines)
+            @test occursin(r"\(z = a \* a\)\u001B\[\d\dm::Float32\u001B\[39m", lines)
+            @test_broken occursin("\nSelect a call to descend into", lines)   # beginning of the line
+            @test occursin("• %1  = *(::Float32,::Float32)::Float32", lines)
+            write(in, 'o')            # back to optimized
+            lines = cread(out)
+            @test !occursin("Variables", lines)
+            @test occursin(r"Base\.mul_float\(.*, .*\)\u001B\[36m::Float32\u001B\[39m", lines)
+            write(in, 'o')
+            lines = cread(out)
+            @test !occursin("Variables", lines)
+            write(in, 'w')            # unoptimized + warntype
+            lines = cread(out)
+            @test occursin("Variables", lines)
+            @test occursin(r"z.*::Float32", lines)
+            @test occursin(r"\nBody.*Float32", lines)
+            @test_broken occursin("\nSelect a call to descend into", lines)   # beginning of the line
+            @test occursin("• %1  = *(::Float32,::Float32)::Float32", lines)
+            # turn off syntax highlighting
+            write(in, "s"); cread(out)
+            write(in, "S")
+            lines = cread(out)
+            @test occursin("""
+            \n\nfunction simplef(a, b)
+                z = a*a
+                return z + b
+            end
+            """, lines)
+            write(in, "A")
+            lines = cread(out)
+            @test occursin("Symbol simplef", lines)
+            @test occursin("Symbol call", lines)
+            write(in, "L")
+            lines = cread(out)
+            @test occursin(r"sitofp i(64|32)", lines)
+            @test occursin("fadd float", lines)
+            @test occursin("┌ @ promotion.jl", lines)  # debug info on by default
+            # turn off debug info
+            write(in, "d"); cread(out)
+            write(in, "d"); cread(out)
+            write(in, "L")
+            lines = cread(out)
+            @test !occursin("┌ @ promotion.jl", lines)
+            write(in, "N")
+            lines = cread(out)
+            @test occursin(".text", lines)
+            @test occursin("retq", lines)
+            # Revise
+            open(fn, "w") do io
+                println(io,
+                """
+                function simplef(a, b)
+                    z = a*b
+                    return z + b
+                end
+                """)
+            end
+            sleep(0.1)
+            write(in, "R")
+            lines = cread(out)
+            write(in, "o"); cread(out)     # optimized code
+            write(in, "o")     # unoptimized code
+            lines = cread(out)
+            @test occursin("z = a * b", lines)
+        end
+    finally
+        # Restore the previous settings
+        for fn in fieldnames(Cthulhu.CthulhuConfig)
+            setfield!(Cthulhu.CONFIG, fn, getfield(CONFIG, fn))
+        end
+        rm(fn)
+    end
+end


### PR DESCRIPTION
This adds some tests of Cthulhu's interactivity. One motivation is simply to improve test coverage, which seems more important as this package gets more widely used. Another motivation is that this is the only way to test the Revise functionality, which was broken for a long time but hopefully fixed in #186.

Finally, I think there are some fixes needed to Cthulhu's interactivity, and having tests makes it easier to improve the code (even if the result of the test changes slightly). As a down payment on that, I've added a couple of blank lines that I think significantly help readability (helping users identify start/stop of new codeviews). Here are some of the other things I've noticed:
- [ ] spurious indentation (sometimes, but not always) in front of "Select a call to descend into". This might actually be left over from Julia's printing. This is currently marked `@test_broken`
- [ ] when you're viewing [S]ource, [A]st, [L]LVM, or [N]ative, it's not obvious how to go back to typed. Should we add a [T]yped to the list?
- [ ] toggling debug state is initially confusing because there are 3 states, not 2, but 2 of the 3 seem quite similar (might require docs)
- [ ] the Variables section seems to be printed based on both the optimization state and the the `iswarn` state, but I'm not certain the latter makes sense
- [ ] it's sometimes hard to know what settings you're in currently; just hitting keys until you get something you like seems to be the strategy I've adopted, but it might be worth asking whether this can be made more rational

I'm not really intending to fix all of those as part of this PR, but we might discuss whether some of these should be addressed.