### PR TITLE
update `stmt_infos` after DCE

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -279,6 +279,11 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                 (codeinf, rt, infos, slottypes) = lookup(interp, mi, optimize)
             end
             codeinf = preprocess_ci!(codeinf, mi, optimize, CONFIG)
+            if optimize
+                infos = codeinf.stmts.info
+            else
+                @assert length(codeinf.code) == length(infos)
+            end
             callsites = find_callsites(interp, codeinf, infos, mi, slottypes, optimize; params)
 
             if display_CI


### PR DESCRIPTION
Previously this led to the statement infos not matching the IR anymore.
I am a bit unsure if we run DCE on unoptimized IR as well, in which case
we would have to update `infos` in the DCE pass as well.
