### PR TITLE
Add optional printing for effects

### DIFF
--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -6,16 +6,18 @@ abstract type CallInfo end
 struct MICallInfo <: CallInfo
     mi::MethodInstance
     rt
-    function MICallInfo(mi::MethodInstance, @nospecialize(rt))
+    effects
+    function MICallInfo(mi::MethodInstance, @nospecialize(rt), effects)
         if isa(rt, LimitedAccuracy)
-            return LimitedCallInfo(new(mi, ignorelimited(rt)))
+            return LimitedCallInfo(new(mi, ignorelimited(rt), effects))
         else
-            return new(mi, rt)
+            return new(mi, rt, effects)
         end
     end
 end
 get_mi(ci::MICallInfo) = ci.mi
 get_rt(ci::CallInfo) = ci.rt
+get_effects(ci::MICallInfo) = EFFECTS_ENABLED ? ci.effects : Effects()
 
 abstract type WrappedCallInfo <: CallInfo end
 
@@ -34,6 +36,7 @@ end
 struct UncachedCallInfo <: WrappedCallInfo
     wrapped::CallInfo
 end
+get_effects(uci::UncachedCallInfo) = Effects()
 
 struct PureCallInfo <: CallInfo
     argtypes::Vector{Any}
@@ -73,6 +76,10 @@ end
 # actual code-error
 get_mi(ci::MultiCallInfo) = error("Can't extract MethodInstance from multiple call informations")
 
+function get_effects(mci::MultiCallInfo)
+    EFFECTS_ENABLED ? mapreduce(get_effects, Core.Compiler.tristate_merge, mci.callinfos) : Effects()
+end
+
 struct TaskCallInfo <: CallInfo
     ci::CallInfo
 end
@@ -81,19 +88,20 @@ get_rt(tci::TaskCallInfo) = get_rt(tci.ci)
 
 struct InvokeCallInfo <: CallInfo
     ci::MICallInfo
-    InvokeCallInfo(mi::MethodInstance, @nospecialize(rt)) =
-        new(MICallInfo(mi, rt))
+    InvokeCallInfo(mi::MethodInstance, @nospecialize(rt), effects::Effects) =
+        new(MICallInfo(mi, rt, effects))
 end
-get_mi(ci::InvokeCallInfo) = get_mi(ci.ci)
-get_rt(ci::InvokeCallInfo) = get_rt(ci.ci)
+get_mi(ici::InvokeCallInfo) = get_mi(ici.ci)
+get_rt(ici::InvokeCallInfo) = get_rt(ici.ci)
+get_effects(ici::InvokeCallInfo) = get_effects(ici.ci)
 
 # OpaqueClosure CallInfo
 struct OCCallInfo <: CallInfo
     ci::MICallInfo
 end
 OCCallInfo(mi::MethodInstance, rt) = OCCallInfo(MICallInfo(mi, rt))
-get_mi(tci::OCCallInfo) = get_mi(tci.ci)
-get_rt(tci::OCCallInfo) = get_rt(tci.ci)
+get_mi(occi::OCCallInfo) = get_mi(occi.ci)
+get_rt(occi::OCCallInfo) = get_rt(occi.ci)
 
 # Special handling for ReturnTypeCall
 struct ReturnTypeCallInfo <: CallInfo
@@ -108,13 +116,15 @@ struct ConstPropCallInfo <: CallInfo
 end
 get_mi(cpci::ConstPropCallInfo) = cpci.result.linfo
 get_rt(cpci::ConstPropCallInfo) = get_rt(cpci.mi)
+get_effects(cpci::ConstPropCallInfo) = get_effects(cpci.result)
 
 struct ConstEvalCallInfo <: CallInfo
     mi::CallInfo
     argtypes::ArgTypes
 end
-get_mi(crci::ConstEvalCallInfo) = get_mi(crci.mi)
-get_rt(crci::ConstEvalCallInfo) = get_rt(crci.mi)
+get_mi(ceci::ConstEvalCallInfo) = get_mi(ceci.mi)
+get_rt(ceci::ConstEvalCallInfo) = get_rt(ceci.mi)
+get_effects(ceci::ConstEvalCallInfo) = get_effects(ceci.mi)
 
 # CUDA callsite
 struct CuCallInfo <: CallInfo
@@ -129,6 +139,7 @@ struct Callsite
     head::Symbol
 end
 get_mi(c::Callsite) = get_mi(c.info)
+get_effects(c::Callsite) = get_effects(c.info)
 
 # Callsite printing
 mutable struct TextWidthLimiter <: IO
@@ -300,6 +311,11 @@ function Base.show(io::IO, c::Callsite)
     iswarn = get(io, :iswarn, false)::Bool
     info = c.info
     rt = get_rt(info)
+    with_effects = get(io, :with_effects, false)
+    if with_effects
+        show(io, get_effects(c))
+        print(io, ' ')
+    end
     if iswarn && is_type_unstable(rt)
         printstyled(io, '%'; color=:red)
     else

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -136,7 +136,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
     else
         isa(mi, MethodInstance) || throw("`mi::MethodInstance` is required")
         print(io, "│ ─ ")
-        println(iolim, Callsite(-1, MICallInfo(mi, rettype), :invoke))
+        println(iolim, Callsite(-1, MICallInfo(mi, rettype, Effects()), :invoke))
     end
 
     # preprinter configuration
