### PR TITLE
Minimal compat for upcoming FinalizerInfo

### DIFF
--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -174,6 +174,9 @@ function process_info(interp, @nospecialize(info), argtypes::ArgTypes, @nospecia
     elseif (@static isdefined(Compiler, :OpaqueClosureCreateInfo) && true) && isa(info, Compiler.OpaqueClosureCreateInfo)
         # TODO: Add ability to descend into OCs at creation site
         return []
+    elseif (@static isdefined(Compiler, :FinalizerInfo) && true) && isa(info, Compiler.FinalizerInfo)
+        # TODO: Add ability to descend into finalizers at creation site
+        return []
     elseif isa(info, Compiler.ReturnTypeCallInfo)
         newargtypes = argtypes[2:end]
         callinfos = process_info(interp, info.info, newargtypes, unwrapType(widenconst(rt)), optimize)


### PR DESCRIPTION
Just enough to avoid having Cthulhu crash out when it sees
a finalizer. Future improvements could allow descending into
the finalizer, but it's not clear if we actually want that,
since it's not really a call site (similar to OC creation though,
so whatever UI indication we choose for those should work
for both).

Should be merged once https://github.com/JuliaLang/julia/pull/45272
is merged in case there are additional renamings.