### PR TITLE
A friendlier face for the squid

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -270,15 +270,16 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                         cthulhu_typed(io, debuginfo, codeinf, rt, mi;
                                     iswarn, hide_type_stable, inline_cost)
                     end
-                    rmatch = match(r"\u001B\[90m\u001B\[(\d+)G( *)\u001B\[1G\u001B\[39m\u001B\[90m( *)\u001B\[39m$", str)
+                    rmatch = findfirst(r"\u001B\[90m\u001B\[(\d+)G( *)\u001B\[1G\u001B\[39m\u001B\[90m( *)\u001B\[39m$", str)
                     if rmatch !== nothing
-                        str = chop(str, tail = 27 + sum(length, rmatch.captures))
+                        str = str[begin:prevind(str, first(rmatch))]
                     end
                     print(term.out_stream::IO, str)
                 else
                     cthulhu_typed(term.out_stream::IO, debuginfo, codeinf, rt, mi;
                                   iswarn, hide_type_stable, inline_cost)
                 end
+                view_cmd = cthulhu_typed
             end
             display_CI = true
         end

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -225,6 +225,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
 
     menu_options = (cursor = '•', scroll_wrap = true)
     display_CI = true
+    view_cmd = cthulhu_typed
     while true
         if override === nothing && optimize && interp.opt[mi].inferred === nothing
             # This was inferred to a pure constant - we have no code to show,
@@ -261,14 +262,30 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
             ci = preprocess_ci!(codeinf, mi, optimize, CONFIG)
             callsites = find_callsites(interp, codeinf, infos, mi, slottypes, optimize; params)
 
-            display_CI && cthulhu_typed(term.out_stream::IO, debuginfo,
-                codeinf, rt, mi;
-                iswarn, hide_type_stable, inline_cost)
+            if display_CI
+                printstyled(IOContext(term.out_stream::IO, :limit=>true), mi.def, '\n'; bold=true)
+                if debuginfo == DInfo.compact
+                    # Eliminate trailing indentation (see first item in bullet list in PR #189)
+                    str = stringify() do io
+                        cthulhu_typed(io, debuginfo, codeinf, rt, mi;
+                                    iswarn, hide_type_stable, inline_cost)
+                    end
+                    rmatch = match(r"\u001B\[90m\u001B\[(\d+)G( *)\u001B\[1G\u001B\[39m\u001B\[90m( *)\u001B\[39m$", str)
+                    if rmatch !== nothing
+                        str = chop(str, tail = 27 + sum(length, rmatch.captures))
+                    end
+                    print(term.out_stream::IO, str)
+                else
+                    cthulhu_typed(term.out_stream::IO, debuginfo, codeinf, rt, mi;
+                                  iswarn, hide_type_stable, inline_cost)
+                end
+            end
             display_CI = true
         end
 
         menu = CthulhuMenu(callsites, optimize; menu_options...)
-        cid = request(term, menu)
+        msg = usage(view_cmd, optimize, iswarn, hide_type_stable, debuginfo, inline_cost, CONFIG.enable_highlighter)
+        cid = request(term, msg, menu)
         toggle = menu.toggle
 
         if toggle === nothing
@@ -288,7 +305,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                     continue
                 end
                 menu = CthulhuMenu(sub_callsites, optimize; sub_menu=true, menu_options...)
-                cid = request(term, menu)
+                cid = request(term, "", menu)
                 if cid == length(sub_callsites) + 1
                     continue
                 end
@@ -376,13 +393,18 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
             display_CI = false
         else
             #Handle Standard alternative view, e.g. :native, :llvm
-            view_cmd = get(CODEVIEWS, toggle, nothing)
-            @assert !isnothing(view_cmd) "invalid option $toggle"
-            println(term.out_stream)
-            view_cmd(term.out_stream::IO, mi, optimize, debuginfo, params, CONFIG)
-            display_CI = false
+            if toggle === :typed
+                view_cmd = cthulhu_typed
+                display_CI = true
+            else
+                view_cmd = get(CODEVIEWS, toggle, nothing)
+                @assert !isnothing(view_cmd) "invalid option $toggle"
+                println(term.out_stream)
+                view_cmd(term.out_stream::IO, mi, optimize, debuginfo, params, CONFIG)
+                display_CI = false
+            end
         end
