### PR TITLE
change "verbose" terminology to "hide"

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -212,7 +212,7 @@ end
 function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::MethodInstance;
     override::Union{Nothing,InferenceResult}=nothing, debuginfo::Union{Symbol,DebugInfo}=DInfo.compact, # default is compact debuginfo
     params=current_params(), optimize::Bool=true, interruptexc::Bool=true,
-    iswarn::Bool=false, hide::Bool=false, inline_cost::Bool=false)
+    iswarn::Bool=false, hide_type_stable::Bool=false, inline_cost::Bool=false)
     if isa(debuginfo, Symbol)
         debuginfo = getfield(DInfo, debuginfo)::DebugInfo
     end
@@ -259,7 +259,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
 
             display_CI && cthulhu_typed(term.out_stream::IO, debuginfo,
                 codeinf, rt, mi;
-                iswarn, hide, inline_cost)
+                iswarn, hide_type_stable, inline_cost)
             display_CI = true
         end
 
@@ -304,7 +304,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                 _descend(term, next_interp, next_mi;
                          debuginfo,
                          params, optimize, interruptexc,
-                         iswarn, hide, inline_cost)
+                         iswarn, hide_type_stable, inline_cost)
                 continue
             end
 
@@ -321,12 +321,12 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
             _descend(term, interp, next_mi;
                      override = isa(info, ConstPropCallInfo) ? info.result : nothing, debuginfo,
                      params,optimize, interruptexc,
-                     iswarn, hide, inline_cost)
+                     iswarn, hide_type_stable, inline_cost)
 
         elseif toggle === :warn
             iswarn ⊻= true
-        elseif toggle === :hide
-            hide ⊻= true
+        elseif toggle === :hide_type_stable
+            hide_type_stable ⊻= true
         elseif toggle === :optimize
             optimize ⊻= true
             if !is_cached(mi)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -213,9 +213,6 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
     override::Union{Nothing,InferenceResult}=nothing, debuginfo::Union{Symbol,DebugInfo}=DInfo.compact, # default is compact debuginfo
     params=current_params(), optimize::Bool=true, interruptexc::Bool=true,
     iswarn::Bool=false, hide_type_stable::Union{Nothing,Bool}=nothing, verbose::Union{Nothing,Bool}=nothing, inline_cost::Bool=false)
-    if !(isnothing(verbose) || isnothing(hide_type_stable))
-        error("`verbose` is being replaced with `hide_type_stable`, do not use both")
-    end
     if isnothing(hide_type_stable)
         hide_type_stable = something(verbose, false)
     end

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -219,7 +219,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
     if isnothing(hide_type_stable)
         hide_type_stable = something(verbose, false)
     end
-    isnothing(verbose) || @warn "use `hide_type_stable` instead of `verbose`." maxlog=1
+    isnothing(verbose) || Base.depwarn("The `verbose` keyword argument to `Cthulhu.descend` is deprecated. Use `hide_type_stable` instead.")
     if isa(debuginfo, Symbol)
         debuginfo = getfield(DInfo, debuginfo)::DebugInfo
     end

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -212,7 +212,7 @@ end
 function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::MethodInstance;
     override::Union{Nothing,InferenceResult}=nothing, debuginfo::Union{Symbol,DebugInfo}=DInfo.compact, # default is compact debuginfo
     params=current_params(), optimize::Bool=true, interruptexc::Bool=true,
-    iswarn::Bool=false, verbose=true, inline_cost::Bool=false)
+    iswarn::Bool=false, hide::Bool=false, inline_cost::Bool=false)
     if isa(debuginfo, Symbol)
         debuginfo = getfield(DInfo, debuginfo)::DebugInfo
     end
@@ -259,7 +259,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
 
             display_CI && cthulhu_typed(term.out_stream::IO, debuginfo,
                 codeinf, rt, mi;
-                iswarn, verbose, inline_cost)
+                iswarn, hide, inline_cost)
             display_CI = true
         end
 
