### PR TITLE
Allow the default state of toggles in `@descend` to be configured and saved persistently

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,7 @@ version = "2.5.5"
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 FoldingTrees = "1eca21be-9b9b-4ed8-839a-6d8ae26b1781"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
@@ -14,6 +15,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 [compat]
 CodeTracking = "0.5, 1"
 FoldingTrees = "1"
+Preferences = "1"
 julia = "1.7"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.5.5"
+version = "2.6.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ You can toggle between these with `o` and `w`.
 Cthulhu has access only to "static" type information, the same information available to the Julia compiler and type inference.
 In some situations, this will lead to incomplete or misleading information about type instabilities.
 
-Take for example: 
+Take for example:
 ```julia
 using Infiltrator: @infiltrate
 using Cthulhu: @descend
@@ -200,7 +200,7 @@ Now invoke `foo` to get REPL in the scope just before `bar` gets called:
 julia> foo(4)
 Infiltrating foo(n::Int64) at ex.jl:10:
 
-infil> 
+infil>
 ```
 
 Enter `@descend bar(x, y, z)` and type `w`:
@@ -219,3 +219,15 @@ Variables
 
 You can see that, for `foo(4)`, the types within `bar` are fully inferred.
 
+## Customization
+
+The default configuration of toggles in the `@descend` menu can be customized
+with `Cthulhu.CONFIG` and persistently saved (via Preferences.jl) using
+`Cthulhu.save_config!()`:
+
+```julia
+julia> Cthulhu.CONFIG.enable_highlighter = true # Change default
+true
+
+julia> Cthulhu.save_config!(Cthulhu.CONFIG) # Will be automatically read next time you `using Cthulhu`
+```

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -67,6 +67,7 @@ end
 """
 const CONFIG = CthulhuConfig()
 
+using Preferences
 include("preferences.jl")
 read_config!(CONFIG)
 

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -33,6 +33,13 @@ Base.@kwdef mutable struct CthulhuConfig
     asm_syntax::Symbol = :att
     dead_code_elimination::Bool = true
     pretty_ast::Bool = false
+    debuginfo::Symbol = :compact
+    optimize::Bool = true
+    iswarn::Bool = false
+    remarks::Bool = false
+    with_effects::Bool = false
+    inline_cost::Bool = false
+    type_annotations::Bool = true
 end
 
 """
@@ -48,7 +55,15 @@ end
 - `dead_code_elimination::Bool`: Enable dead-code elimination for high-level Julia IR.
   Defaults to `true`. DCE is known to be buggy and you may want to disable it if you
   encounter errors. Please report such bugs with a MWE to Julia or Cthulhu.
