### PR TITLE
update to incoming changes in `Core.Compiler`

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -10,7 +10,7 @@ using REPL: REPL, AbstractTerminal
 using Core: MethodInstance
 const Compiler = Core.Compiler
 using Core.Compiler: MethodMatch, LimitedAccuracy, ignorelimited
-
+import Base: unwrapva, isvarargtype
 const mapany = Base.mapany
 
 # branch on https://github.com/JuliaLang/julia/pull/42125

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -176,21 +176,23 @@ function Base.take!(io::TextWidthLimiter)
 end
 
 function headstring(@nospecialize(T))
-    T = widenconst(Base.unwrapva(T))
+    if isvarargtype(T)
+        T = unwrapva(T)
+    elseif isa(T, TypeVar)
+        return string(T.name)
+    end
+    T = widenconst(T)
     if T isa Union || T === Union{}
         return string(T)::String
     elseif T isa UnionAll
         return headstring(Base.unwrap_unionall(T))
-    elseif T isa TypeVar
-        return string(T.name)
     else
         return string(T.name.name)::String
     end
 end
 
-
 function __show_limited(limiter, name, tt, @nospecialize(rt))
-    vastring(@nospecialize(T)) = (Base.isvarargtype(T) ? headstring(T)*"..." : string(T)::String)
+    vastring(@nospecialize(T)) = (isvarargtype(T) ? headstring(T)*"..." : string(T)::String)
 
     if !has_space(limiter, name)
         print(limiter, '…')

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -3,7 +3,7 @@
 ##
 
 using Base.Meta
-using .Compiler: widenconst, argextype, Const, MethodMatchInfo,
+import .Compiler: widenconst, argextype, Const, MethodMatchInfo,
     UnionSplitApplyCallInfo, UnionSplitInfo, ConstCallInfo,
     MethodResultPure, ApplyCallInfo
 


### PR DESCRIPTION
After <https://github.com/JuliaLang/julia/pull/42583> is merged,
`widenconst` doesn't accept non-valid Julia types (i.e. `TypeVar`/`Vararg`),
and we will handle them explicitly.