@@ -304,7 +304,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                 _descend(term, next_interp, next_mi;
                          debuginfo,
                          params, optimize, interruptexc,
-                         iswarn, verbose, inline_cost)
+                         iswarn, hide, inline_cost)
                 continue
             end
 
@@ -321,12 +321,12 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
             _descend(term, interp, next_mi;
                      override = isa(info, ConstPropCallInfo) ? info.result : nothing, debuginfo,
                      params,optimize, interruptexc,
-                     iswarn, verbose, inline_cost)
+                     iswarn, hide, inline_cost)
 
         elseif toggle === :warn
             iswarn ⊻= true
-        elseif toggle === :verbose
-            verbose ⊻= true
+        elseif toggle === :hide
+            hide ⊻= true
         elseif toggle === :optimize
             optimize ⊻= true
             if !is_cached(mi)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -212,7 +212,14 @@ end
 function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::MethodInstance;
     override::Union{Nothing,InferenceResult}=nothing, debuginfo::Union{Symbol,DebugInfo}=DInfo.compact, # default is compact debuginfo
     params=current_params(), optimize::Bool=true, interruptexc::Bool=true,
-    iswarn::Bool=false, hide_type_stable::Bool=false, inline_cost::Bool=false)
+    iswarn::Bool=false, hide_type_stable::Union{Nothing,Bool}=nothing, verbose::Union{Nothing,Bool}=nothing, inline_cost::Bool=false)
+    if !(isnothing(verbose) || isnothing(hide_type_stable))
+        error("`verbose` is being replaced with `hide_type_stable`, do not use both")
+    end
+    if isnothing(hide_type_stable)
+        hide_type_stable = something(verbose, false)
+    end
+    isnothing(verbose) || @warn "use `hide_type_stable` instead of `verbose`." maxlog=1
     if isa(debuginfo, Symbol)
         debuginfo = getfield(DInfo, debuginfo)::DebugInfo
     end

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -79,11 +79,11 @@ end
 cthulhu_warntype(args...; kwargs...) = cthulhu_warntype(stdout::IO, args...; kwargs...)
 function cthulhu_warntype(io::IO, debuginfo::Union{DebugInfo,Symbol},
     src::Union{CodeInfo,IRCode}, @nospecialize(rt), mi::Union{Nothing,MethodInstance}=nothing;
-    hide::Bool=false, inline_cost::Bool=false)
+    hide_type_stable::Bool=false, inline_cost::Bool=false)
     if inline_cost
         isa(mi, MethodInstance) || error("Need a MethodInstance to show inlining costs. Call `cthulhu_typed` directly instead.")
     end
-    cthulhu_typed(io, debuginfo, src, rt, mi; iswarn=true, hide, inline_cost)
+    cthulhu_typed(io, debuginfo, src, rt, mi; iswarn=true, hide_type_stable, inline_cost)
     return nothing
 end
 
@@ -91,7 +91,7 @@ cthulhu_typed(io::IO, debuginfo::DebugInfo, args...; kwargs...) =
     cthulhu_typed(io, Symbol(debuginfo), args...; kwargs...)
 function cthulhu_typed(io::IO, debuginfo::Symbol,
     src::Union{CodeInfo,IRCode}, @nospecialize(rt), mi::Union{Nothing,MethodInstance};
-    iswarn::Bool=false, hide::Bool=false, inline_cost::Bool=false)
+    iswarn::Bool=false, hide_type_stable::Bool=false, inline_cost::Bool=false)
     debuginfo = IRShow.debuginfo(debuginfo)
     lineprinter = __debuginfo[debuginfo]
     rettype = ignorelimited(rt)
@@ -139,7 +139,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
     end
     postprinter = iswarn ? InteractiveUtils.warntype_type_printer : IRShow.default_expr_type_printer
 
-    should_print_stmt = hide ? is_type_unstable : Returns(true)
+    should_print_stmt = hide_type_stable ? is_type_unstable : Returns(true)
     bb_color = (src isa IRCode && debuginfo === :compact) ? :normal : :light_black
 
     irshow_config = IRShowConfig(preprinter, postprinter; should_print_stmt, bb_color)