-- `pretty_ast::Bool`: Use a pretty printer for the ast dump. Defaults to false.
+- `pretty_ast::Bool`: Use a pretty printer for the ast dump. Defaults to `false`.
+- `debuginfo::Symbol`: Initial state of "debuginfo" toggle. Defaults to `:compact`.
+  Options:. `:none`, `:compact`, `:source`
+- `optimize::Bool`: Initial state of "optimize" toggle. Defaults to `true`.
+- `iswarn::Bool`: Initial state of "warn" toggle. Defaults to `false`.
+- `remarks::Bool` Initial state of "remarks" toggle. Defaults to `false`.
+- `with_effects::Bool` Intial state of "effects" toggle. Defaults to `false`.
+- `inline_cost::Bool` Initial state of "inlining costs" toggle. Defaults to `false`.
+- `type_annotations::Bool` Initial state of "type annnotations" toggle. Defaults to `true`.
 """
 const CONFIG = CthulhuConfig()
 
@@ -313,10 +328,17 @@ end
 # src/ui.jl provides the user facing interface to which _descend responds
 ##
 function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::MethodInstance;
-    override::Union{Nothing,InferenceResult}=nothing, debuginfo::Union{Symbol,DebugInfo}=DInfo.compact, # default is compact debuginfo
-    optimize::Bool=true, interruptexc::Bool=true,
-    iswarn::Bool=false, hide_type_stable::Union{Nothing,Bool}=nothing, verbose::Union{Nothing,Bool}=nothing,
-    remarks::Bool=false, with_effects::Bool=false, inline_cost::Bool=false, type_annotations::Bool=true)
+    override::Union{Nothing,InferenceResult}=nothing,    
+    debuginfo::Union{Symbol,DebugInfo}=CONFIG.debuginfo,    # default is compact debuginfo
+    optimize::Bool=CONFIG.optimize,                         # default is true
+    interruptexc::Bool=true,
+    iswarn::Bool=CONFIG.iswarn,                             # default is false
+    hide_type_stable::Union{Nothing,Bool}=nothing, verbose::Union{Nothing,Bool}=nothing,
+    remarks::Bool=CONFIG.remarks,                           # default is false
+    with_effects::Bool=CONFIG.with_effects,                 # default is false
+    inline_cost::Bool=CONFIG.inline_cost,                   # default is false
+    type_annotations::Bool=CONFIG.type_annotations          # default is true
+    )
 
     if isnothing(hide_type_stable)
         hide_type_stable = something(verbose, false)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -328,15 +328,15 @@ end
 # src/ui.jl provides the user facing interface to which _descend responds
 ##
 function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::MethodInstance;
-    override::Union{Nothing,InferenceResult}=nothing,    
+    override::Union{Nothing,InferenceResult}=nothing,
     debuginfo::Union{Symbol,DebugInfo}=CONFIG.debuginfo,    # default is compact debuginfo
     optimize::Bool=CONFIG.optimize,                         # default is true
     interruptexc::Bool=true,
     iswarn::Bool=CONFIG.iswarn,                             # default is false
     hide_type_stable::Union{Nothing,Bool}=nothing, verbose::Union{Nothing,Bool}=nothing,
-    remarks::Bool=CONFIG.remarks,                           # default is false
+    remarks::Bool=CONFIG.remarks&!CONFIG.optimize,          # default is false
     with_effects::Bool=CONFIG.with_effects,                 # default is false
-    inline_cost::Bool=CONFIG.inline_cost,                   # default is false
+    inline_cost::Bool=CONFIG.inline_cost&CONFIG.optimize,   # default is false
     type_annotations::Bool=CONFIG.type_annotations          # default is true
     )
 

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -67,6 +67,9 @@ end
 """
 const CONFIG = CthulhuConfig()
 
+include("preferences.jl")
+read_config!(CONFIG)
+
 module DInfo
     @enum DebugInfo none compact source
 end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -3,15 +3,14 @@
 ```julia
 save_config!(config::CthulhuConfig=CONFIG, force=true)
 ```
-If Preferences.jl is loaded, save a Cthulhu.jl configuration `config`
-(by default, `Cthulhu.CONFIG`) to your `LocalPreferences.toml` file.
+Save a Cthulhu.jl configuration `config` (by default, `Cthulhu.CONFIG`) to your
+`LocalPreferences.toml` file using Preferences.jl.
 
 The saved preferences will be automatically loaded next time you `using Cthulhu`
