### PR TITLE
use consistent with InteractiveUtils syntax highlighting for llvm and native code

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -26,10 +26,9 @@ end
 
 # Options
 - `enable_highlighter::Bool`: Use command line `highlighter` to syntax highlight
-  LLVM and native code.  Set to `true` if `highlighter` exists at the import
-  time.
-- `highlighter::Cmd`: A command line program that receives "llvm" or "asm" as
-  an argument and the code as stdin.  Defaults to `$(CthulhuConfig().highlighter)`.
+  Julia, LLVM and native code.
+- `highlighter::Cmd`: A command line program that receives "julia" as an argument and julia
+   code as stdin. Defaults to `$(CthulhuConfig().highlighter)`.
 - `asm_syntax::Symbol`: Set the syntax of assembly code being used.
   Defaults to `$(CthulhuConfig().asm_syntax)`.
 - `dead_code_elimination::Bool`: Enable dead-code elimination for high-level Julia IR.
@@ -381,7 +380,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
             if CONFIG.enable_highlighter
                 @info "Using syntax highlighter $(CONFIG.highlighter)"
             else
-                @info "Turned off syntax highlighter for LLVM and native code."
+                @info "Turned off syntax highlighter for Julia, LLVM and native code."
             end
             display_CI = false
         elseif toggle === :dump_params

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -618,7 +618,7 @@ let config = Cthulhu.CthulhuConfig(
     highlighter = `I_am_hoping_this_command_does_not_exist`,
     enable_highlighter = true,
 )
-    for lexer in ["llvm", "asm"]
+    for lexer in ["julia"]
         @test begin
             @test_logs (:warn, r"Highlighter command .* does not exist.") begin
                 sprint() do io


### PR DESCRIPTION
I think the syntax highlighting that InteractiveUtils have is significantly nicer than the one provided by pygmentize. It is also nice to be consistent. And it avoids having to have the `pygmentize` library installed.
There is no julia syntax highlighter available from Base, if we want to use a pure Julia solution, there is https://github.com/JuliaDocs/Highlights.jl

Before:

![Screenshot from 2021-08-10 15-14-54](https://user-images.githubusercontent.com/1282691/128873455-36f82066-0a11-41e6-94fb-b0f7df035799.png)

![Screenshot from 2021-08-10 15-15-16](https://user-images.githubusercontent.com/1282691/128873461-ecc4c0da-cc64-4d6c-8f93-614c6f9a2edd.png)

After:


![Screenshot from 2021-08-10 15-11-29](https://user-images.githubusercontent.com/1282691/128873550-5496c979-2830-4c25-b740-db491b8881e4.png)

![Screenshot from 2021-08-10 15-16-43](https://user-images.githubusercontent.com/1282691/128873672-8529e471-908d-45f1-99d4-28ca7b39d65d.png)