### PR TITLE
print slotnames in optimized source

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -97,9 +97,9 @@ end
 # # for API consistency with the others
 # function cthulhu_typed(io::IO, mi::MethodInstance, optimize, debuginfo, params, config::CthulhuConfig)
 #     interp = mkinterp(mi)
-#     codeinf, rt, infos, slottypes = lookup(interp, mi, optimize)
-#     ci = Cthulhu.preprocess_ci!(codeinf, mi, optimize, config)
-#     cthulhu_typed(io, debuginfo, codeinf, rt, mi)
+#     (; src, rt, infos, slottypes) = lookup(interp, mi, optimize)
+#     ci = Cthulhu.preprocess_ci!(src, mi, optimize, config)
+#     cthulhu_typed(io, debuginfo, src, rt, mi)
 # end
 
 cthulhu_typed(io::IO, debuginfo::DebugInfo, args...; kwargs...) =
@@ -259,15 +259,13 @@ end
 function InteractiveUtils.code_typed(b::Bookmark; optimize::Bool=true)
     interp = b.interp
     mi = b.mi
-    (ci, rt) = lookup(interp, mi, optimize)
-    ci = preprocess_ci!(ci, mi, optimize, CONFIG)
-    if ci isa IRCode
-        ir = ci
-        ci = copy(interp.unopt[mi].src)
+    (; src, rt, codeinf) = lookup(interp, mi, optimize)
+    src = preprocess_ci!(src, mi, optimize, CONFIG)
+    if src isa IRCode
         nargs = Int((mi.def::Method).nargs) - 1
-        Core.Compiler.replace_code_newstyle!(ci, ir, nargs)
+        Core.Compiler.replace_code_newstyle!(codeinf, src, nargs)
     end
-    return ci => rt
+    return codeinf => rt
 end
 
 InteractiveUtils.code_warntype(b::Bookmark; kw...) =

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -10,6 +10,7 @@ end
 
 struct OptimizedSource
     ir::IRCode
+    src::CodeInfo
     isinlineable::Bool
 end
 