@@ -249,7 +249,7 @@ function Base.show(
     world = get_world_counter(b.interp)
     CI, rt = InteractiveUtils.code_typed(b; optimize)
     if get(io, :typeinfo, Any) === Bookmark  # a hack to check if in Vector etc.
-        print(io, Callsite(-1, MICallInfo(b.mi, rt), :invoke))
+        print(io, Callsite(-1, MICallInfo(b.mi, rt, Effects()), :invoke))
         print(io, " (world: ", world, ")")
         return
     end

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -5,9 +5,10 @@ using Core.Compiler: AbstractInterpreter, NativeInterpreter, InferenceState,
 struct InferredSource
     src::CodeInfo
     stmt_info::Vector{Any}
-    rt
-    InferredSource(src::CodeInfo, stmt_info::Vector{Any}, @nospecialize(rt)) =
-        new(src, stmt_info, rt)
+    effects::Effects
+    rt::Any
+    InferredSource(src::CodeInfo, stmt_info::Vector{Any}, effects, @nospecialize(rt)) =
+        new(src, stmt_info, effects, rt)
 end
 
 struct OptimizedSource
@@ -76,6 +77,7 @@ function Compiler.finish(state::InferenceState, interp::CthulhuInterpreter)
     interp.unopt[Core.Compiler.any(state.result.overridden_by_const) ? state.result : state.linfo] = InferredSource(
         copy(state.src),
         copy(state.stmt_info),
+        isdefined(Core.Compiler, :Effects) ? state.ipo_effects : nothing,
         state.result.result)
     return r
 end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -12,15 +12,15 @@ mutable struct CthulhuMenu <: TerminalMenus.ConfiguredMenu{TerminalMenus.Config}
     config::TerminalMenus.Config
 end
 
-function show_as_line(callsite::Callsite, optimize::Bool, iswarn::Bool)
+function show_as_line(callsite::Callsite, with_effects::Bool, optimize::Bool, iswarn::Bool)
     reduced_displaysize = displaysize(stdout)::Tuple{Int,Int} .- (0, 3)
     sprint() do io
-        show(IOContext(io, :limit=>true, :displaysize=>reduced_displaysize, :optimize=>optimize, :iswarn=>iswarn, :color=>iswarn), callsite)
+        show(IOContext(io, :limit=>true, :displaysize=>reduced_displaysize, :optimize=>optimize, :iswarn=>iswarn, :color=>iswarn||with_effects, :with_effects=>with_effects), callsite)
     end
 end
 
-function CthulhuMenu(callsites, optimize::Bool, iswarn::Bool; pagesize::Int=10, sub_menu = false, kwargs...)
-    options = vcat(map(callsite->show_as_line(callsite, optimize, iswarn), callsites), ["↩"])
+function CthulhuMenu(callsites, with_effects::Bool, optimize::Bool, iswarn::Bool; pagesize::Int=10, sub_menu = false, kwargs...)
+    options = vcat(map(callsite->show_as_line(callsite, with_effects, optimize, iswarn), callsites), ["↩"])
     length(options) < 1 && error("CthulhuMenu must have at least one option")
 
     # if pagesize is -1, use automatic paging
@@ -46,7 +46,7 @@ function stringify(@nospecialize(f), io::IO=IOBuffer())
 end
 
 const debugcolors = (:nothing, :light_black, :yellow)
-function usage(@nospecialize(view_cmd), optimize, iswarn, hide_type_stable, debuginfo, remarks, inline_cost, type_annotations, highlight)
+function usage(@nospecialize(view_cmd), optimize, iswarn, hide_type_stable, debuginfo, remarks, with_effects, inline_cost, type_annotations, highlight)
     colorize(iotmp, use_color::Bool, c::Char) = stringify(iotmp) do io
         use_color ? printstyled(io, c; color=:cyan) : print(io, c)
     end
@@ -63,6 +63,7 @@ function usage(@nospecialize(view_cmd), optimize, iswarn, hide_type_stable, debu
             printstyled(io, 'd'; color=debugcolors[Int(debuginfo)+1])
         end, "]ebuginfo, [",
         colorize(iotmp, remarks, 'r'), "]emarks, [",
+        colorize(iotmp, with_effects, 'e'), "]ffects, [",
         colorize(iotmp, inline_cost, 'i'), "]nlining costs, [",
         colorize(iotmp, type_annotations, 't'), "]ype annotations, [",
         colorize(iotmp, highlight, 's'), "]yntax highlight for Source/LLVM/Native.")
@@ -95,6 +96,9 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
         return true
     elseif key == UInt32('r')
         m.toggle = :remarks
+        return true
+    elseif key == UInt32('e')
+        m.toggle = :with_effects
         return true
     elseif key == UInt32('i')
         m.toggle = :inline_cost
@@ -129,7 +133,7 @@ function TerminalMenus.keypress(m::CthulhuMenu, key::UInt32)
     elseif key == UInt32('R')
         m.toggle = :revise
         return true
-    elseif key == UInt32('e') || key == UInt32('E')
+    elseif key == UInt32('E')
         m.toggle = :edit
         return true
     end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -244,7 +244,7 @@ end
             end)
             callinfo = only(callsites).info
             @test isa(callinfo, Cthulhu.ConstEvalCallInfo)
-            @test callinfo.mi.rt == Core.Const(factorial(12))
+            @test Cthulhu.get_rt(callinfo) == Core.Const(factorial(12))
             io = IOBuffer()
             print(io, only(callsites))
             @test occursin("= < consteval > issue41694(::Core.Const(12))", String(take!(io)))


### PR DESCRIPTION
This adds optional printing for effects by callsite. Press `e` to turn them on or off!

CC: @Keno @aviatesk 