### PR TITLE
Improve inferrability

### DIFF
--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -164,25 +164,25 @@ end
 function headstring(@nospecialize(T))
     T = widenconst(Base.unwrapva(T))
     if T isa Union || T === Union{}
-        return string(T)
+        return string(T)::String
     elseif T isa UnionAll
         return headstring(Base.unwrap_unionall(T))
     else
-        return string(T.name.name)
+        return string(T.name.name)::String
     end
 end
 
 
-function __show_limited(limiter, name, tt, rt)
-    vastring(@nospecialize(T)) = Base.isvarargtype(T) ? headstring(T)*"..." : string(T)
+function __show_limited(limiter, name, tt, @nospecialize(rt))
+    vastring(@nospecialize(T)) = (Base.isvarargtype(T) ? headstring(T)*"..." : string(T)::String)
 
     if !has_space(limiter, name)
         print(limiter, '…')
         return
     end
     print(limiter, string(name))
-    pstrings = map(vastring, tt)
-    headstrings = map(headstring, tt)
+    pstrings = String[vastring(T) for T in tt]
+    headstrings = String[headstring(T) for T in tt]
     print(limiter, "(")
     if length(pstrings) != 0
         # See if we have space to print all the parameters fully
@@ -201,7 +201,7 @@ function __show_limited(limiter, name, tt, rt)
     print(limiter, ")")
 
     # If we have space for the return type, print it
-    rts = string(rt)
+    rts = string(rt)::String
     if has_space(limiter, textwidth(rts)+2)
         print(limiter, string("::", rts))
     elseif has_space(limiter, 3)
@@ -213,7 +213,7 @@ end
 function show_callinfo(limiter, mici::MICallInfo)
     mi = mici.mi
     tt = (Base.unwrap_unionall(mi.specTypes)::DataType).parameters[2:end]
-    name = mi.def.name
+    name = (mi.def::Method).name
     rt = mici.rt
     __show_limited(limiter, name, tt, rt)
 end

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -37,7 +37,7 @@ function cthulhu_native(io::IO, mi, optimize, debuginfo, params, config::Cthulhu
 end
 
 function cthulhu_ast(io::IO, mi, optimize, debuginfo, params, config::CthulhuConfig)
-    meth = mi.def
+    meth = mi.def::Method
     ast = definition(Expr, meth)
     if ast!==nothing
         if !config.pretty_ast
@@ -53,7 +53,7 @@ function cthulhu_ast(io::IO, mi, optimize, debuginfo, params, config::CthulhuCon
 end
 
 function cthulhu_source(io::IO, mi, optimize, debuginfo, params, config::CthulhuConfig)
-    meth = mi.def
+    meth = mi.def::Method
     def = definition(String, meth)
     if isnothing(def)
         return @warn "couldn't retrieve source of $meth"
@@ -239,7 +239,7 @@ function InteractiveUtils.code_typed(b::Bookmark; optimize = true)
     if ci isa IRCode
         ir = ci
         ci = copy(interp.unopt[mi].src)
-        nargs = Int(mi.def.nargs) - 1
+        nargs = Int((mi.def::Method).nargs) - 1
         Core.Compiler.replace_code_newstyle!(ci, ir, nargs)
     end
     return ci => rt

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -26,7 +26,7 @@ CthulhuInterpreter() = CthulhuInterpreter(
     NativeInterpreter(),
     Dict{MethodInstance, InferredSource}(),
     Dict{MethodInstance, CodeInstance}(),
-    Dict{MethodInstance, Vector{Tuple{Int, String}}}()
+    Dict{MethodInstance, Vector{Pair{Int, String}}}()
 )
 
 import Core.Compiler: InferenceParams, OptimizationParams, get_world_counter,

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -44,14 +44,14 @@ end
 TerminalMenus.options(m::CthulhuMenu) = m.options
 TerminalMenus.cancel(m::CthulhuMenu) = m.selected = -1
 
-function stringify(@nospecialize(f), io=IOBuffer())
+function stringify(@nospecialize(f), io::IO=IOBuffer())
     f(IOContext(io, :color=>true))
     return String(take!(io))
 end
 
 const debugcolors = (:nothing, :light_black, :yellow)
-function usage(view_cmd, optimize, iswarn, hide_type_stable, debuginfo, inline_cost, highlight)
-    colorize(use_color::Bool, c::Char) = stringify(iotmp) do io
+function usage(@nospecialize(view_cmd), optimize, iswarn, hide_type_stable, debuginfo, inline_cost, highlight)
+    colorize(iotmp, use_color::Bool, c::Char) = stringify(iotmp) do io
         use_color ? printstyled(io, c; color=:cyan) : print(io, c)
     end
 
@@ -60,20 +60,20 @@ function usage(view_cmd, optimize, iswarn, hide_type_stable, debuginfo, inline_c
 
     println(ioctx, "Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.")
     println(ioctx, "Toggles: [",
-        colorize(optimize, 'o'), "]ptimize, [",
-        colorize(iswarn, 'w'), "]arn, [",
-        colorize(hide_type_stable, 'h'), "]ide type-stable statements, [",
+        colorize(iotmp, optimize, 'o'), "]ptimize, [",
+        colorize(iotmp, iswarn, 'w'), "]arn, [",
+        colorize(iotmp, hide_type_stable, 'h'), "]ide type-stable statements, [",
         stringify(iotmp) do io
             printstyled(io, 'd'; color=debugcolors[Int(debuginfo)+1])
         end, "]ebuginfo, [",
-        colorize(inline_cost, 'i'), "]nlining costs, [",
-        colorize(highlight, 's'), "]yntax highlight for Source/LLVM/Native.")
+        colorize(iotmp, inline_cost, 'i'), "]nlining costs, [",
+        colorize(iotmp, highlight, 's'), "]yntax highlight for Source/LLVM/Native.")
     println(ioctx, "Show: [",
-        colorize(view_cmd === cthulhu_source, 'S'), "]ource code, [",
-        colorize(view_cmd === cthulhu_ast, 'A'), "]ST, [",
-        colorize(view_cmd === cthulhu_typed, 'T'), "]yped code, [",
-        colorize(view_cmd === cthulhu_llvm, 'L'), "]LVM IR, [",
-        colorize(view_cmd === cthulhu_native, 'N'), "]ative code")
+        colorize(iotmp, view_cmd === cthulhu_source, 'S'), "]ource code, [",
+        colorize(iotmp, view_cmd === cthulhu_ast, 'A'), "]ST, [",
+        colorize(iotmp, view_cmd === cthulhu_typed, 'T'), "]yped code, [",
+        colorize(iotmp, view_cmd === cthulhu_llvm, 'L'), "]LVM IR, [",
+        colorize(iotmp, view_cmd === cthulhu_native, 'N'), "]ative code")
     print(ioctx,
     """
     Actions: [E]dit source code, [R]evise and redisplay


### PR DESCRIPTION
SnoopCompile detected many new inference problems, most notably a
large number of `Core.Box` slots. Fixing this is the reason for some
substantial code-moves. (Inner functions sometimes seem surprisingly
difficult to fix, so I frequently just move them out and pass arguments.)