### PR TITLE
Fix @interp

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -485,6 +485,8 @@ function mkinterp(interp::AbstractInterpreter, @nospecialize(args...))
     (interp′, mi)
 end
 
+mkinterp(@nospecialize(args...)) = mkinterp(NativeInterpreter(), args...)
+
 function _descend(@nospecialize(args...);
                   interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
     (interp′, mi) = mkinterp(interp, args...)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -485,7 +485,7 @@ function mkinterp(interp::AbstractInterpreter, @nospecialize(args...))
     (interp′, mi)
 end
 
-mkinterp(@nospecialize(args...)) = mkinterp(NativeInterpreter(), args...)
+mkinterp(@nospecialize(args...); interp::AbstractInterpreter=NativeInterpreter()) = mkinterp(interp, args...)
 
 function _descend(@nospecialize(args...);
                   interp::AbstractInterpreter=NativeInterpreter(), kwargs...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -496,6 +496,21 @@ end
     @test isa(mi, Core.MethodInstance)   # just check that the above succeeded
 end
 
+@testset "@interp" begin
+    finterp1(x) = 2
+    (interp, mi) = Cthulhu.@interp finterp1(5)
+    @test isa(mi, Core.MethodInstance)
+
+    finterp2(x, y) = string(x, y)
+    (interp, mi) = Cthulhu.@interp finterp2("hi", " there")
+    @test isa(mi, Core.MethodInstance)
+
+    finterp3(x, y, z) = (x + y) / z
+    tt = Tuple{typeof(finterp3), Int64, Int64, Float64}
+    (interp, mi) = Cthulhu.mkinterp(tt)
+    @test isa(mi, Core.MethodInstance)
+end
+
 ## Functions for "backedges & treelist"
 # The printing changes when the functions are defined inside the testset
 fbackedge1() = 1


### PR DESCRIPTION
Before:
```
julia> using Cthulhu

julia> foo(x) = x + 2
foo (generic function with 1 method)

julia> Cthulhu.@interp foo(2)
ERROR: MethodError: no method matching mkinterp(::typeof(foo), ::Type{Tuple{Int64}})
Closest candidates are:
  mkinterp(::Core.Compiler.AbstractInterpreter, ::Any...) at ~/.julia/packages/Cthulhu/vWhSH/src/Cthulhu.jl:488
Stacktrace:
 [1] top-level scope
   @ REPL[8]:1
```

After:
```
julia> using Cthulhu

julia> foo(x) = x + 2
foo (generic function with 1 method)

julia> (interp, mi) = Cthulhu.@interp foo(2);

julia> interp.opt[mi].inferred.ir
1 1 ─ %1 = Base.add_int(_2, 2)::Int64                                                                                                                                                                            │╻ +
  └──      return %1
```