@@ -204,7 +204,7 @@ Base.show(io::IO, b::Bookmark) =
 # Turn off `optimize` and `debuginfo` for default `show` so that the
 # output is smaller.
 function Base.show(io::IO, ::MIME"text/plain", b::Bookmark;
-                   optimize = false, debuginfo = :none, iswarn=false, hide=true)
+                   optimize = false, debuginfo = :none, iswarn=false, hide_type_stable=true)
     world = b.interp.native.world
     CI, rt = InteractiveUtils.code_typed(b; optimize)
     if get(io, :typeinfo, Any) === Bookmark  # a hack to check if in Vector etc.
@@ -213,7 +213,7 @@ function Base.show(io::IO, ::MIME"text/plain", b::Bookmark;
         return
     end
     println(io, "Cthulhu.Bookmark (world: ", world, ")")
-    cthulhu_typed(io, debuginfo, CI, rt, b.mi; iswarn, hide)
+    cthulhu_typed(io, debuginfo, CI, rt, b.mi; iswarn, hide_type_stable)
 end
 
 function InteractiveUtils.code_typed(b::Bookmark; optimize = true)
@@ -236,11 +236,11 @@ function InteractiveUtils.code_warntype(
     io::IO,
     b::Bookmark;
     debuginfo = :source,
-    hide::Bool = true,
+    hide_type_stable::Bool = true,
     kw...,
 )
     CI, rt = InteractiveUtils.code_typed(b; kw...)
-    cthulhu_warntype(io, debuginfo, CI, rt, b.mi; hide)
+    cthulhu_warntype(io, debuginfo, CI, rt, b.mi; hide_type_stable)
 end
 
 InteractiveUtils.code_llvm(b::Bookmark) = InteractiveUtils.code_llvm(stdout::IO, b)

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -48,7 +48,7 @@ function TerminalMenus.header(m::CthulhuMenu)
     m.sub_menu && return ""
     """
     Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
-    Toggles: [o]ptimize, [w]arn, [v]erbose printing for warntype code, [d]ebuginfo, [i]nlining costs, [s]yntax highlight for Source/LLVM/Native.
+    Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [i]nlining costs, [s]yntax highlight for Source/LLVM/Native.
     Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
     Actions: [E]dit source code, [R]evise and redisplay
     Advanced: dump [P]arams cache.
@@ -60,8 +60,8 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
     if key == UInt32('w')
         m.toggle = :warn
         return true
-    elseif key == UInt32('v')
-        m.toggle = :verbose
+    elseif key == UInt32('h')
+        m.toggle = :hide
         return true
     elseif key == UInt32('o')
         m.toggle = :optimize

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -61,7 +61,7 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
         m.toggle = :warn
         return true
     elseif key == UInt32('h')
-        m.toggle = :hide
+        m.toggle = :hide_type_stable
         return true
     elseif key == UInt32('o')
         m.toggle = :optimize

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -677,12 +677,12 @@ Revise.track(CthulhuTestSandbox, normpath(@__DIR__, "sandbox.jl"))
 
     @testset "debuginfo: $debuginfo" for debuginfo in instances(Cthulhu.DInfo.DebugInfo)
         @testset "iswarn: $iswarn" for iswarn in tf
-            @testset "verbose: $verbose" for verbose in tf
+            @testset "hide: $hide" for hide in tf
                 @testset "inline_cost: $inline_cost" for inline_cost in tf
                     io = IOBuffer()
                     Cthulhu.cthulhu_typed(io, debuginfo,
                         src, rt, mi;
-                        iswarn, verbose, inline_cost)
+                        iswarn, hide, inline_cost)
                     @test !isempty(String(take!(io))) # just check it works
                 end
             end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -706,10 +706,16 @@ end
             return String(take!(io))
         end
 
-        # by default, should print every statement
-        @test occursin("globalvar", prints())
-        # should omit type stable statements
-        @test !occursin("globalvar", prints(; hide_type_stable=true))
+        let # by default, should print every statement
+            s = prints()
+            @test occursin("globalvar", s)
+            @test occursin("undefvar", s)
+        end
+        let # should omit type stable statements
+            s = prints(; hide_type_stable=true)
+            @test !occursin("globalvar", s)
+            @test occursin("undefvar", s)
+        end
     end
 
     let # unoptimize code
@@ -727,14 +733,28 @@ end
             return String(take!(io))
         end
 
-        # by default, should print every statement
-        @test occursin("globalvar", prints())
-        # should omit type stable statements
-        @test !occursin("globalvar", prints(; hide_type_stable=true))
+        let # by default, should print every statement
+            s = prints()
+            @test occursin("globalvar", s)
+            @test occursin("undefvar", s)
+        end
+        let # should omit type stable statements
+            s = prints(; hide_type_stable=true)
+            @test !occursin("globalvar", s)
+            @test_broken occursin("undefvar", s)
+        end
 
-        # works for warn mode
-        @test occursin("globalvar", prints(; iswarn=true))
-        @test !occursin("globalvar", prints(; iswarn=true, hide_type_stable=true))
+        # should work for warn mode
+        let
+            s = prints(; iswarn=true)
+            @test occursin("globalvar", s)
+            @test occursin("undefvar", s)
+        end
+        let
+            s = prints(; iswarn=true, hide_type_stable=true)
+            @test !occursin("globalvar", s)
+            @test_broken occursin("undefvar", s)
+        end
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -677,16 +677,64 @@ Revise.track(CthulhuTestSandbox, normpath(@__DIR__, "sandbox.jl"))
 
     @testset "debuginfo: $debuginfo" for debuginfo in instances(Cthulhu.DInfo.DebugInfo)
         @testset "iswarn: $iswarn" for iswarn in tf
-            @testset "hide: $hide" for hide in tf
+            @testset "hide_type_stable: $hide_type_stable" for hide_type_stable in tf
                 @testset "inline_cost: $inline_cost" for inline_cost in tf
                     io = IOBuffer()
                     Cthulhu.cthulhu_typed(io, debuginfo,
                         src, rt, mi;
-                        iswarn, hide, inline_cost)
+                        iswarn, hide_type_stable, inline_cost)
                     @test !isempty(String(take!(io))) # just check it works
                 end
             end
         end
+    end
+end
+
+@testset "hide type-stable statements" begin
+    let # optimize code
+        _, src, infos, mi, rt, slottypes = @eval Module() begin
+            const globalvar = Ref(42)
+            $process() do
+                a = sin(globalvar[])
+                b = sin(undefvar)
+                return (a, b)
+            end
+        end
+        function prints(; kwargs...)
+            io = IOBuffer()
+            Cthulhu.cthulhu_typed(io, :none, src, rt, mi; kwargs...)
+            return String(take!(io))
+        end
+
+        # by default, should print every statement
+        @test occursin("globalvar", prints())
+        # should omit type stable statements
+        @test !occursin("globalvar", prints(; hide_type_stable=true))
+    end
+
+    let # unoptimize code
+        _, src, infos, mi, rt, slottypes = @eval Module() begin
+            const globalvar = Ref(42)
+            $process(; optimize=false) do
+                a = sin(globalvar[])
+                b = sin(undefvar)
+                return (a, b)
+            end
+        end
+        function prints(; kwargs...)
+            io = IOBuffer()
+            Cthulhu.cthulhu_typed(io, :none, src, rt, mi; kwargs...)
+            return String(take!(io))
+        end
+
+        # by default, should print every statement
+        @test occursin("globalvar", prints())
+        # should omit type stable statements
+        @test !occursin("globalvar", prints(; hide_type_stable=true))
+
+        # works for warn mode
+        @test occursin("globalvar", prints(; iswarn=true))
+        @test !occursin("globalvar", prints(; iswarn=true, hide_type_stable=true))
     end
 end
 


### PR DESCRIPTION
As discussed in #189 and #191, the sense of "verbose" option seems to be
flipped, and its behavior is a bit confusing.

In this PR, I'd propose:
- change "verbose" to "hide" (type-stable statements)
- make it `false` by default
- respect this configuration whenever if we're inspecting `IRCode` or `CodeInfo`,
  or in warntype mode