### PR TITLE
fix alignment of inlining cost with verbose dinfo

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -132,6 +132,10 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
         function preprinter(io, linestart, idx)
             str = idx > 0 ? lpad(cst[idx], nd+1) : " "^(nd+1)
             str = sprint(io -> Base.printstyled(io, str; color=:green); context=:color=>true)
+            if debuginfo === :source
+                str *= " "
+                linestart *= " "^(nd+2)
+            end
             return str * _lineprinter(io, linestart, idx)
         end
     else


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/5220528/128177915-f843b7ae-ea0d-4c70-ad68-cc0b33a5d517.png)

After:
![image](https://user-images.githubusercontent.com/5220528/128178006-ce5a1081-09f3-4b1f-9df3-6da9d38c2ca2.png)
