### PR TITLE
Add a native interpreter kwarg, forward method_table queries

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -347,6 +347,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
 
             # forcibly enter and inspect the frame, although the native interpreter gave up
             if info isa UncachedCallInfo || info isa TaskCallInfo
+                # XXX: this may use a different native interpreter
                 next_interp = CthulhuInterpreter()
                 next_mi = get_mi(info)::MethodInstance
                 do_typeinf!(next_interp, next_mi)
@@ -470,25 +471,21 @@ function get_specialization(@nospecialize(F), @nospecialize(TT))
     return get_specialization(Base.signature_type(F, TT))
 end
 
-function mkinterp(@nospecialize(args...))
-    interp = CthulhuInterpreter()
+function mkinterp(native_interpreter::AbstractInterpreter, @nospecialize(args...))
+    interp = CthulhuInterpreter(native_interpreter)
     mi = get_specialization(args...)
     do_typeinf!(interp, mi)
     (interp, mi)
 end
 
-# function mkinterp(mi::MethodInstance)
-#     interp = CthulhuInterpreter()
-#     do_typeinf!(interp, mi)
-#     interp
-# end
-
-function _descend(@nospecialize(args...); kwargs...)
-    (interp, mi) = mkinterp(args...)
+function _descend(@nospecialize(args...);
+                  native_interpreter::AbstractInterpreter=NativeInterpreter(), kwargs...)
+    (interp, mi) = mkinterp(native_interpreter, args...)
     _descend(interp, mi; kwargs...)
 end
-function _descend(term::AbstractTerminal, @nospecialize(args...); kwargs...)
-    (interp, mi) = mkinterp(args...)
+function _descend(term::AbstractTerminal, @nospecialize(args...);
+                  native_interpreter=NativeInterpreter(), kwargs...)
+    (interp, mi) = mkinterp(native_interpreter, args...)
     _descend(term, interp, mi; kwargs...)
 end
 
@@ -500,7 +497,7 @@ descend_code_warntype(b::Bookmark; kw...) =
 
 FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.writeoption(buf, data.callstr, charsused)
 
-function ascend(term, mi; kwargs...)
+function ascend(term, mi; native_interpreter::AbstractInterpreter=NativeInterpreter(), kwargs...)
     root = treelist(mi)
     menu = TreeMenu(root)
     choice = menu.current
@@ -514,7 +511,7 @@ function ascend(term, mi; kwargs...)
             if !isroot(node)
                 # Help user find the sites calling the parent
                 miparent = instance(node.parent.data.nd)
-                ulocs = find_caller_of(miparent, mi)
+                ulocs = find_caller_of(native_interpreter, miparent, mi)
                 if !isempty(ulocs)
                     strlocs = [string(" "^k[3] * '"', k[2], "\", ", k[1], ": lines ", v) for (k, v) in ulocs]
                     push!(strlocs, "Browse typed code")
@@ -535,7 +532,7 @@ function ascend(term, mi; kwargs...)
             end
             # The main application of `ascend` is finding cases of non-inferrability, so the
             # warn highlighting is useful.
-            interp = CthulhuInterpreter()
+            interp = CthulhuInterpreter(native_interpreter)
             do_typeinf!(interp, mi)
             browsecodetyped && _descend(term, interp, mi; iswarn=true, optimize=false, interruptexc=false, kwargs...)
         end

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -16,7 +16,7 @@ end
 const Remarks = Vector{Pair{Int, String}}
 
 mutable struct CthulhuInterpreter <: AbstractInterpreter
-    native::NativeInterpreter
+    native::AbstractInterpreter
 
     unopt::Dict{Union{MethodInstance, InferenceResult}, InferredSource}
     opt::Dict{MethodInstance, CodeInstance}
@@ -24,12 +24,13 @@ mutable struct CthulhuInterpreter <: AbstractInterpreter
     remarks::Dict{MethodInstance, Remarks}
 end
 