-if Preferences.jl is loaded.
 
 ## Examples
 ```julia
-julia> using Cthulhu, Preferences
+julia> using Cthulhu
 
 julia> Cthulhu.CONFIG.enable_highlighter = true
 true
@@ -19,56 +18,40 @@ true
 julia> Cthulhu.CONFIG.debuginfo = :none     # Customize some defaults
 :none
 
-julia> Cthulhu.save_config!(Cthulhu.CONFIG) # Will be read next time you `using Cthulhu, Preferences`
+julia> Cthulhu.save_config!(Cthulhu.CONFIG) # Will be automatically read next time you `using Cthulhu`
 ```
 """
 function save_config!(config::CthulhuConfig=CONFIG, force=true)
-    # Call Preferences.set_preferences!() without introducing a dependency on Preferences
-    id = Base.PkgId(UUID("21216c6a-2e73-6563-6e65-726566657250"), "Preferences")
-    mod = get(Base.loaded_modules, id, nothing)
-    if mod == nothing
-        @warn "Preferences.jl must be loaded in order to save configuration to file."
-    else
-        set_preferences! = getfield(mod, :set_preferences!)::Function
-        cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
-        set_preferences!(cthulhu_id,
-            "enable_highlighter" => config.enable_highlighter,
-            "highlighter" => config.highlighter.exec,
-            "asm_syntax" => String(config.asm_syntax),
-            "dead_code_elimination" => config.dead_code_elimination,
-            "pretty_ast" => config.pretty_ast,
-            "debuginfo" => String(config.debuginfo),
-            "optimize" => config.optimize,
-            "iswarn" => config.iswarn,
-            "remarks" => config.remarks,
-            "with_effects" => config.with_effects,
-            "inline_cost" => config.inline_cost,
-            "type_annotations" => config.type_annotations,
-            force=force
-        )
-    end
+    cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
+    set_preferences!(cthulhu_id,
+        "enable_highlighter" => config.enable_highlighter,
+        "highlighter" => config.highlighter.exec,
+        "asm_syntax" => String(config.asm_syntax),
+        "dead_code_elimination" => config.dead_code_elimination,
+        "pretty_ast" => config.pretty_ast,
+        "debuginfo" => String(config.debuginfo),
+        "optimize" => config.optimize,
+        "iswarn" => config.iswarn,
+        "remarks" => config.remarks,
+        "with_effects" => config.with_effects,
+        "inline_cost" => config.inline_cost,
+        "type_annotations" => config.type_annotations,
+        force=force
+    )
 end
 
 function read_config!(config::CthulhuConfig)
-    # Call Preferences.set_preferences!() without introducing a dependency on Preferences
-    id = Base.PkgId(UUID("21216c6a-2e73-6563-6e65-726566657250"), "Preferences")
-    mod = get(Base.loaded_modules, id, nothing)
-    if mod == nothing
-        @info "Preferences.jl not loaded. Using default configuration."
-    else
-        cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
-        load_preference = getfield(mod, :load_preference)::Function
-        config.enable_highlighter = load_preference(cthulhu_id, "enable_highlighter", config.enable_highlighter)
-        config.highlighter = Cmd(load_preference(cthulhu_id, "highlighter", config.highlighter))
-        config.asm_syntax = Symbol(load_preference(cthulhu_id, "asm_syntax", config.asm_syntax))
-        config.dead_code_elimination = load_preference(cthulhu_id, "dead_code_elimination", config.dead_code_elimination)
-        config.pretty_ast = load_preference(cthulhu_id, "pretty_ast", config.pretty_ast)
-        config.debuginfo = Symbol(load_preference(cthulhu_id, "debuginfo", config.debuginfo))
-        config.optimize = load_preference(cthulhu_id, "optimize", config.optimize)
-        config.iswarn = load_preference(cthulhu_id, "iswarn", config.iswarn)
-        config.remarks = load_preference(cthulhu_id, "remarks", config.remarks)
-        config.with_effects = load_preference(cthulhu_id, "with_effects", config.with_effects)
-        config.inline_cost = load_preference(cthulhu_id, "inline_cost", config.inline_cost)
-        config.type_annotations = load_preference(cthulhu_id, "type_annotations", config.type_annotations)
-    end
+    cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
+    config.enable_highlighter = load_preference(cthulhu_id, "enable_highlighter", config.enable_highlighter)
+    config.highlighter = Cmd(load_preference(cthulhu_id, "highlighter", config.highlighter))
+    config.asm_syntax = Symbol(load_preference(cthulhu_id, "asm_syntax", config.asm_syntax))
+    config.dead_code_elimination = load_preference(cthulhu_id, "dead_code_elimination", config.dead_code_elimination)
+    config.pretty_ast = load_preference(cthulhu_id, "pretty_ast", config.pretty_ast)
+    config.debuginfo = Symbol(load_preference(cthulhu_id, "debuginfo", config.debuginfo))
+    config.optimize = load_preference(cthulhu_id, "optimize", config.optimize)
+    config.iswarn = load_preference(cthulhu_id, "iswarn", config.iswarn)
+    config.remarks = load_preference(cthulhu_id, "remarks", config.remarks)
+    config.with_effects = load_preference(cthulhu_id, "with_effects", config.with_effects)
+    config.inline_cost = load_preference(cthulhu_id, "inline_cost", config.inline_cost)
+    config.type_annotations = load_preference(cthulhu_id, "type_annotations", config.type_annotations)
 end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -1,4 +1,28 @@
-function save_config!(config::CthulhuConfig, force=true)
+
+"""
+```julia
+save_config!(config::CthulhuConfig=CONFIG, force=true)
+```
+If Preferences.jl is loaded, save a Cthulhu.jl configuration `config`
+(by default, `Cthulhu.CONFIG`) to your `LocalPreferences.toml` file.
+
+The saved preferences will be automatically loaded next time you `using Cthulhu`
+if Preferences.jl is loaded.
+
+## Examples
+```julia
+julia> using Cthulhu, Preferences
+
+julia> Cthulhu.CONFIG.enable_highlighter = true
+true
+
+julia> Cthulhu.CONFIG.debuginfo = :none     # Customize some defaults
+:none
+
+julia> Cthulhu.save_config!(Cthulhu.CONFIG) # Will be read next time you `using Cthulhu, Preferences`
+```
+"""
+function save_config!(config::CthulhuConfig=CONFIG, force=true)
     # Call Preferences.set_preferences!() without introducing a dependency on Preferences
     id = Base.PkgId(UUID("21216c6a-2e73-6563-6e65-726566657250"), "Preferences")
     mod = get(Base.loaded_modules, id, nothing)

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -1,0 +1,48 @@
+function save_config!(config::CthulhuConfig, force=true)
+    # Call Preferences.set_preferences!() without introducing a dependency on Preferences
+    id = Base.PkgId(UUID("21216c6a-2e73-6563-6e65-726566657250"), "Preferences")
+    mod = get(Base.loaded_modules, id, nothing)
+    if mod == nothing
+        @warn "Preferences.jl must be loaded in order to save configuration to file."
+    else
+        set_preferences! = getfield(mod, :set_preferences!)::Function
+        set_preferences!(Cthulhu,
+            "enable_highlighter" => config.enable_highlighter,
+            "highlighter" => config.highlighter.exec,
+            "asm_syntax" => String(config.asm_syntax),
+            "dead_code_elimination" => config.dead_code_elimination,
+            "pretty_ast" => config.pretty_ast,
+            "debuginfo" => String(config.debuginfo),
+            "optimize" => config.optimize,
+            "iswarn" => config.iswarn,
+            "remarks" => config.remarks,
+            "with_effects" => config.with_effects,
+            "inline_cost" => config.inline_cost,
+            "type_annotations" => config.type_annotations,
+            force=force
+        )
+    end
+end
+
+function read_config!(config::CthulhuConfig)
+    # Call Preferences.set_preferences!() without introducing a dependency on Preferences
+    id = Base.PkgId(UUID("21216c6a-2e73-6563-6e65-726566657250"), "Preferences")
+    mod = get(Base.loaded_modules, id, nothing)
+    if mod == nothing
+        @info "Preferences.jl not loaded. Using default configuration."
+    else
+        load_preference = getfield(mod, :load_preference)::Function
+        config.enable_highlighter = load_preference(Cthulhu, "enable_highlighter", config.enable_highlighter)
+        config.highlighter = Cmd(load_preference(Cthulhu, "highlighter", config.highlighter))
+        config.asm_syntax = Symbol(load_preference(Cthulhu, "asm_syntax", config.asm_syntax))
+        config.dead_code_elimination = load_preference(Cthulhu, "dead_code_elimination", config.dead_code_elimination)
+        config.pretty_ast = load_preference(Cthulhu, "pretty_ast", config.pretty_ast)
+        config.debuginfo = Symbol(load_preference(Cthulhu, "debuginfo", config.debuginfo))
+        config.optimize = load_preference(Cthulhu, "optimize", config.optimize)
+        config.iswarn = load_preference(Cthulhu, "iswarn", config.iswarn)
+        config.remarks = load_preference(Cthulhu, "remarks", config.remarks)
+        config.with_effects = load_preference(Cthulhu, "with_effects", config.with_effects)
+        config.inline_cost = load_preference(Cthulhu, "inline_cost", config.inline_cost)
+        config.type_annotations = load_preference(Cthulhu, "type_annotations", config.type_annotations)
+    end
+end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -30,7 +30,8 @@ function save_config!(config::CthulhuConfig=CONFIG, force=true)
         @warn "Preferences.jl must be loaded in order to save configuration to file."
     else
         set_preferences! = getfield(mod, :set_preferences!)::Function
-        set_preferences!(Cthulhu,
+        cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
+        set_preferences!(cthulhu_id,
             "enable_highlighter" => config.enable_highlighter,
             "highlighter" => config.highlighter.exec,
             "asm_syntax" => String(config.asm_syntax),
@@ -55,18 +56,19 @@ function read_config!(config::CthulhuConfig)
     if mod == nothing
         @info "Preferences.jl not loaded. Using default configuration."
     else
+        cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
         load_preference = getfield(mod, :load_preference)::Function
-        config.enable_highlighter = load_preference(Cthulhu, "enable_highlighter", config.enable_highlighter)
-        config.highlighter = Cmd(load_preference(Cthulhu, "highlighter", config.highlighter))
-        config.asm_syntax = Symbol(load_preference(Cthulhu, "asm_syntax", config.asm_syntax))
-        config.dead_code_elimination = load_preference(Cthulhu, "dead_code_elimination", config.dead_code_elimination)
-        config.pretty_ast = load_preference(Cthulhu, "pretty_ast", config.pretty_ast)
-        config.debuginfo = Symbol(load_preference(Cthulhu, "debuginfo", config.debuginfo))
-        config.optimize = load_preference(Cthulhu, "optimize", config.optimize)
-        config.iswarn = load_preference(Cthulhu, "iswarn", config.iswarn)
-        config.remarks = load_preference(Cthulhu, "remarks", config.remarks)
-        config.with_effects = load_preference(Cthulhu, "with_effects", config.with_effects)
-        config.inline_cost = load_preference(Cthulhu, "inline_cost", config.inline_cost)
-        config.type_annotations = load_preference(Cthulhu, "type_annotations", config.type_annotations)
+        config.enable_highlighter = load_preference(cthulhu_id, "enable_highlighter", config.enable_highlighter)
+        config.highlighter = Cmd(load_preference(cthulhu_id, "highlighter", config.highlighter))
+        config.asm_syntax = Symbol(load_preference(cthulhu_id, "asm_syntax", config.asm_syntax))
+        config.dead_code_elimination = load_preference(cthulhu_id, "dead_code_elimination", config.dead_code_elimination)
+        config.pretty_ast = load_preference(cthulhu_id, "pretty_ast", config.pretty_ast)
+        config.debuginfo = Symbol(load_preference(cthulhu_id, "debuginfo", config.debuginfo))
+        config.optimize = load_preference(cthulhu_id, "optimize", config.optimize)
+        config.iswarn = load_preference(cthulhu_id, "iswarn", config.iswarn)
+        config.remarks = load_preference(cthulhu_id, "remarks", config.remarks)
+        config.with_effects = load_preference(cthulhu_id, "with_effects", config.with_effects)
+        config.inline_cost = load_preference(cthulhu_id, "inline_cost", config.inline_cost)
+        config.type_annotations = load_preference(cthulhu_id, "type_annotations", config.type_annotations)
     end
 end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -23,7 +23,7 @@ julia> Cthulhu.save_config!(Cthulhu.CONFIG) # Will be automatically read next ti
 """
 function save_config!(config::CthulhuConfig=CONFIG, force=true)
     cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