-        println(term.out_stream)
+        println(term.out_stream::IO)
     end
 end
 _descend(interp::CthulhuInterpreter, mi::MethodInstance; kwargs...) =
@@ -411,6 +433,12 @@ function mkinterp(@nospecialize(args...))
     do_typeinf!(interp, mi)
     (interp, mi)
 end
+
+# function mkinterp(mi::MethodInstance)
+#     interp = CthulhuInterpreter()
+#     do_typeinf!(interp, mi)
+#     interp
+# end
 
 function _descend(@nospecialize(args...); kwargs...)
     (interp, mi) = mkinterp(args...)

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -87,6 +87,14 @@ function cthulhu_warntype(io::IO, debuginfo::Union{DebugInfo,Symbol},
     return nothing
 end
 
+# # for API consistency with the others
+# function cthulhu_typed(io::IO, mi::MethodInstance, optimize, debuginfo, params, config::CthulhuConfig)
+#     interp = mkinterp(mi)
+#     codeinf, rt, infos, slottypes = lookup(interp, mi, optimize)
+#     ci = Cthulhu.preprocess_ci!(codeinf, mi, optimize, config)
+#     cthulhu_typed(io, debuginfo, codeinf, rt, mi)
+# end
+
 cthulhu_typed(io::IO, debuginfo::DebugInfo, args...; kwargs...) =
     cthulhu_typed(io, Symbol(debuginfo), args...; kwargs...)
 function cthulhu_typed(io::IO, debuginfo::Symbol,
@@ -107,7 +115,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
         if src.slotnames !== nothing
             slotnames = Base.sourceinfo_slotnames(src)
             lambda_io = IOContext(lambda_io, :SOURCE_SLOTNAMES => slotnames)
-            iswarn && show_variables(io, src, slotnames)
+            show_variables(io, src, slotnames)
         end
     end
 
@@ -164,6 +172,7 @@ end
 # These are standard code views that don't need any special handling,
 # This namedtuple maps toggle::Symbol to function
 const CODEVIEWS = (;
+    # typed=cthulhu_typed,
     llvm=cthulhu_llvm,
     native=cthulhu_native,
     ast=cthulhu_ast,

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -44,15 +44,41 @@ end
 TerminalMenus.options(m::CthulhuMenu) = m.options
 TerminalMenus.cancel(m::CthulhuMenu) = m.selected = -1
 
-function TerminalMenus.header(m::CthulhuMenu)
-    m.sub_menu && return ""
+function stringify(@nospecialize(f), io=IOBuffer())
+    f(IOContext(io, :color=>true))
+    return String(take!(io))
+end
+
+const debugcolors = (:nothing, :light_black, :yellow)
+function usage(view_cmd, optimize, iswarn, hide_type_stable, debuginfo, inline_cost, highlight)
+    colorize(use_color::Bool, c::Char) = stringify(iotmp) do io
+        use_color ? printstyled(io, c; color=:cyan) : print(io, c)
+    end
+
+    io, iotmp = IOBuffer(), IOBuffer()
+    ioctx = IOContext(io, :color=>true)
+
+    println(ioctx, "Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.")
+    println(ioctx, "Toggles: [",
+        colorize(optimize, 'o'), "]ptimize, [",
+        colorize(iswarn, 'w'), "]arn, [",
+        colorize(hide_type_stable, 'h'), "]ide type-stable statements, [",
+        stringify(iotmp) do io
+            printstyled(io, 'd'; color=debugcolors[Int(debuginfo)+1])
+        end, "]ebuginfo, [",
+        colorize(inline_cost, 'i'), "]nlining costs, [",
+        colorize(highlight, 's'), "]yntax highlight for Source/LLVM/Native.")
+    println(ioctx, "Show: [",
+        colorize(view_cmd === cthulhu_source, 'S'), "]ource code, [",
+        colorize(view_cmd === cthulhu_ast, 'A'), "]ST, [",
+        colorize(view_cmd === cthulhu_typed, 'T'), "]yped code, [",
+        colorize(view_cmd === cthulhu_llvm, 'L'), "]LVM IR, [",
+        colorize(view_cmd === cthulhu_native, 'N'), "]ative code")
+    print(ioctx,
     """
-    Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
-    Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [i]nlining costs, [s]yntax highlight for Source/LLVM/Native.
-    Show: [S]ource code, [A]ST, [L]LVM IR, [N]ative code
     Actions: [E]dit source code, [R]evise and redisplay
-    Advanced: dump [P]arams cache.
-    """
+    Advanced: dump [P]arams cache.""")
+    return String(take!(io))
 end
 
 function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
@@ -75,11 +101,14 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
     elseif key == UInt32('s')
         m.toggle = :highlighter
         return true
-   elseif key == UInt32('S')
+    elseif key == UInt32('S')
         m.toggle = :source
         return true
-   elseif key == UInt32('A')
+    elseif key == UInt32('A')
         m.toggle = :ast
+        return true
+    elseif key == UInt32('T')
+        m.toggle = :typed
         return true
     elseif key == UInt32('L')
         m.toggle = :llvm

--- a/test/terminal.jl
+++ b/test/terminal.jl
@@ -29,6 +29,9 @@ const keydict = Dict(:up => "\e[A",
     if isdefined(Base, :active_repl)
         @test Cthulhu.default_terminal() isa REPL.Terminals.TTYTerminal
     end
+    colorize(use_color::Bool, c::Char) = Cthulhu.stringify() do io
+        use_color ? printstyled(io, c; color=:cyan) : print(io, c)
+    end
     # Write a file that we track with Revise. Creating it programmatically allows us to rewrite it with
     # different content
     fn = tempname()
@@ -43,7 +46,12 @@ const keydict = Dict(:up => "\e[A",
     end
     includet(fn)
 
+    # Copy the user's current settings and set up the defaults
     CONFIG = deepcopy(Cthulhu.CONFIG)
+    config = Cthulhu.CthulhuConfig()
+    for fn in fieldnames(Cthulhu.CthulhuConfig)
+        setfield!(Cthulhu.CONFIG, fn, getfield(config, fn))
+    end
 
     try
         fake_terminal() do term, in, out
@@ -53,23 +61,27 @@ const keydict = Dict(:up => "\e[A",
             lines = cread(out)
             @test occursin("invoke simplef(::Float32,::Int32)::Float32", lines)
             @test occursin(r"Base\.mul_float\(.*, .*\)\u001B\[36m::Float32\u001B\[39m", lines)
-            @test_broken occursin("\nSelect a call to descend into", lines)   # beginning of the line
+            @test occursin('[' * colorize(true, 'o') * "]ptimize", lines)
+            @test occursin('[' * colorize(true, 'T') * "]yped", lines)
+
+            @test occursin("\nSelect a call to descend into", lines)   # beginning of the line
             @test occursin('•', lines)
             write(in, 'o')            # switch to unoptimized
             lines = cread(out)
             @test occursin("invoke simplef(::Float32,::Int32)::Float32", lines)
             @test occursin(r"\(z = a \* a\)\u001B\[\d\dm::Float32\u001B\[39m", lines)
-            @test_broken occursin("\nSelect a call to descend into", lines)   # beginning of the line
+            @test occursin('[' * colorize(false, 'o') * "]ptimize", lines)
+            @test occursin("\nSelect a call to descend into", lines)   # beginning of the line
             @test occursin("• %1  = *(::Float32,::Float32)::Float32", lines)
             # Call selection
             write(in, keydict[:down])
             write(in, keydict[:enter])
-            lines = cread(out)
+            lines = cread1(out)
             lines = cread(out)
             @test occursin("• %1  = promote(::Float32,::Int32)::Tuple{Float32, Float32}", lines)
             write(in, keydict[:up])
             write(in, keydict[:enter])
-            lines = cread(out)
+            lines = cread1(out)
             lines = cread(out)
             @test occursin("• %1  = *(::Float32,::Float32)::Float32", lines)  # back to where we started
             write(in, 'o')            # back to optimized
@@ -79,21 +91,21 @@ const keydict = Dict(:up => "\e[A",
             write(in, 'i')            # inline cost
             lines = cread(out)
             @test occursin(r"\u001B\[32m \d\u001B\[39m %\d += Base\.mul_float", lines)
+            @test occursin('[' * colorize(true, 'i') * "]nlining costs", lines)
             write(in, 'i')
             lines = cread(out)
             write(in, 'o')
             lines = cread(out)
-            @test !occursin("Variables", lines)
+            @test occursin("Variables", lines)
             write(in, 'w')            # unoptimized + warntype
             lines = cread(out)
             @test occursin("Variables", lines)
             @test occursin(r"z.*::Float32", lines)
             @test occursin(r"\nBody.*Float32", lines)
-            @test_broken occursin("\nSelect a call to descend into", lines)   # beginning of the line
+            @test occursin('[' * colorize(true, 'w') * "]arn", lines)
+            @test occursin("\nSelect a call to descend into", lines)   # beginning of the line
             @test occursin("• %1  = *(::Float32,::Float32)::Float32", lines)
-            # turn off syntax highlighting
-            write(in, "s"); cread(out)
-            write(in, "S")
+            write(in, 'S')
             lines = cread(out)
             @test occursin("""
             \n\nfunction simplef(a, b)
@@ -101,25 +113,42 @@ const keydict = Dict(:up => "\e[A",
                 return z + b
             end
             """, lines)
-            write(in, "A")
+            @test occursin('[' * colorize(true, 'S') * "]ource", lines)
+            # turn on syntax highlighting
+            write(in, 's'); cread(out)
+            write(in, 'S')
+            lines = cread(out)
+            @test occursin("simplef", lines)
+            @test occursin("\u001B", first(split(lines, '\n')))
+            @test occursin('[' * colorize(true, 's') * "]yntax", lines)
+            write(in, 's'); cread(out)  # off again
+            write(in, 'A')
             lines = cread(out)
             @test occursin("Symbol simplef", lines)
             @test occursin("Symbol call", lines)
-            write(in, "L")
+            @test occursin('[' * colorize(true, 'A') * "]ST", lines)
+            write(in, 'L')
             lines = cread(out)
             @test occursin(r"sitofp i(64|32)", lines)
             @test occursin("fadd float", lines)
             @test occursin("┌ @ promotion.jl", lines)  # debug info on by default
+            @test occursin('[' * colorize(true, 'L') * "]LVM", lines)
             # turn off debug info
-            write(in, "d"); cread(out)
-            write(in, "d"); cread(out)
-            write(in, "L")
+            write(in, 'd'); cread(out)
+            write(in, 'd'); cread(out)
+            write(in, 'L')
             lines = cread(out)
+            @test occursin('[' * colorize(false, 'd') * "]ebuginfo", lines)
             @test !occursin("┌ @ promotion.jl", lines)
-            write(in, "N")
+            write(in, 'N')
             lines = cread(out)
             @test occursin(".text", lines) || occursin("__text", lines)
             @test occursin("retq", lines)
+            @test occursin('[' * colorize(true, 'N') * "]ative", lines)
+            write(in, 'T')
+            lines = cread(out)
+            @test occursin(r"\(z \+ b\)\u001B\[\d\dm::Float32\u001B\[39m", lines)
+            @test occursin('[' * colorize(true, 'T') * "]yped", lines)
             # Revise
             open(fn, "w") do io
                 println(io,
@@ -131,13 +160,12 @@ const keydict = Dict(:up => "\e[A",
                 """)
             end
             sleep(0.1)
-            write(in, "R")
+            write(in, 'R')
             lines = cread(out)
-            write(in, "o"); cread(out)     # optimized code
-            write(in, "o")     # unoptimized code
+            write(in, 'T')
             lines = cread(out)
             @test occursin("z = a * b", lines)
-            write(in, "q")
+            write(in, 'q')
         end
         # Multicall & iswarn=true
         fake_terminal() do term, in, out
@@ -152,7 +180,7 @@ const keydict = Dict(:up => "\e[A",
             @test occursin("%2  = fmulti(::Int32)::Union{Float32, $Int}", lines)
             @test occursin("%2  = fmulti(::Float32)::Union{Float32, $Int}", lines)
             @test occursin("%2  = fmulti(::Char)::Union{Float32, $Int}", lines)
-            write(in, "q")
+            write(in, 'q')
         end
         # Tasks (see the special handling in `_descend`)
         ftask() = @sync @async show(io, "Hello")
@@ -165,7 +193,7 @@ const keydict = Dict(:up => "\e[A",
             write(in, keydict[:enter])
             lines = cread(out)
             @test occursin("call show(::IO,::String)", lines)
-            write(in, "q")
+            write(in, 'q')
         end
         # ascend
         @noinline inner3(x) = 3x
@@ -188,8 +216,8 @@ const keydict = Dict(:up => "\e[A",
                  occursin(r"caller.*inner3", lines[8]) ? 8 : error("not found")
             @test occursin("inner2", lines[ln+1])
             @test any(str -> occursin("Variables", str), lines[ln+2:end])
-            write(in, "q")
-            write(in, "q")
+            write(in, 'q')
+            write(in, 'q')
         end
     finally
         # Restore the previous settings

--- a/test/terminal.jl
+++ b/test/terminal.jl
@@ -105,6 +105,7 @@ const keydict = Dict(:up => "\e[A",
             @test occursin('[' * colorize(true, 'w') * "]arn", lines)
             @test occursin("\nSelect a call to descend into", lines)   # beginning of the line
             @test occursin("• %1  = *(::Float32,::Float32)::Float32", lines)
+            # Source view
             write(in, 'S')
             lines = cread(out)
             @test occursin("""
@@ -122,11 +123,18 @@ const keydict = Dict(:up => "\e[A",
             @test occursin("\u001B", first(split(lines, '\n')))
             @test occursin('[' * colorize(true, 's') * "]yntax", lines)
             write(in, 's'); cread(out)  # off again
+            # Toggling 'o' goes back to typed code, make sure it also updates the selector status
+            write(in, 'o')
+            lines = cread(out)
+            @test occursin('[' * colorize(true, 'T') * "]yped", lines)
+            write(in, 'o'); cread(out)   # toggle it back for later tests
+            # AST view
             write(in, 'A')
             lines = cread(out)
             @test occursin("Symbol simplef", lines)
             @test occursin("Symbol call", lines)
             @test occursin('[' * colorize(true, 'A') * "]ST", lines)
+            # LLVM view
             write(in, 'L')
             lines = cread(out)
             @test occursin(r"sitofp i(64|32)", lines)
@@ -140,11 +148,13 @@ const keydict = Dict(:up => "\e[A",
             lines = cread(out)
             @test occursin('[' * colorize(false, 'd') * "]ebuginfo", lines)
             @test !occursin("┌ @ promotion.jl", lines)
+            # Native-code view
             write(in, 'N')
             lines = cread(out)
             @test occursin(".text", lines) || occursin("__text", lines)
             @test occursin("retq", lines)
             @test occursin('[' * colorize(true, 'N') * "]ative", lines)
+            # Typed-view (by selector)
             write(in, 'T')
             lines = cread(out)
             @test occursin(r"\(z \+ b\)\u001B\[\d\dm::Float32\u001B\[39m", lines)


### PR DESCRIPTION
This adds several elements of UI polish first identified in #189:
- eliminates spurious indentation
- adds a [T]yped code-selector
- encodes state by the color of toggles & selectors
- prints Variables for unoptimized typed code regardless of iswarn

It also prints the method being inspected in bold at the top of the code.

The best way to review is probably just to try it :smile:.
