### PR TITLE
Detect more callsites in `ascend` (closes #275)

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -610,7 +610,7 @@ function ascend(term, mi; interp::AbstractInterpreter=NativeInterpreter(), kwarg
             if !isroot(node)
                 # Help user find the sites calling the parent
                 miparent = instance(node.parent.data.nd)
-                ulocs = find_caller_of(interp, miparent, mi; allcandidates=true, optimize_choices = (false, true))
+                ulocs = find_caller_of(interp, miparent, mi; allow_unspecialized=true)
                 if !isempty(ulocs)
                     strlocs = [string(" "^k[3] * '"', k[2], "\", ", k[1], ": lines ", v) for (k, v) in ulocs]
                     push!(strlocs, "Browse typed code")

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -610,7 +610,7 @@ function ascend(term, mi; interp::AbstractInterpreter=NativeInterpreter(), kwarg
             if !isroot(node)
                 # Help user find the sites calling the parent
                 miparent = instance(node.parent.data.nd)
-                ulocs = find_caller_of(interp, miparent, mi)
+                ulocs = find_caller_of(interp, miparent, mi; allcandidates=true, optimize_choices = (false, true))
                 if !isempty(ulocs)
                     strlocs = [string(" "^k[3] * '"', k[2], "\", ", k[1], ": lines ", v) for (k, v) in ulocs]
                     push!(strlocs, "Browse typed code")
@@ -618,7 +618,7 @@ function ascend(term, mi; interp::AbstractInterpreter=NativeInterpreter(), kwarg
                     browsecodetyped = false
                     choice2 = 1
                     while choice2 != -1
-                        choice2 = TerminalMenus.request(term, "\nChoose caller of $miparent or proceed to typed code:", linemenu; cursor=choice2)
+                        choice2 = TerminalMenus.request(term, "\nChoose possible caller of $miparent or proceed to typed code:", linemenu; cursor=choice2)
                         if 0 < choice2 < length(strlocs)
                             loc = ulocs[choice2]
                             edit(String(loc[1][2]), first(loc[2]))

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -259,16 +259,16 @@ function callinfo(sig, rt, max_methods=-1; world=get_world_counter())
     return MultiCallInfo(sig, rt, callinfos)
 end
 
-function find_caller_of(interp::AbstractInterpreter, callee::MethodInstance, caller::MethodInstance; allcandidates::Bool=false, optimize_choices=(true, false))
+function find_caller_of(interp::AbstractInterpreter, callee::MethodInstance, caller::MethodInstance; allow_unspecialized::Bool=false)
     interp′ = CthulhuInterpreter(interp)
     do_typeinf!(interp′, caller)
     locs = Tuple{Core.LineInfoNode,Int}[]
-    for optimize in optimize_choices
+    for optimize in (true, false)
         (; src, rt, infos, slottypes) = lookup(interp′, caller, optimize)
         src = preprocess_ci!(src, caller, optimize, CONFIG)
         callsites = find_callsites(interp′, src, infos, caller, slottypes, optimize)
-        callsites = allcandidates ? filter(cs->maybe_callsite(cs, callee), callsites) :
-                                    filter(cs->is_callsite(cs, callee), callsites)
+        callsites = allow_unspecialized ? filter(cs->maybe_callsite(cs, callee), callsites) :
+                                          filter(cs->is_callsite(cs, callee), callsites)
         foreach(cs -> add_sourceline!(locs, src, cs.id), callsites)
     end
     # Consolidate by method, but preserve the order

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -259,15 +259,16 @@ function callinfo(sig, rt, max_methods=-1; world=get_world_counter())
     return MultiCallInfo(sig, rt, callinfos)
 end
 
-function find_caller_of(interp::AbstractInterpreter, callee::MethodInstance, caller::MethodInstance)
+function find_caller_of(interp::AbstractInterpreter, callee::MethodInstance, caller::MethodInstance; allcandidates::Bool=false, optimize_choices=(true, false))
     interp′ = CthulhuInterpreter(interp)
     do_typeinf!(interp′, caller)
     locs = Tuple{Core.LineInfoNode,Int}[]
-    for optimize in (true, false)
+    for optimize in optimize_choices
         (; src, rt, infos, slottypes) = lookup(interp′, caller, optimize)
         src = preprocess_ci!(src, caller, optimize, CONFIG)
         callsites = find_callsites(interp′, src, infos, caller, slottypes, optimize)
-        callsites = filter(cs->is_callsite(cs, callee), callsites)
+        callsites = allcandidates ? filter(cs->maybe_callsite(cs, callee), callsites) :
+                                    filter(cs->is_callsite(cs, callee), callsites)
         foreach(cs -> add_sourceline!(locs, src, cs.id), callsites)
     end
     # Consolidate by method, but preserve the order

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -615,6 +615,23 @@ end
     info, lines = only(Cthulhu.find_caller_of(NativeInterpreter(), micallee_Float64, micaller))
     @test info == (:caller, Symbol(@__FILE__), 0) && lines == [line2]
 
+    M = Module()
+    @eval M begin
+        f(x::String...) = join(x, ' ')
+        f(x::Int...) = sum(x)
+        g(c) = f(c...); const gline = @__LINE__
+    end
+    @test M.g(Any["cat", "dog"]) == "cat dog"
+
+    mif = Cthulhu.get_specialization(M.f, Tuple{String, Vararg{String}})
+    mig = Cthulhu.get_specialization(M.g, Tuple{Vector{Any}})
+    @test isempty(Cthulhu.find_caller_of(Cthulhu.CthulhuInterpreter(), mif, mig))
+    candidate, lines = only(Cthulhu.find_caller_of(Cthulhu.CthulhuInterpreter(), mif, mig; allcandidates=true))
+    @test candidate[1] == nameof(M.g)
+    @test candidate[2] == Symbol(@__FILE__)
+    @test candidate[3] == 0 # depth
+    @test lines == [M.gline]
+
     # Detection in optimized (post-inlining) code
     @noinline nicallee(x) = 2x
     midcaller(x) = nicallee(x), @__LINE__

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -626,7 +626,7 @@ end
     mif = Cthulhu.get_specialization(M.f, Tuple{String, Vararg{String}})
     mig = Cthulhu.get_specialization(M.g, Tuple{Vector{Any}})
     @test isempty(Cthulhu.find_caller_of(Cthulhu.CthulhuInterpreter(), mif, mig))
-    candidate, lines = only(Cthulhu.find_caller_of(Cthulhu.CthulhuInterpreter(), mif, mig; allcandidates=true))
+    candidate, lines = only(Cthulhu.find_caller_of(Cthulhu.CthulhuInterpreter(), mif, mig; allow_unspecialized=true))
     @test candidate[1] == nameof(M.g)
     @test candidate[2] == Symbol(@__FILE__)
     @test candidate[3] == 0 # depth


### PR DESCRIPTION
This reorganizes `is_callsite` around `get_mi` and adds
`maybe_callsite` to detect potential callees from poorly-inferred
callers.

I'm not entirely certain what was happening in #275 (it's possible it was artifactual from some changes I'd made to julia itself), but this *seems* to behave better than the non-`get_mi`-based predecessor so I think this change makes sense on its own.