### PR TITLE
improve `return_type` handling

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -9,7 +9,7 @@ using REPL: REPL, AbstractTerminal
 
 using Core: MethodInstance
 const Compiler = Core.Compiler
-using Core.Compiler: MethodMatch, LimitedAccuracy, ignorelimited
+import Core.Compiler: MethodMatch, LimitedAccuracy, ignorelimited, specialize_method
 import Base: unwrapva, isvarargtype
 const mapany = Base.mapany
 
@@ -462,7 +462,7 @@ end
 
 function get_specialization(@nospecialize(TT))
     match = Base._which(TT)
-    mi = Core.Compiler.specialize_method(match)
+    mi = specialize_method(match)
     return mi
 end
 

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -76,7 +76,7 @@ function Compiler.finish(state::InferenceState, interp::CthulhuInterpreter)
 end
 
 function Compiler.transform_result_for_cache(interp::CthulhuInterpreter, linfo::MethodInstance,
-        valid_worlds::Core.Compiler.WorldRange, @nospecialize(inferred_result))
+        valid_worlds::WorldRange, @nospecialize(inferred_result))
     if isa(inferred_result, OptimizationState)
         opt = inferred_result
         if isdefined(opt, :ir)


### PR DESCRIPTION
- improve `ReturnTypeCallInfo` printing (see the example below)
- don't error when trying to descend into a failed `return_type` site

> before
```julia
julia> only_ints(::Integer) = 1;

julia> descend(; optimize=false) do
           t1 = Base._return_type(only_ints, Tuple{Int})     # successful `return_type`
           t2 = Base._return_type(only_ints, Tuple{Float64}) # failed `return_type`
           t1, t2
       end
(::var"#3#4")() in Main at REPL[3]:2
Variables
  #self#::Core.Const(var"#3#4"())
  t2::Type{Union{}}
  t1::Type{Int64}

│ ─ %-1  = invoke #3()::Core.Const((Int64, Union{}))
    @ REPL[3]:2 within `#3`
1 ─ %1 = Base._return_type::Core.Const(Core.Compiler.return_type)
│   %2 = Core.apply_type(Main.Tuple, Main.Int)::Core.Const(Tuple{Int64})
│        (t1 = (%1)(Main.only_ints, %2))::Core.Const(Int64)
│   @ REPL[3]:3 within `#3`
│   %4 = Base._return_type::Core.Const(Core.Compiler.return_type)
│   %5 = Core.apply_type(Main.Tuple, Main.Float64)::Core.Const(Tuple{Float64})
│        (t2 = (%4)(Main.only_ints, %5))::Core.Const(Union{})
│   @ REPL[3]:4 within `#3`
│   %7 = Core.tuple(t1::Core.Const(Int64), t2::Core.Const(Union{}))::Core.Const((Int64, Union{}))
└──      return %7
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %3  = return_type < only_ints(::Int64)::Core.Const(Int64) >
   %6  = return_type < → return_type(::typeof(only_ints),::Type{Tuple{Float64}})::Core.Const(Union{}) >
   ↩
```

> this commit
```julia
julia> only_ints(::Integer) = 1;

julia> descend(; optimize=false) do
           t1 = Base._return_type(only_ints, Tuple{Int})     # successful `return_type`
           t2 = Base._return_type(only_ints, Tuple{Float64}) # failed `return_type`
           t1, t2
       end
(::var"#3#4")() in Main at REPL[3]:2
Variables
  #self#::Core.Const(var"#3#4"())
  t2::Type{Union{}}
  t1::Type{Int64}

│ ─ %-1  = invoke #3()::Core.Const((Int64, Union{}))
    @ REPL[3]:2 within `#3`
1 ─ %1 = Base._return_type::Core.Const(Core.Compiler.return_type)
│   %2 = Core.apply_type(Main.Tuple, Main.Int)::Core.Const(Tuple{Int64})
│        (t1 = (%1)(Main.only_ints, %2))::Core.Const(Int64)
│   @ REPL[3]:3 within `#3`
│   %4 = Base._return_type::Core.Const(Core.Compiler.return_type)
│   %5 = Core.apply_type(Main.Tuple, Main.Float64)::Core.Const(Tuple{Float64})
│        (t2 = (%4)(Main.only_ints, %5))::Core.Const(Union{})
│   @ REPL[3]:4 within `#3`
│   %7 = Core.tuple(t1::Core.Const(Int64), t2::Core.Const(Union{}))::Core.Const((Int64, Union{}))
└──      return %7
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %3  = return_type < only_ints(::Int64)::Int64 >
   %6  = return_type < only_ints(::Float64)::Union{} >
   ↩
```