### PR TITLE
A more colourful menu

### DIFF
--- a/src/ui.jl
+++ b/src/ui.jl
@@ -102,11 +102,17 @@ function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_
         active_option ? printstyled(io, c; bold=true, color=:green) : printstyled(io, c; color=:red)
     end
 
+    colorize(s::AbstractString; color::Symbol = :cyan) = stringify() do io
+        printstyled(io, s; color)
+    end
+
     io = IOBuffer()
     ioctx = IOContext(io, :color=>true)
 
-    println(ioctx, "Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.")
-    print(ioctx, "Toggles: [",
+    println(ioctx,
+        colorize("Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark."; color=:blue))
+    print(ioctx,
+        colorize("Toggles"), ": [",
         colorize(iswarn, 'w'), "]arn, [",
         colorize(hide_type_stable, 'h'), "]ide type-stable statements, [",
         colorize(type_annotations, 't'), "]ype annotations, [",
@@ -138,19 +144,21 @@ function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_
     end
     print(ioctx, '.')
     println(ioctx)
-    println(ioctx, "Show: [",
+    println(ioctx,
+        colorize("Show"), ": [",
         colorize(annotate_source, 'S'), "]ource code, [",
         colorize(view_cmd === cthulhu_ast, 'A'), "]ST, [",
         colorize(!annotate_source && view_cmd === cthulhu_typed, 'T'), "]yped code, [",
         colorize(view_cmd === cthulhu_llvm, 'L'), "]LVM IR, [",
         colorize(view_cmd === cthulhu_native, 'N'), "]ative code")
     print(ioctx,
-    """
-    Actions: [E]dit source code, [R]evise and redisplay""")
+        colorize("Actions"),
+        ": [E]dit source code, [R]evise and redisplay")
     if !annotate_source
         print(ioctx,
-        """
-        \nAdvanced: dump [P]arams cache.""")
+        "\n",
+        colorize("Advanced"),
+        ": dump [P]arams cache.")
     end
     return String(take!(io))
 end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -98,8 +98,8 @@ function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_
                debuginfo, remarks, with_effects, exception_type, inline_cost,
                type_annotations, highlight, inlay_types_vscode, diagnostics_vscode,
                jump_always, custom_toggles::Vector{CustomToggle})
-    colorize(use_color::Bool, c::Char) = stringify() do io
-        use_color ? printstyled(io, c; color=:cyan) : print(io, c)
+    colorize(active_option::Bool, c::Char) = stringify() do io
+        active_option ? printstyled(io, c; bold=true, color=:green) : printstyled(io, c; color=:red)
     end
 
     io = IOBuffer()

--- a/test/test_terminal.jl
+++ b/test/test_terminal.jl
@@ -54,8 +54,12 @@ end
 
 @testset "Terminal" begin
     @test _Cthulhu.default_terminal() isa REPL.Terminals.TTYTerminal
-    colorize(use_color::Bool, c::Char) = _Cthulhu.stringify() do io
-        use_color ? printstyled(io, c; color=:cyan) : print(io, c)
+    colorize(active_option::Bool, c::Char) = _Cthulhu.stringify() do io
+        active_option ? printstyled(io, c; bold=true, color=:green) : printstyled(io, c; color=:red)
+    end
+
+    colorize(s::AbstractString; color::Symbol = :cyan) = _Cthulhu.stringify() do io
+        printstyled(io, s; color)
     end
     # Write a file that we track with Revise. Creating it programmatically allows us to rewrite it with
     # different content
@@ -87,7 +91,7 @@ end
         @test occursin(r"Base\.mul_float\(.*, .*\)::Float32", text)
         @test occursin('[' * colorize(true, 'o') * "]ptimize", displayed)
         @test occursin('[' * colorize(true, 'T') * "]yped", displayed)
-        @test occursin("\nSelect a call to descend into", text) # beginning of the line
+        @test occursin('\n' * colorize("Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark."; color = :blue), displayed) # beginning of the line
         @test occursin('•', text)
         write(terminal, 'o') # switch to unoptimized
         displayed, text = read_from(terminal)
@@ -95,7 +99,7 @@ end
         @test occursin("::Const(*)", text)
         @test occursin("(z = (%1)(a, a))", text)
         @test occursin('[' * colorize(false, 'o') * "]ptimize", displayed)
-        @test occursin("\nSelect a call to descend into", text) # beginning of the line
+        @test occursin('\n' * colorize("Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark."; color = :blue), displayed) # beginning of the line
         @test occursin("• %2 = *(::Float32,::Float32)::Float32", text)
 
         # Call selection
@@ -128,7 +132,7 @@ end
         @test occursin(r"z.*::Float32", text)
         @test occursin("Body", text)
         @test occursin('[' * colorize(true, 'w') * "]arn", displayed)
-        @test occursin("\nSelect a call to descend into", text)
+        @test occursin('\n' * colorize("Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark."; color = :blue), displayed)
         @test occursin("• %2 = *(::Float32,::Float32)::Float32", text)
 
         # Source view
@@ -169,7 +173,7 @@ end
         write(terminal, 'd'); cread(terminal)
         write(terminal, 'L')
         displayed, text = read_from(terminal)
-        @test occursin('[' * colorize(false, 'd') * "]ebuginfo", displayed)
+        @test occursin("[d]ebuginfo", displayed)
         @test !occursin("┌ @ promotion.jl", text)
 
         # Native code view


### PR DESCRIPTION
This PR adds colours to the menu options and also makes the colours for options that can be toggled (except for `debuginfo`) more expressive.

Before:

![before](https://user-images.githubusercontent.com/47104651/136267384-bb5b28cc-c117-43db-90b4-c6af09dadafe.png)

After:

![after](https://user-images.githubusercontent.com/47104651/136267115-bae22b33-1666-4bc7-8641-bd494c6d1960.png)
