### PR TITLE
fix printing of `PureCallInfo`

### DIFF
--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -252,7 +252,7 @@ end
 function show_callinfo(limiter, (; argtypes, rt)::PureCallInfo)
     ft, tt... = argtypes
     f = Compiler.singleton_type(ft)
-    name = isnothing(f) ? "unknown" : nameof(f)
+    name = isnothing(f) ? "unknown" : string(f)
     __show_limited(limiter, name, tt, rt)
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -224,6 +224,16 @@ end
     end
 end
 
+struct SingletonPureCallable{N} end
+
+@testset "PureCallInfo" begin
+    s = sprint(Cthulhu.show_callinfo, Cthulhu.PureCallInfo(Any[typeof(sin), Float64], Float64))
+    @test s == "sin(::Float64)::Float64"
+
+    s = sprint(Cthulhu.show_callinfo, Cthulhu.PureCallInfo(Any[SingletonPureCallable{1}, Float64], Float64))
+    @test s == "SingletonPureCallable{1}()(::Float64)::Float64"
+end
+
 # Failed return_type
 only_ints(::Integer) = 1
 return_type_failure(::T) where T = Base._return_type(only_ints, Tuple{T})


### PR DESCRIPTION
This errored before if the called object did not define `nameof`.
