### PR TITLE
fix #196

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -267,7 +267,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
             else
                 (codeinf, rt, infos, slottypes) = lookup(interp, mi, optimize)
             end
-            ci = preprocess_ci!(codeinf, mi, optimize, CONFIG)
+            codeinf = preprocess_ci!(codeinf, mi, optimize, CONFIG)
             callsites = find_callsites(interp, codeinf, infos, mi, slottypes, optimize; params)
 
             if display_CI


### PR DESCRIPTION
Fixes #196 by making sure Cthulhu doesn't call `argextype` on
expressions other than `:call` and `:invoke`, which can result
in error. Other expressions like `:foreigncall` should be handled
by special casing.