### PR TITLE
Add descend method for MethodInstance

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -165,6 +165,12 @@ Shortcut for [`descend_code_typed`](@ref).
 """
 const descend = descend_code_typed
 
+function descend(mi::MethodInstance; kwargs...)
+    interp = Cthulhu.CthulhuInterpreter()
+    Cthulhu.do_typeinf!(interp, mi)
+    descend(interp, mi; kwargs...)
+end
+
 descend(interp::CthulhuInterpreter, mi::MethodInstance; kwargs...) = _descend(interp, mi; iswarn=false, interruptexc=false, kwargs...)
 
 function codeinst_rt(code::CodeInstance)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -165,10 +165,15 @@ Shortcut for [`descend_code_typed`](@ref).
 """
 const descend = descend_code_typed
 
-function descend(mi::MethodInstance; kwargs...)
+function descend_code_typed(mi::MethodInstance; kwargs...)
     interp = Cthulhu.CthulhuInterpreter()
     Cthulhu.do_typeinf!(interp, mi)
-    descend(interp, mi; kwargs...)
+    _descend(interp, mi; iswarn=false, interruptexc=false, kwargs...)
+end
+function descend_code_warntype(mi::MethodInstance; kwargs...)
+    interp = Cthulhu.CthulhuInterpreter()
+    Cthulhu.do_typeinf!(interp, mi)
+    _descend(interp, mi; iswarn=true, interruptexc=false, kwargs...)
 end
 
 descend(interp::CthulhuInterpreter, mi::MethodInstance; kwargs...) = _descend(interp, mi; iswarn=false, interruptexc=false, kwargs...)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -165,15 +165,15 @@ Shortcut for [`descend_code_typed`](@ref).
 """
 const descend = descend_code_typed
 
-function descend_code_typed(mi::MethodInstance; kwargs...)
+function descend_code_typed(mi::MethodInstance; terminal=default_terminal(), kwargs...)
     interp = Cthulhu.CthulhuInterpreter()
     Cthulhu.do_typeinf!(interp, mi)
-    _descend(interp, mi; iswarn=false, interruptexc=false, kwargs...)
+    _descend(terminal, interp, mi; iswarn=false, interruptexc=false, kwargs...)
 end
-function descend_code_warntype(mi::MethodInstance; kwargs...)
+function descend_code_warntype(mi::MethodInstance; terminal=default_terminal(), kwargs...)
     interp = Cthulhu.CthulhuInterpreter()
     Cthulhu.do_typeinf!(interp, mi)
-    _descend(interp, mi; iswarn=true, interruptexc=false, kwargs...)
+    _descend(terminal, interp, mi; iswarn=true, interruptexc=false, kwargs...)
 end
 
 descend(interp::CthulhuInterpreter, mi::MethodInstance; kwargs...) = _descend(interp, mi; iswarn=false, interruptexc=false, kwargs...)

--- a/test/terminal.jl
+++ b/test/terminal.jl
@@ -206,6 +206,25 @@ const keydict = Dict(:up => "\e[A",
             @test occursin("call show(::IO,::String)", lines)
             write(in, 'q')
         end
+        # descend with MethodInstances
+        mi = Cthulhu.get_specialization(MultiCall.callfmulti, Tuple{typeof(Ref{Any}(1))})
+        fake_terminal() do term, in, out
+            @async begin
+                descend(mi; interruptexc=false, optimize=false, terminal=term)
+            end
+            lines = cread(out)
+            @test occursin("fmulti(::Any)", lines)
+            write(in, 'q')
+        end
+        fake_terminal() do term, in, out
+            @async begin
+                descend_code_warntype(mi; interruptexc=false, optimize=false, terminal=term)
+            end
+            lines = cread(out)
+            @test occursin("Base.getindex(c)\e[91m\e[1m::Any\e[22m\e[39m", lines)
+            write(in, 'q')
+        end
+
         # ascend
         @noinline inner3(x) = 3x
         @inline   inner2(x) = 2*inner3(x)


### PR DESCRIPTION
This is useful for descending into methodinstances you get from `SnoopCompile.@snoopi_deep`.