-    set_preferences!(cthulhu_id,
+    @set_preferences!(
         "enable_highlighter" => config.enable_highlighter,
         "highlighter" => config.highlighter.exec,
         "asm_syntax" => String(config.asm_syntax),

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -1,7 +1,7 @@
 
 """
 ```julia
-save_config!(config::CthulhuConfig=CONFIG, force=true)
+save_config!(config::CthulhuConfig=CONFIG)
 ```
 Save a Cthulhu.jl configuration `config` (by default, `Cthulhu.CONFIG`) to your
 `LocalPreferences.toml` file using Preferences.jl.
@@ -21,8 +21,7 @@ julia> Cthulhu.CONFIG.debuginfo = :none     # Customize some defaults
 julia> Cthulhu.save_config!(Cthulhu.CONFIG) # Will be automatically read next time you `using Cthulhu`
 ```
 """
-function save_config!(config::CthulhuConfig=CONFIG, force=true)
-    cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
+function save_config!(config::CthulhuConfig=CONFIG)
     @set_preferences!(
         "enable_highlighter" => config.enable_highlighter,
         "highlighter" => config.highlighter.exec,
@@ -36,22 +35,20 @@ function save_config!(config::CthulhuConfig=CONFIG, force=true)
         "with_effects" => config.with_effects,
         "inline_cost" => config.inline_cost,
         "type_annotations" => config.type_annotations,
-        force=force
     )
 end
 
 function read_config!(config::CthulhuConfig)
-    cthulhu_id = UUID("f68482b8-f384-11e8-15f7-abe071a5a75f")
-    config.enable_highlighter = load_preference(cthulhu_id, "enable_highlighter", config.enable_highlighter)
-    config.highlighter = Cmd(load_preference(cthulhu_id, "highlighter", config.highlighter))
-    config.asm_syntax = Symbol(load_preference(cthulhu_id, "asm_syntax", config.asm_syntax))
-    config.dead_code_elimination = load_preference(cthulhu_id, "dead_code_elimination", config.dead_code_elimination)
-    config.pretty_ast = load_preference(cthulhu_id, "pretty_ast", config.pretty_ast)
-    config.debuginfo = Symbol(load_preference(cthulhu_id, "debuginfo", config.debuginfo))
-    config.optimize = load_preference(cthulhu_id, "optimize", config.optimize)
-    config.iswarn = load_preference(cthulhu_id, "iswarn", config.iswarn)
-    config.remarks = load_preference(cthulhu_id, "remarks", config.remarks)
-    config.with_effects = load_preference(cthulhu_id, "with_effects", config.with_effects)
-    config.inline_cost = load_preference(cthulhu_id, "inline_cost", config.inline_cost)
-    config.type_annotations = load_preference(cthulhu_id, "type_annotations", config.type_annotations)
+    config.enable_highlighter = @load_preference("enable_highlighter", config.enable_highlighter)
+    config.highlighter = Cmd(@load_preference("highlighter", config.highlighter))
+    config.asm_syntax = Symbol(@load_preference("asm_syntax", config.asm_syntax))
+    config.dead_code_elimination = @load_preference("dead_code_elimination", config.dead_code_elimination)
+    config.pretty_ast = @load_preference("pretty_ast", config.pretty_ast)
+    config.debuginfo = Symbol(@load_preference("debuginfo", config.debuginfo))
+    config.optimize = @load_preference("optimize", config.optimize)
+    config.iswarn = @load_preference("iswarn", config.iswarn)
+    config.remarks = @load_preference("remarks", config.remarks)
+    config.with_effects = @load_preference("with_effects", config.with_effects)
+    config.inline_cost = @load_preference("inline_cost", config.inline_cost)
+    config.type_annotations = @load_preference("type_annotations", config.type_annotations)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -898,3 +898,21 @@ let
     inferred = interp.unopt[mi]
     @test inferred.rt === Core.Const(1)
 end
+
+## --- Test loading and saving of preferences
+
+@testset "preferences" begin
+    # Test that load and save are able to set state
+    Cthulhu.CONFIG.enable_highlighter = true
+    Cthulhu.CONFIG.debuginfo = :none
+    Cthulhu.save_config!(Cthulhu.CONFIG)
+
+    Cthulhu.CONFIG.enable_highlighter = false
+    Cthulhu.CONFIG.debuginfo = :compact
+    @test Cthulhu.CONFIG.debuginfo == :compact
+    @test !Cthulhu.CONFIG.enable_highlighter
+
+    Cthulhu.read_config!(Cthulhu.CONFIG)
+    @test Cthulhu.CONFIG.debuginfo == :none
+    @test Cthulhu.CONFIG.enable_highlighter
+end


### PR DESCRIPTION
This PR (1) allows the default state of various toggles in `@descend`/`_descend` to be set in `Cthulhu.CONFIG` and (2) allows that configuration to be persistently saved between sessions using Preferences.jl

Example:
```
using Cthulhu

# Customize some defaults
Cthulhu.CONFIG.enable_highlighter = true
Cthulhu.CONFIG.debuginfo = :none

# Save to LocalPreferences.toml using Preferences.jl
# Will be automatically read next time you `using Cthulhu`
Cthulhu.save_config!(Cthulhu.CONFIG)
```