### PR TITLE
more use `AbstractInterpreter` interfaces, don't hardcode `NativeInterpreter` params

### DIFF
--- a/test/codeview.jl
+++ b/test/codeview.jl
@@ -4,7 +4,7 @@ using .CthulhuTestSandbox
 Revise.track(CthulhuTestSandbox, normpath(@__DIR__, "sandbox.jl"))
 
 @testset "printer test" begin
-    _, src, infos, mi, rt, slottypes = process(testf_revise);
+    interp, src, infos, mi, rt, slottypes = process(testf_revise);
     tf = (true, false)
 
     @testset "codeview: $codeview" for codeview in Cthulhu.CODEVIEWS
@@ -13,11 +13,10 @@ Revise.track(CthulhuTestSandbox, normpath(@__DIR__, "sandbox.jl"))
         end
         @testset "optimize: $optimize" for optimize in tf
             @testset "debuginfo: $debuginfo" for debuginfo in instances(Cthulhu.DInfo.DebugInfo)
-                params = Cthulhu.current_params()
                 config = Cthulhu.CONFIG
 
                 io = IOBuffer()
-                codeview(io, mi, optimize, debuginfo, params, config)
+                codeview(io, mi, optimize, debuginfo, interp, config)
                 @test !isempty(String(take!(io))) # just check it works
             end
         end


### PR DESCRIPTION
```julia
julia> function summer(f, xs)
           s = zero(eltype(xs))
           for x in xs
               s += f(x)
           end
           s
       end
summer (generic function with 1 method)

julia> @descend interp=CC.NativeInterpreter(; opt_params=CC.OptimizationParams(; inline_nonleaf_penalty=10)) inline_cost=true summer(sin, Number[1,2,3])
summer(f, xs) in Main at REPL[9]:1
│ ─ %-1  = invoke summer(::typeof(sin),::Vector{Number})::Any
3 1 ──  1 %1  = Base.bitcast(UInt64, 1)::UInt64        │╻╷╷   iterate
  │     1 %2  = Base.sub_int(%1, 0x0000000000000001)::UInt64   iterate
  │     4 %3  = Base.arraylen(_3)::Int64               │││╻     length
  │     1 %4  = Base.sle_int(0, %3)::Bool              ││││╻╷    >=
  │     1 %5  = Base.bitcast(UInt64, %3)::UInt64       │││││╻     reinterpret
  │     1 %6  = Base.ult_int(%2, %5)::Bool             ││││╻     <
  │     1 %7  = Base.and_int(%4, %6)::Bool             ││││╻     &
  └───  0       goto #3 if not %7                      │││
  2 ──  4 %9  = Base.arrayref(false, _3, 1)::Number    │││╻     getindex
  │     1 %10 = Base.add_int(1, 1)::Int64              │││╻     +
  └───  0       goto #4                                │││
  3 ──  0       Base.nothing::Core.Const(nothing)      │││
  └───  0       goto #4                                │││
  4 ┄─  0 %14 = φ (#2 => false, #3 => true)::Bool      ││
  │     0 %15 = φ (#2 => %9)::Number                   ││
  │     0 %16 = φ (#2 => %10)::Int64                   ││
  └───  0       goto #5                                ││
  5 ──  0 %18 = Base.not_int(%14)::Bool                │
  └───  0       goto #11 if not %18                    │
  6 ┄─  0 %20 = φ (#5 => %15, #10 => %38)::Number      │
  │     0 %21 = φ (#5 => %16, #10 => %39)::Int64       │
  │     0 %22 = φ (#5 => 0, #10 => %24)::Any           │
4 │    10 %23 = (_2)(%20)::Any                         │
  │    10 %24 = (%22 + %23)::Any                       │
5 │     1 %25 = Base.bitcast(UInt64, %21)::UInt64      │╻╷    iterate
  │     1 %26 = Base.sub_int(%25, 0x0000000000000001)::UInt64  -
  │     4 %27 = Base.arraylen(_3)::Int64               ││╻     length
  │     1 %28 = Base.sle_int(0, %27)::Bool             │││╻╷    >=
  │     1 %29 = Base.bitcast(UInt64, %27)::UInt64      ││││╻     reinterpret
  │     1 %30 = Base.ult_int(%26, %29)::Bool           │││╻     <
  │     1 %31 = Base.and_int(%28, %30)::Bool           │││╻     &
  └───  0       goto #8 if not %31                     ││
  7 ──  4 %33 = Base.arrayref(false, _3, %21)::Number  ││╻     getindex
  │     1 %34 = Base.add_int(%21, 1)::Int64            ││╻     +
  └───  0       goto #9                                ││
  8 ──  0       Base.nothing::Core.Const(nothing)      ││
  └───  0       goto #9                                ││
  9 ┄─  0 %38 = φ (#7 => %33)::Number                  │
  │     0 %39 = φ (#7 => %34)::Int64                   │
  │     0 %40 = φ (#7 => false, #8 => true)::Bool      │
  │     0 %41 = Base.not_int(%40)::Bool                │
  └───  0       goto #11 if not %41                    │
  10 ─ 40       goto #6                                │
6 11 ┄  0 %44 = φ (#9 => %24, #5 => 0)::Any            │
  └───  0       return %44                             │
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • ↩
```