-CthulhuInterpreter() = CthulhuInterpreter(
-    NativeInterpreter(),
-    Dict{MethodInstance, InferredSource}(),
-    Dict{MethodInstance, CodeInstance}(),
-    Dict{MethodInstance, Remarks}()
-)
+CthulhuInterpreter(native_interp::AbstractInterpreter=NativeInterpreter()) =
+    CthulhuInterpreter(
+        native_interp,
+        Dict{MethodInstance, InferredSource}(),
+        Dict{MethodInstance, CodeInstance}(),
+        Dict{MethodInstance, Remarks}()
+    )
 
 import Core.Compiler: InferenceParams, OptimizationParams, get_world_counter,
     get_inference_cache, code_cache, method_table,

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -32,7 +32,7 @@ CthulhuInterpreter() = CthulhuInterpreter(
 )
 
 import Core.Compiler: InferenceParams, OptimizationParams, get_world_counter,
-    get_inference_cache, code_cache,
+    get_inference_cache, code_cache, method_table,
     WorldView, lock_mi_inference, unlock_mi_inference, InferenceState
 using Base: @invoke
 
@@ -40,6 +40,7 @@ Compiler.InferenceParams(interp::CthulhuInterpreter) = InferenceParams(interp.na
 Compiler.OptimizationParams(interp::CthulhuInterpreter) = OptimizationParams(interp.native)
 Compiler.get_world_counter(interp::CthulhuInterpreter) = get_world_counter(interp.native)
 Compiler.get_inference_cache(interp::CthulhuInterpreter) = get_inference_cache(interp.native)
+Compiler.method_table(interp::CthulhuInterpreter, sv::InferenceState) = method_table(interp.native, sv)
 
 # No need to do any locking since we're not putting our results into the runtime cache
 Compiler.lock_mi_inference(interp::CthulhuInterpreter, mi::MethodInstance) = nothing

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -24,9 +24,9 @@ mutable struct CthulhuInterpreter <: AbstractInterpreter
     remarks::Dict{MethodInstance, Remarks}
 end
 
-CthulhuInterpreter(native_interp::AbstractInterpreter=NativeInterpreter()) =
+CthulhuInterpreter(interp::AbstractInterpreter=NativeInterpreter()) =
     CthulhuInterpreter(
-        native_interp,
+        interp,
         Dict{MethodInstance, InferredSource}(),
         Dict{MethodInstance, CodeInstance}(),
         Dict{MethodInstance, Remarks}()

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -250,8 +250,8 @@ function callinfo(sig, rt, max_methods=-1; params=current_params())
     return MultiCallInfo(sig, rt, callinfos)
 end
 
-function find_caller_of(callee::MethodInstance, caller::MethodInstance)
-    interp = CthulhuInterpreter()
+function find_caller_of(native_interp::AbstractInterpreter, callee::MethodInstance, caller::MethodInstance)
+    interp = CthulhuInterpreter(native_interp)
     do_typeinf!(interp, caller)
     params = current_params()
     locs = Tuple{Core.LineInfoNode,Int}[]

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -250,15 +250,15 @@ function callinfo(sig, rt, max_methods=-1; params=current_params())
     return MultiCallInfo(sig, rt, callinfos)
 end
 
-function find_caller_of(native_interp::AbstractInterpreter, callee::MethodInstance, caller::MethodInstance)
-    interp = CthulhuInterpreter(native_interp)
-    do_typeinf!(interp, caller)
+function find_caller_of(interp::AbstractInterpreter, callee::MethodInstance, caller::MethodInstance)
+    interp′ = CthulhuInterpreter(interp)
+    do_typeinf!(interp′, caller)
     params = current_params()
     locs = Tuple{Core.LineInfoNode,Int}[]
     for optimize in (true, false)
-        (CI, rt, infos, slottypes) = lookup(interp, caller, optimize)
+        (CI, rt, infos, slottypes) = lookup(interp′, caller, optimize)
         CI = preprocess_ci!(CI, caller, optimize, CONFIG)
-        callsites = find_callsites(interp, CI, infos, caller, slottypes, optimize; params=params)
+        callsites = find_callsites(interp′, CI, infos, caller, slottypes, optimize; params=params)
         callsites = filter(cs->is_callsite(cs, callee), callsites)
         foreach(cs -> add_sourceline!(locs, CI, cs.id), callsites)
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -478,7 +478,7 @@ end
         end
     end
     function doprint(f)
-        interp, mi = Cthulhu.mkinterp(f, ())
+        interp, mi = Cthulhu.mkinterp(NativeInterpreter(), f, ())
         src, rt = Cthulhu.lookup(interp, mi, true)
         io = IOBuffer()
         Cthulhu.cthulhu_typed(io, :none, src, rt, mi; iswarn=false)
@@ -492,7 +492,7 @@ end
 
 @testset "Issue #132" begin
     f132(w, dim) = [i == dim ? w[i]/2 : w[i]/1 for i in eachindex(w)]
-    interp, mi = Cthulhu.mkinterp(f132, (Vector{Int}, Int))
+    interp, mi = Cthulhu.mkinterp(NativeInterpreter(), f132, (Vector{Int}, Int))
     @test isa(mi, Core.MethodInstance)   # just check that the above succeeded
 end
 
@@ -562,9 +562,9 @@ end
     micaller = Cthulhu.get_specialization(caller, Tuple{Int})
     micallee_Int = Cthulhu.get_specialization(callee, Tuple{Int})
     micallee_Float4 = Cthulhu.get_specialization(callee, Tuple{Float64})
-    info, lines = only(Cthulhu.find_caller_of(micallee_Int, micaller))
+    info, lines = only(Cthulhu.find_caller_of(NativeInterpreter(), micallee_Int, micaller))
     @test info == (:caller, Symbol(@__FILE__), 0) && lines == [line1, line3]
-    info, lines = only(Cthulhu.find_caller_of(micallee_Float4, micaller))
+    info, lines = only(Cthulhu.find_caller_of(NativeInterpreter(), micallee_Float4, micaller))
     @test info == (:caller, Symbol(@__FILE__), 0) && lines == [line2]
 
     # Detection in optimized (post-inlining) code
@@ -578,7 +578,7 @@ end
     _, line1, line2 = outercaller(7)
     micaller = Cthulhu.get_specialization(outercaller, Tuple{Int})
     micallee = Cthulhu.get_specialization(nicallee, Tuple{Int})
-    callerinfo = Cthulhu.find_caller_of(micallee, micaller)
+    callerinfo = Cthulhu.find_caller_of(NativeInterpreter(), micallee, micaller)
     @test length(callerinfo) == 2
     info, lines = callerinfo[1]
     @test info == (:outercaller, Symbol(@__FILE__), 0)
@@ -665,7 +665,7 @@ end
 include("codeview.jl")
 
 @testset "Bookmarks" begin
-    (interp, mi) = Cthulhu.mkinterp(sqrt, Tuple{Float64})
+    (interp, mi) = Cthulhu.mkinterp(NativeInterpreter(), sqrt, Tuple{Float64})
     b = Cthulhu.Bookmark(mi, interp)
 
     @testset "code_typed(bookmark)" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,5 +1,7 @@
+using Core.Compiler: NativeInterpreter
+
 function process(@nospecialize(f), @nospecialize(TT=()); optimize=true)
-    (interp, mi) = Cthulhu.mkinterp(f, TT)
+    (interp, mi) = Cthulhu.mkinterp(NativeInterpreter(), f, TT)
     (ci, rt, infos, slottypes) = Cthulhu.lookup(interp, mi, optimize; allow_no_codeinf=true)
     if ci !== nothing
         ci = Cthulhu.preprocess_ci!(ci, mi, optimize, Cthulhu.CthulhuConfig(dead_code_elimination=true))


### PR DESCRIPTION
Although this doesn't solve the fundamental problem of composing abstract interpreters (since we're still bypassing most of the native interpreter's logic here), by forwarding the `method_table` query to the now user-customizable native interpreter the GPU compiler can use this to reflect on GPU code using Cthulhu. Until we add other logic to the GPUInterpreter (e.g. custom inlining thresholds as in https://github.com/JuliaGPU/GPUCompiler.jl/pull/186), that is.