### PR TITLE
Reduce latency

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -1,5 +1,7 @@
 module Cthulhu
 
+Base.Experimental.@compiler_options compile=min optimize=1
+
 using CodeTracking: definition, whereis
 using InteractiveUtils
 using UUIDs
@@ -524,5 +526,14 @@ Follow a chain of calls (either through a backtrace `bt` or the backedges of a `
 with the option to `descend` into intermediate calls. `kwargs` are passed to [`descend`](@ref).
 """
 ascend
+
+if ccall(:jl_generating_output, Cint, ()) == 1
+    input = Pipe()
+    Base.link_pipe!(input, reader_supports_async=true, writer_supports_async=true)
+    term = REPL.Terminals.TTYTerminal("dumb", input.out, IOBuffer(), IOBuffer())
+    write(input.in, 'q')
+    descend(gcd, (Int, Int); terminal=term)
+    nothing
+end
 
 end


### PR DESCRIPTION
```
julia> using Cthulhu

julia> tstart = time(); descend(gcd, (Int, Int)); time() - tstart
```
and hit 'q' while you are waiting.

Here's the timing:
- master: 6.57s
- this branch with just precompilation: 5.86s
- this branch with compile=min optimize=1: 4.68s

I haven't run this extensively, so I can't promise that there isn't a hit to runtime performance, but it looks from my analysis in #209 that this module is not performance-sensitive. It's a bit at odds with a couple of annotations we have https://github.com/JuliaDebug/Cthulhu.jl/blob/60d8b5476ad79d6796ce5295c10c312d9e32d0bb/src/Cthulhu.jl#L179
so some discussion may be merited.