@@ -82,7 +83,7 @@ function Compiler.transform_result_for_cache(interp::CthulhuInterpreter, linfo::
     if isa(inferred_result, OptimizationState)
         opt = inferred_result
         if isdefined(opt, :ir)
-            return OptimizedSource(opt.ir::IRCode, opt.src.inlineable)
+            return OptimizedSource(opt.ir::IRCode, opt.src, opt.src.inlineable)
         end
     end
     return inferred_result
@@ -120,7 +121,7 @@ function Compiler.finish!(interp::CthulhuInterpreter, caller::InferenceResult)
     if isa(src, OptimizationState)
         opt = src
         if isdefined(opt, :ir)
-            caller.src = OptimizedSource(opt.ir, opt.src.inlineable)
+            caller.src = OptimizedSource(opt.ir, opt.src, opt.src.inlineable)
         end
     end
 end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -251,11 +251,11 @@ function find_caller_of(interp::AbstractInterpreter, callee::MethodInstance, cal
     do_typeinf!(interp′, caller)
     locs = Tuple{Core.LineInfoNode,Int}[]
     for optimize in (true, false)
-        (CI, rt, infos, slottypes) = lookup(interp′, caller, optimize)
-        CI = preprocess_ci!(CI, caller, optimize, CONFIG)
-        callsites = find_callsites(interp′, CI, infos, caller, slottypes, optimize)
+        (; src, rt, infos, slottypes) = lookup(interp′, caller, optimize)
+        src = preprocess_ci!(src, caller, optimize, CONFIG)
+        callsites = find_callsites(interp′, src, infos, caller, slottypes, optimize)
         callsites = filter(cs->is_callsite(cs, callee), callsites)
-        foreach(cs -> add_sourceline!(locs, CI, cs.id), callsites)
+        foreach(cs -> add_sourceline!(locs, src, cs.id), callsites)
     end
     # Consolidate by method, but preserve the order
     prlookup = Dict{Tuple{Symbol,Symbol},Int}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -479,7 +479,7 @@ end
     end
     function doprint(f)
         interp, mi = Cthulhu.mkinterp(NativeInterpreter(), f, ())
-        src, rt = Cthulhu.lookup(interp, mi, true)
+        (; src, rt) = Cthulhu.lookup(interp, mi, true)
         io = IOBuffer()
         Cthulhu.cthulhu_typed(io, :none, src, rt, mi; iswarn=false)
         return String(take!(io))

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -2,11 +2,11 @@ using Core.Compiler: NativeInterpreter
 
 function process(@nospecialize(f), @nospecialize(TT=()); optimize=true)
     (interp, mi) = Cthulhu.mkinterp(NativeInterpreter(), f, TT)
-    (ci, rt, infos, slottypes) = Cthulhu.lookup(interp, mi, optimize; allow_no_codeinf=true)
-    if ci !== nothing
-        ci = Cthulhu.preprocess_ci!(ci, mi, optimize, Cthulhu.CthulhuConfig(dead_code_elimination=true))
+    (; src, rt, infos, slottypes) = Cthulhu.lookup(interp, mi, optimize; allow_no_src=true)
+    if src !== nothing
+        src = Cthulhu.preprocess_ci!(src, mi, optimize, Cthulhu.CthulhuConfig(dead_code_elimination=true))
     end
-    interp, ci, infos, mi, rt, slottypes
+    (; interp, src, infos, mi, rt, slottypes)
 end
 
 function find_callsites_by_ftt(@nospecialize(f), @nospecialize(TT=Tuple{}); optimize=true)


### PR DESCRIPTION
This commit makes our code base a bit more complicated, but allows us to
see the names of slot in optimized source as well.

Here is an example:
```julia
X = rand(ComplexF32, 64, 64);
dst = reinterpret(reshape, Float32, X);
src = copy(dst);
function reduced(dest, src)
    src = Base.unalias(dest, src)
    iterdest, itersrc = eachindex(dest), eachindex(src)
    # Dual-iterator implementation
    ret = iterate(iterdest)
    @inbounds for a in src
        idx, state = ret
        dest[idx] = a
        ret = iterate(iterdest, state)
    end
    return dest
end
using Cthulhu
@descend reduced(dst, src)
```
```diff
diff --git a/after.jl b/before.jl
index 83e2046..800abe6 100644
--- a/after.jl
+++ b/before.jl
@@ -11,7 +11,7 @@ reduced(dest, src) in Main at REPL[5]:1
    │    %8   = (%7 === 0x08)::Bool             ││││╻        ==
    │    %9   = Base.not_int(%8)::Bool          │││╻        !
    └───        goto #4 if not %9               │││
-   3 ── %11  = Base.getfield(_2, :parent)::Matrix{ComplexF32}etproperty
+   3 ── %11  = Base.getfield(dest, :parent)::Matrix{ComplexF32}property
    │    %12  = $(Expr(:foreigncall, :(:jl_array_ptr), Ptr{ComplexF32}, svec(Any), 0, :(:ccall), :(%11)))::Ptr{ComplexF32}
    │    %13  = Core.bitcast(Core.UInt, %12)::UInt64│╻        UInt64
    │    %14  = $(Expr(:foreigncall, :(:jl_array_ptr), Ptr{Float32}, svec(Any), 0, :(:ccall), Core.Argument(3)))::Ptr{Float32}
@@ -27,8 +27,8 @@ reduced(dest, src) in Main at REPL[5]:1
    7 ── %24  = $(Expr(:foreigncall, :(:jl_array_copy), Ref{Array{Float32, 3}}, svec(Any), 0, :(:ccall), Core.Argument(3)))::Array{Float32, 3}
    └───        goto #9                         ││
    8 ──        goto #9                         ││
-   9 ┄─ %27  = φ (#7 => %24, #8 => _3)::Array{Float32, 3}
-3  │    %28  = Base.getfield(_2, :parent)::Matrix{ComplexF32}index
+   9 ┄─ %27  = φ (#7 => %24, #8 => src@_3)::Array{Float32, 3}
+3  │    %28  = Base.getfield(dest, :parent)::Matrix{ComplexF32}dex
    └─── %29  = Base.arraylen(%28)::Int64       ││╻        eachindex
    10 ─ %30  = Base.slt_int(%29, 0)::Bool      │││╻╷╷╷     eachindex
    │    %31  = Core.ifelse::Core.Const(Core.ifelse)╻        oneto
@@ -118,7 +118,7 @@ reduced(dest, src) in Main at REPL[5]:1
    45 ┄ %115 = φ (#41 => %107, #43 => %111)::Core.PartialStruct(Tuple{Tuple{Int64, Int64, Int64}, Int64}, Any[Tuple{Int64, Int64, Int64}, Core.Const(3)])
    │    %116 = Core.getfield(%115, 1)::Tuple{Int64, Int64, Int64}
 8  │    %117 = %new(Base.RefValue{Float32}, %84)::Base.RefValue{Float32}
-   │    %118 = Base.getfield(_2, :parent)::Matrix{ComplexF32}property
+   │    %118 = Base.getfield(dest, :parent)::Matrix{ComplexF32}operty
    │    %119 = Base.getfield(%102, :j)::Int64  │││
    │    %120 = Base.arrayref(false, %118, %119)::ComplexF32etindex
    │    %121 = %new(Base.RefValue{ComplexF32}, %120)::Base.RefValue{ComplexF32}
@@ -160,7 +160,7 @@ reduced(dest, src) in Main at REPL[5]:1
    └───        goto #63                        │││
    63 ─        $(Expr(:gc_preserve_end, :(%122)))
    │    %159 = Base.getfield(%121, :x)::ComplexF32╷       getindex
-   │    %160 = Base.getfield(_2, :parent)::Matrix{ComplexF32}property
+   │    %160 = Base.getfield(dest, :parent)::Matrix{ComplexF32}operty
    │    %161 = Base.getfield(%102, :j)::Int64  │││
    │           Base.arrayset(false, %160, %159, %161)::Matrix{ComplexF32}
    └───        goto #64                        │╻        setindex!
@@ -212,7 +212,7 @@ reduced(dest, src) in Main at REPL[5]:1
    │    %209 = Base.not_int(%208)::Bool        │
    └───        goto #77 if not %209            │
    76 ─        goto #35                        │
-11 77 ┄        return _2                       │
+11 77 ┄        return dest                     │
 Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
 Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
 Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
```