### PR TITLE
Improve get_effects functionality, add tests

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -17,7 +17,7 @@ const ArgTypes = Vector{Any}
 
 @static if !isdefined(Core.Compiler, :Effects)
     const Effects = Nothing
-    const EFFECTS_TOTAL = Nothing
+    const EFFECTS_TOTAL = nothing
     const EFFECTS_ENABLED = false
 else
     const Effects = Core.Compiler.Effects
@@ -243,6 +243,7 @@ if EFFECTS_ENABLED
     get_effects(unopt::Dict{Union{MethodInstance, InferenceResult}, InferredSource}, mi::MethodInstance) =
         haskey(unopt, mi) ? get_effects(unopt[mi]) : Effects()
     get_effects(result::InferenceResult) = result.ipo_effects
+    get_effects(result::Compiler.ConstResult) = result.effects
 else
     get_effects(_...) = nothing
 end

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -54,6 +54,7 @@ struct FailedCallInfo <: CallInfo
 end
 get_mi(ci::FailedCallInfo) = fail(ci)
 get_rt(ci::FailedCallInfo) = fail(ci)
+get_effects(ci::FailedCallInfo) = Effects()
 function fail(ci::FailedCallInfo)
     @error "MethodInstance extraction failed" ci.sig ci.rt
     return nothing
@@ -64,7 +65,10 @@ struct GeneratedCallInfo <: CallInfo
     sig
     rt
 end
-function get_mi(genci::GeneratedCallInfo)
+get_mi(genci::GeneratedCallInfo) = fail(genci)
+get_rt(genci::GeneratedCallInfo) = fail(genci)
+get_effects(genci::GeneratedCallInfo) = Effects()
+function fail(genci::GeneratedCallInfo)
     @error "Can't extract MethodInstance from call to generated functions" genci.sig genci.rt
     return nothing
 end
@@ -86,6 +90,7 @@ struct TaskCallInfo <: CallInfo
 end
 get_mi(tci::TaskCallInfo) = get_mi(tci.ci)
 get_rt(tci::TaskCallInfo) = get_rt(tci.ci)
+get_effects(tci::TaskCallInfo) = get_effects(tci.ci)
 
 struct InvokeCallInfo <: CallInfo
     ci::MICallInfo
@@ -137,6 +142,7 @@ struct CuCallInfo <: CallInfo
 end
 get_mi(gci::CuCallInfo) = get_mi(gci.cumi)
 get_rt(gci::CuCallInfo) = get_rt(gci.cumi)
