### PR TITLE
make sure to widen `LimitedAccuracy` when calling `widenconst` on unoptimized source

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -47,7 +47,10 @@ function find_callsites(interp::CthulhuInterpreter, CI::Union{Core.CodeInfo, IRC
                 if !optimize
                     args = (ignorelhs(c)::Expr).args
                 end
-                types = mapany(@nospecialize(arg) -> widenconst(argextype(arg, CI, sptypes, slottypes)), args)
+                types = mapany(function (@nospecialize(arg),)
+                                   t = argextype(arg, CI, sptypes, slottypes)
+                                   return widenconst(ignorelimited(t))
+                               end, args)
                 was_return_type = false
                 if isa(info, Core.Compiler.ReturnTypeCallInfo)
                     info = info.info


### PR DESCRIPTION
When inspecting recursive calls in https://github.com/CliMA/ClimaCore.jl/pull/195, I found this `widenconst` can throw .
We will redesign `LimitedAccuracy` in the near future, but I think it would be better to have this for now.