+get_effects(gci::CuCallInfo) = get_effects(gci.cumi)
 
 struct Callsite
     id::Int # ssa-id

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -154,7 +154,11 @@ function process_info(interp, @nospecialize(info), argtypes::ArgTypes, @nospecia
             end
         end
     elseif (@static isdefined(Compiler, :InvokeCallInfo) && true) && isa(info, Compiler.InvokeCallInfo)
-        return Any[InvokeCallInfo(Core.Compiler.specialize_method(info.match), rt, Effects())]
+        mi = Core.Compiler.specialize_method(info.match)
+        res = info.result
+        effects = isnothing(res) ? Effects() : get_effects(info.result)
+        ici = InvokeCallInfo(mi, rt, effects)
+        return Any[ici]
     elseif (@static isdefined(Compiler, :OpaqueClosureCallInfo) && true) && isa(info, Compiler.OpaqueClosureCallInfo)
         return Any[OCCallInfo(Core.Compiler.specialize_method(info.match), rt)]
     elseif (@static isdefined(Compiler, :OpaqueClosureCreateInfo) && true) && isa(info, Compiler.OpaqueClosureCreateInfo)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -46,8 +46,14 @@ isordered(::Type{T}) where {T<:AbstractDict} = false
     callsites = find_callsites_by_ftt(iterate, (Base.IdSet{Any}, Union{}); optimize=false)
     @test callsites[1].info isa Cthulhu.ConstPropCallInfo
 
-    # Broken stuff in Julia
-    @test_broken find_callsites_by_ftt(Core.Compiler._limit_type_size, Tuple{Any, Type{Any}, Core.SimpleVector, Int, Int})  # ssair/ir.jl bug
+    if Cthulhu.EFFECTS_ENABLED
+        effects = Cthulhu.get_effects(callsites[1].info)
+        @test !Core.Compiler.is_concrete_eval_eligible(effects)
+        @test !Core.Compiler.is_consistent(effects)
+        @test Core.Compiler.is_effect_free(effects)
+        @test Core.Compiler.is_nothrow(effects)
+        @test Core.Compiler.is_terminates(effects)
+    end
 end
 
 @testset "Expr heads" begin
@@ -138,6 +144,7 @@ let callsites = find_callsites_by_ftt(f_matches, Tuple{Any, Any}; optimize=false
     @test length(callsites) == 1
     callinfo = callsites[1].info
     @test callinfo isa Cthulhu.MultiCallInfo
+    Cthulhu.EFFECTS_ENABLED && @test Cthulhu.get_effects(callinfo) |> Core.Compiler.is_concrete_eval_eligible
     io = IOBuffer()
     Cthulhu.show_callinfo(io, callinfo)
     @test occursin(r"→ g_matches\(::Any, ?::Any\)::Union{Float64, ?Int\d+}", String(take!(io)))
@@ -158,6 +165,13 @@ end
         @test length(callsites) == 1
         ci = first(callsites).info
         @test isa(ci, Cthulhu.UncachedCallInfo)
+        if Cthulhu.EFFECTS_ENABLED
+            effects = Cthulhu.get_effects(ci)
+            @test !Core.Compiler.is_consistent(effects)
+            @test Core.Compiler.is_effect_free(effects)
+            @test !Core.Compiler.is_nothrow(effects)
+            @test !Core.Compiler.is_terminates(effects)
+        end
         @test Cthulhu.is_callsite(ci, ci.wrapped.mi)
         io = IOBuffer()
         show(io, first(callsites))
@@ -249,6 +263,7 @@ end
             callinfo = only(callsites).info
             @test isa(callinfo, Cthulhu.ConstEvalCallInfo)
             @test Cthulhu.get_rt(callinfo) == Core.Const(factorial(12))
+            @test Cthulhu.get_effects(callinfo) |> Core.Compiler.is_concrete_eval_eligible
             io = IOBuffer()
             print(io, only(callsites))
             @test occursin("= < consteval > issue41694(::Core.Const(12))", String(take!(io)))
@@ -259,11 +274,18 @@ end
 struct SingletonPureCallable{N} end
 
 @testset "PureCallInfo" begin
-    s = sprint(Cthulhu.show_callinfo, Cthulhu.PureCallInfo(Any[typeof(sin), Float64], Float64))
+    c1 = Cthulhu.PureCallInfo(Any[typeof(sin), Float64], Float64)
+    s = sprint(Cthulhu.show_callinfo, c1)
     @test s == "sin(::Float64)::Float64"
 
-    s = sprint(Cthulhu.show_callinfo, Cthulhu.PureCallInfo(Any[SingletonPureCallable{1}, Float64], Float64))
+    c2 =  Cthulhu.PureCallInfo(Any[SingletonPureCallable{1}, Float64], Float64)
+    s = sprint(Cthulhu.show_callinfo, c2)
     @test s == "SingletonPureCallable{1}()(::Float64)::Float64"
+
+    if Cthulhu.EFFECTS_ENABLED
+        @test Cthulhu.get_effects(c1) |> Core.Compiler.is_total
+        @test Cthulhu.get_effects(c2) |> Core.Compiler.is_total
+    end
 end
 
 @testset "ReturnTypeCallInfo" begin
@@ -294,6 +316,11 @@ end
     io = IOBuffer()
     print(io, callsites[2])
     @test occursin("return_type < only_ints(::Float64)::Union{} >", String(take!(io)))
+
+    if Cthulhu.EFFECTS_ENABLED
+        @test Cthulhu.get_effects(callinfo1.vmi) |> Core.Compiler.is_total
+        @test_broken Cthulhu.get_effects(callinfo2.vmi) |> Core.Compiler.is_concrete_eval_eligible # don't have effects from FailedCallInfo yet
+    end
 end
 
 @testset "OCCallInfo" begin
@@ -304,6 +331,10 @@ end
     @test length(callsites) == 1
     callinfo = only(callsites).info
     @test callinfo isa Cthulhu.OCCallInfo
+    if Cthulhu.EFFECTS_ENABLED
+        @test Cthulhu.get_effects(callinfo) |> !Core.Compiler.is_total
+        # TODO not sure what these effects are (and neither is Base.infer_effects yet)
+    end
     @test callinfo.ci.rt === Base.return_types((Int,Int)) do a, b
         sin(a) + cos(b)
     end |> only === Float64
@@ -345,6 +376,7 @@ end
         callsite = only(callsites)
         info = callsite.info
         @test isa(info, Cthulhu.InvokeCallInfo)
+        Cthulhu.EFFECTS_ENABLED && Cthulhu.get_effects(info) |> Core.Compiler.is_total
         print(io, callsite)
         @test info.ci.rt === Core.Compiler.Const(:Integer)
     end
@@ -359,6 +391,7 @@ end
         callsite = only(callsites)
         info = callsite.info
         @test isa(info, Cthulhu.InvokeCallInfo)
+        Cthulhu.EFFECTS_ENABLED && Cthulhu.get_effects(info) |> Core.Compiler.is_total
         @test info.ci.rt === Core.Compiler.Const(:Int)
     end
 end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -13,6 +13,7 @@ function find_callsites_by_ftt(@nospecialize(f), @nospecialize(TT=Tuple{}); opti
     interp, ci, infos, mi, _, slottypes = process(f, TT; optimize)
     ci === nothing && return Cthulhu.Callsite[]
     callsites = Cthulhu.find_callsites(interp, ci, infos, mi, slottypes, optimize)
+    @test all(c -> Cthulhu.get_effects(c) isa Cthulhu.Effects, callsites)
     return callsites
 end
 


### PR DESCRIPTION
This adds some functions and tests to at least ensure that `get_effects` doesn't error for each type of callsite

Accuracy for each likely still needs work

CC @aviatesk 