### PR TITLE
Refactor Cthulhu to allow custom callinfo for external packages

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -310,7 +310,7 @@ function lookup_optimized(interp::CthulhuInterpreter, mi::MethodInstance, allow_
         error("couldn't find the source; inspect `Main.interp` and `Main.mi`")
     end
     effects = get_effects(codeinst)
-    return (; src, rt, infos, slottypes, codeinf, effects)
+    return (; src, rt, infos, slottypes, effects, codeinf)
 end
 
 function lookup_unoptimized(interp::CthulhuInterpreter, mi::MethodInstance)
@@ -322,11 +322,8 @@ function lookup_unoptimized(interp::CthulhuInterpreter, mi::MethodInstance)
     if isnothing(slottypes)
         slottypes = Any[ Any for i = 1:length(src.slotflags) ]
     end
-    return (; src, rt, infos, slottypes, codeinf, effects)
+    return (; src, rt, infos, slottypes, effects, codeinf)
 end
-
-_descend(term::AbstractTerminal, interp::AbstractInterpreter, mi::MethodInstance; kwargs...) =
-    _descend(term, interp, AbstractCursor(interp, mi); kwargs...)
 
 ##
 # _descend is the main driver function.
@@ -426,7 +423,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, curs::Abst
                     end
                 end
             end
-            (; src, rt, infos, slottypes, codeinf, effects) = lookup(interp, curs, optimize)
+            (; src, rt, infos, slottypes, effects, codeinf) = lookup(interp, curs, optimize)
         end
         mi = get_mi(curs)
         src = preprocess_ci!(src, mi, optimize, CONFIG)
@@ -659,6 +656,9 @@ function mkinterp(interp::AbstractInterpreter, @nospecialize(args...))
 end
 
 mkinterp(@nospecialize(args...); interp::AbstractInterpreter=NativeInterpreter()) = mkinterp(interp, args...)
+
+_descend(term::AbstractTerminal, interp::AbstractInterpreter, mi::MethodInstance; kwargs...) =
+    _descend(term, interp, AbstractCursor(interp, mi); kwargs...)
 
 function _descend(@nospecialize(args...);
                   interp::AbstractInterpreter=NativeInterpreter(), kwargs...)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -628,7 +628,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, curs::Abst
     end
 end
 _descend(interp::AbstractInterpreter, mi::MethodInstance; terminal=default_terminal(), kwargs...) =
-    _descend(default_terminal(), interp, mi; kwargs...)
+    _descend(terminal, interp, mi; kwargs...)
 
 function do_typeinf!(interp::AbstractInterpreter, mi::MethodInstance)
     result = InferenceResult(mi)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -83,6 +83,7 @@ include("reflection.jl")
 include("ui.jl")
 include("codeview.jl")
 include("backedges.jl")
+include("interface.jl")
 
 export descend, @descend, descend_code_typed, descend_code_warntype, @descend_code_typed, @descend_code_warntype
 export ascend
@@ -210,6 +211,8 @@ function _descend_with_error_handling(@nospecialize(f), @nospecialize(argtypes =
     end
     __descend_with_error_handling(tt; kwargs...)
 end
+_descend_with_error_handling(mi::MethodInstance; kwargs...) =
+    __descend_with_error_handling(mi; kwargs...)
 _descend_with_error_handling(@nospecialize(tt::Type{<:Tuple}); kwargs...) =
     __descend_with_error_handling(tt; kwargs...)
 _descend_with_error_handling(interp::AbstractInterpreter, mi::MethodInstance; kwargs...) =
@@ -237,18 +240,7 @@ Shortcut for [`descend_code_typed`](@ref).
 """
 const descend = descend_code_typed
 
-function descend_code_typed(mi::MethodInstance; terminal=default_terminal(), kwargs...)
-    interp = Cthulhu.CthulhuInterpreter()
-    Cthulhu.do_typeinf!(interp, mi)
-    _descend(terminal, interp, mi; iswarn=false, interruptexc=false, kwargs...)
-end
-function descend_code_warntype(mi::MethodInstance; terminal=default_terminal(), kwargs...)
-    interp = Cthulhu.CthulhuInterpreter()
-    Cthulhu.do_typeinf!(interp, mi)
-    _descend(terminal, interp, mi; iswarn=true, interruptexc=false, kwargs...)
-end
-
-descend(interp::CthulhuInterpreter, mi::MethodInstance; kwargs...) = _descend(interp, mi; iswarn=false, interruptexc=false, kwargs...)
+descend(interp::AbstractInterpreter, mi::MethodInstance; kwargs...) = _descend(interp, mi; iswarn=false, interruptexc=false, kwargs...)
 
 function codeinst_rt(code::CodeInstance)
     rettype = code.rettype
@@ -332,13 +324,18 @@ function lookup_unoptimized(interp::CthulhuInterpreter, mi::MethodInstance)
     end
     return (; src, rt, infos, slottypes, codeinf, effects)
 end
+lookup(interp::CthulhuInterpreter, curs::CthulhuCursor, optimize::Bool; allow_no_src::Bool=false) =
+    lookup(interp, curs.mi, optimize; allow_no_src)
+
+_descend(term::AbstractTerminal, interp::AbstractInterpreter, mi::MethodInstance; kwargs...) =
+    _descend(term, interp, AbstractCursor(interp, mi); kwargs...)
 
 ##
 # _descend is the main driver function.
 # src/reflection.jl has the tools to discover methods
 # src/ui.jl provides the user facing interface to which _descend responds
 ##
-function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::MethodInstance;
+function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, curs::AbstractCursor;
     override::Union{Nothing,InferenceResult} = nothing,
     debuginfo::Union{Symbol,DebugInfo}       = CONFIG.debuginfo,                     # default is compact debuginfo
     optimize::Bool                           = CONFIG.optimize,                      # default is true
@@ -407,6 +404,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
             end
         else
             if optimize
+                mi = get_mi(curs)
                 codeinst = interp.opt[mi]
                 if codeinst.inferred === nothing
                     if isdefined(codeinst, :rettype_const)
@@ -430,15 +428,16 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                     end
                 end
             end
-            (; src, rt, infos, slottypes, codeinf, effects) = lookup(interp, mi, optimize)
+            (; src, rt, infos, slottypes, codeinf, effects) = lookup(interp, curs, optimize)
         end
-        src = preprocess_ci!(src, mi, optimize, CONFIG)
+        src = preprocess_ci!(src, get_mi(curs), optimize, CONFIG)
         if optimize # optimization might have deleted some statements
             infos = src.stmts.info
         else
             @assert length(src.code) == length(infos)
         end
-        callsites = find_callsites(interp, src, infos, mi, slottypes, optimize)
+        callsites = find_callsites(interp, src, infos, get_mi(curs), slottypes, optimize)
+        mi = get_mi(curs)
 
         if display_CI
             _remarks = remarks ? get(interp.remarks, mi, nothing) : nothing
@@ -539,12 +538,12 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
             end
 
             # recurse
-            next_mi = get_mi(callsite)::Union{MethodInstance,Nothing}
-            if next_mi === nothing
+            next_cursor = navigate(curs, callsite)::Union{AbstractCursor,Nothing}
+            if next_cursor === nothing
                 continue
             end
 
-            _descend(term, interp, next_mi;
+            _descend(term, interp, next_cursor;
                      override = isa(info, ConstPropCallInfo) ? info.result : nothing, debuginfo,
                      optimize, interruptexc,
                      iswarn, hide_type_stable,
@@ -605,6 +604,9 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
                 revise()
                 mi = get_specialization(mi.specTypes)::MethodInstance
                 do_typeinf!(interp, mi)
+                curs = update_mi(curs, mi)
+            else
+                @warn "Failed to load Revise."
             end
         elseif toggle === :edit
             edit(whereis(mi.def::Method)...)
@@ -625,10 +627,10 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, mi::Method
         println(iostream)
     end
 end
-_descend(interp::CthulhuInterpreter, mi::MethodInstance; kwargs...) =
-    _descend(default_terminal(), interp::CthulhuInterpreter, mi::MethodInstance; kwargs...)
+_descend(interp::AbstractInterpreter, mi::MethodInstance; terminal=default_terminal(), kwargs...) =
+    _descend(default_terminal(), interp, mi; kwargs...)
 
-function do_typeinf!(interp::CthulhuInterpreter, mi::MethodInstance)
+function do_typeinf!(interp::AbstractInterpreter, mi::MethodInstance)
     result = InferenceResult(mi)
     # we may want to handle the case when `InferenceState(...)` returns `nothing`,
     # which indicates code generation of a `@generated` has been failed,
@@ -663,12 +665,20 @@ mkinterp(@nospecialize(args...); interp::AbstractInterpreter=NativeInterpreter()
 function _descend(@nospecialize(args...);
                   interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
     (interp′, mi) = mkinterp(interp, args...)
-    _descend(interp′, mi; kwargs...)
+    _descend(interp′, mi; interruptexc=false, kwargs...)
 end
+
+function _descend(term::AbstractTerminal, mi::MethodInstance;
+    interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
+    interp′ = Cthulhu.CthulhuInterpreter(interp)
+    Cthulhu.do_typeinf!(interp′, mi)
+    _descend(term, interp′, mi; interruptexc=false, kwargs...)
+end
+
 function _descend(term::AbstractTerminal, @nospecialize(args...);
                   interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
     (interp′, mi) = mkinterp(interp, args...)
-    _descend(term, interp′, mi; kwargs...)
+    _descend(term, interp′, mi; interruptexc=false, kwargs...)
 end
 
 descend_code_typed(b::Bookmark; kw...) =

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -410,7 +410,7 @@ function _descend(term::AbstractTerminal, interp::CthulhuInterpreter, curs::Abst
     end
     while true
         if override !== nothing
-            (; src, rt, infos, slottypes, codeinf, effects) = lookup_constproped(interp, curs, optimize)
+            (; src, rt, infos, slottypes, codeinf, effects) = lookup_constproped(interp, curs, override, optimize)
         else
             if optimize
                 mi = get_mi(curs)

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -313,6 +313,60 @@ function show_callinfo(limiter, (; vmi)::ReturnTypeCallInfo)
     end
 end
 
+function print_callsite_info(limiter::IO, info::WrappedCallInfo)
+    wrapped_callinfo(limiter, info)
+    show_callinfo(limiter, ignorewrappers(info))
+end
+
+function print_callsite_info(limiter::IO, info::PureCallInfo)
+    print(limiter, " = < pure > ")
+    show_callinfo(limiter, info)
+end
+
+function print_callsite_info(limiter::IO, info::Union{MultiCallInfo, FailedCallInfo, GeneratedCallInfo})
+    print(limiter, " = call ")
+    show_callinfo(limiter, info)
+end
+
+function print_callsite_info(limiter::IO, info::TaskCallInfo)
+    print(limiter, " = task < ")
+    show_callinfo(limiter, info.ci)
+    print(limiter, " >")
+end
+
+function print_callsite_info(limiter::IO, info::InvokeCallInfo)
+    print(limiter, " = invoke < ")
+    show_callinfo(limiter, info.ci)
+    print(limiter, " >")
+end
+
+function print_callsite_info(limiter::IO, info::ReturnTypeCallInfo)
+    print(limiter, " = return_type < ")
+    show_callinfo(limiter, info)
+    print(limiter, " >")
+end
+
+function print_callsite_info(limiter::IO, info::CuCallInfo)
+    print(limiter, " = cucall < ")
+    show_callinfo(limiter, info.cumi)
+    print(limiter, " >")
+end
+
+function print_callsite_info(limiter::IO, info::ConstPropCallInfo)
+    print(limiter, " = < constprop > ")
+    show_callinfo(limiter, info)
+end
+
+function print_callsite_info(limiter::IO, info::ConcreteCallInfo)
+    print(limiter, " = < concrete eval > ")
+    show_callinfo(limiter, info)
+end
+
+function print_callsite_info(limiter::IO, info::OCCallInfo)
+    print(limiter, " = < opaque closure call > ")
+    show_callinfo(limiter, info.ci)
+end
+
 function Base.show(io::IO, c::Callsite)
     limit = get(io, :limit, false)::Bool
     cols = limit ? (displaysize(io)::Tuple{Int,Int})[2] : typemax(Int)
@@ -336,44 +390,8 @@ function Base.show(io::IO, c::Callsite)
     if isa(info, MICallInfo)
         optimize ? print(limiter, string(" = ", c.head, ' ')) : print(limiter, " = ")
         show_callinfo(limiter, info)
-    elseif isa(info, WrappedCallInfo)
-        wrapped_callinfo(limiter, info)
-        show_callinfo(limiter, ignorewrappers(info))
-    elseif isa(info, PureCallInfo)
-        print(limiter, " = < pure > ")
-        show_callinfo(limiter, info)
-    elseif info isa MultiCallInfo
-        print(limiter, " = call ")
-        show_callinfo(limiter, info)
-    elseif info isa FailedCallInfo ||
-           info isa GeneratedCallInfo
-        print(limiter, " = call ")
-        show_callinfo(limiter, info)
-    elseif info isa TaskCallInfo
-        print(limiter, " = task < ")
-        show_callinfo(limiter, info.ci)
-        print(limiter, " >")
-    elseif info isa InvokeCallInfo
-        print(limiter, " = invoke < ")
-        show_callinfo(limiter, info.ci)
-        print(limiter, " >")
-    elseif isa(info, ReturnTypeCallInfo)
-        print(limiter, " = return_type < ")
-        show_callinfo(limiter, info)
-        print(limiter, " >")
-    elseif isa(info, CuCallInfo)
-        print(limiter, " = cucall < ")
-        show_callinfo(limiter, info.cumi)
-        print(limiter, " >")
-    elseif isa(info, ConstPropCallInfo)
-        print(limiter, " = < constprop > ")
-        show_callinfo(limiter, info)
-    elseif isa(info, ConcreteCallInfo)
-        print(limiter, " = < concrete eval > ")
-        show_callinfo(limiter, info)
-    elseif isa(info, OCCallInfo)
-        print(limiter, " = < opaque closure call > ")
-        show_callinfo(limiter, info.ci)
+    else
+        print_callsite_info(limiter, info)
     end
     return
 end

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -108,7 +108,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
     src::Union{CodeInfo,IRCode}, @nospecialize(rt), mi::Union{Nothing,MethodInstance};
     iswarn::Bool=false, hide_type_stable::Bool=false,
     remarks::Union{Nothing,Remarks}=nothing, inline_cost::Bool=false,
-    type_annotations::Bool=true, interp::CthulhuInterpreter=CthulhuInterpreter())
+    type_annotations::Bool=true, interp::AbstractInterpreter=CthulhuInterpreter())
 
     debuginfo = IRShow.debuginfo(debuginfo)
     lineprinter = __debuginfo[debuginfo]

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -3,6 +3,7 @@
 
 Required overloads:
 - `Cthulhu.lookup(interp::AbstractInterpreter, curs::AbstractCursor, optimize::Bool)`
+- `Cthulhu.lookup_constproped(interp::AbstractInterpreter, curs::AbstractCursor, override::InferenceResult, optimize::Bool)`
 - `Cthulhu.get_mi(curs::AbstractCursor) -> MethodInstance`
 - `Cthulhu.update_cursor(curs::AbstractCursor, mi::MethodInstance)`
 - `Cthulhu.navigate(curs::AbstractCursor, callsite::Callsite) -> AbstractCursor`
@@ -14,10 +15,17 @@ end
 
 lookup(interp::AbstractInterpreter, curs::AbstractCursor, optimize::Bool) = error("""
 missing `$AbstractCursor` API:
-`$(typeof(curs))` is required to implement the `$lookup(::$(typeof(interp)), ::$(typeof(curs)), optimize::Bool)` interface.
+`$(typeof(curs))` is required to implement the `$lookup(::$(typeof(interp)), ::$(typeof(curs)), ::Bool)` interface.
 """)
 lookup(interp::CthulhuInterpreter, curs::CthulhuCursor, optimize::Bool) =
     lookup(interp, get_mi(curs), optimize)
+
+lookup_constproped(interp::AbstractInterpreter, curs::AbstractCursor, override::InferenceResult, optimize::Bool) = error("""
+missing `$AbstractCursor` API:
+`$(typeof(curs))` is required to implement the `$lookup_constproped(::$(typeof(interp)), ::$(typeof(curs)), ::InferenceResult, ::Bool)` interface.
+""")
+lookup_constproped(interp::CthulhuInterpreter, ::CthulhuCursor, override::InferenceResult, optimize::Bool) =
+    lookup_constproped(interp, override, optimize)
 
 get_mi(curs::AbstractCursor) = error("""
 missing `$AbstractCursor` API:

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -3,19 +3,16 @@ struct CthulhuCursor <: AbstractCursor
     mi::MethodInstance
 end
 
-function update_mi(curs::CthulhuCursor, mi::MethodInstance)
-    CthulhuCursor(mi)
-end
+update_mi(curs::AbstractCursor, ::MethodInstance) = error("""
+missing `$AbstractCursor` API:
+`$(typeof(curs))` is required to implement the `$update_mi(::$(typeof(curs)), ::MethodInstance) -> $(typeof(curs))` interface.
+""")
+update_mi(curs::CthulhuCursor, mi::MethodInstance) = CthulhuCursor(mi)
 
 # This method is optional, but should be implemented if there is
 # a sensible default cursor for a MethodInstance
-AbstractCursor(interp::CthulhuInterpreter, mi::MethodInstance) =
+AbstractCursor(interp::AbstractInterpreter, mi::MethodInstance) =
     CthulhuCursor(mi)
-
-function get_optimized_code(interp::CthulhuInterpreter,
-                                curs::CthulhuCursor)
-    return interp.opt[curs.mi].inferred
-end
 
 get_mi(curs::CthulhuCursor) = curs.mi
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,33 +1,49 @@
+"""
+    AbstractCursor
+
+Required overloads:
+- `Cthulhu.lookup(interp::AbstractInterpreter, curs::AbstractCursor, optimize::Bool)`
+- `Cthulhu.get_mi(curs::AbstractCursor) -> MethodInstance`
+- `Cthulhu.update_cursor(curs::AbstractCursor, mi::MethodInstance)`
+- `Cthulhu.navigate(curs::AbstractCursor, callsite::Callsite) -> AbstractCursor`
+"""
 abstract type AbstractCursor; end
 struct CthulhuCursor <: AbstractCursor
     mi::MethodInstance
 end
 
-update_mi(curs::AbstractCursor, ::MethodInstance) = error("""
+lookup(interp::AbstractInterpreter, curs::AbstractCursor, optimize::Bool) = error("""
 missing `$AbstractCursor` API:
-`$(typeof(curs))` is required to implement the `$update_mi(::$(typeof(curs)), ::MethodInstance) -> $(typeof(curs))` interface.
+`$(typeof(curs))` is required to implement the `$lookup(::$(typeof(interp)), ::$(typeof(curs)), optimize::Bool)` interface.
 """)
-update_mi(curs::CthulhuCursor, mi::MethodInstance) = CthulhuCursor(mi)
+lookup(interp::CthulhuInterpreter, curs::CthulhuCursor, optimize::Bool) =
+    lookup(interp, get_mi(curs), optimize)
+
+get_mi(curs::AbstractCursor) = error("""
+missing `$AbstractCursor` API:
+`$(typeof(curs))` is required to implement the `$get_mi(::$(typeof(curs))) -> MethodInstance` interface.
+""")
+get_mi(curs::CthulhuCursor) = curs.mi
+
+update_cursor(curs::AbstractCursor, ::MethodInstance) = error("""
+missing `$AbstractCursor` API:
+`$(typeof(curs))` is required to implement the `$update_cursor(::$(typeof(curs)), ::MethodInstance) -> $(typeof(curs))` interface.
+""")
+update_cursor(curs::CthulhuCursor, mi::MethodInstance) = CthulhuCursor(mi)
+
+navigate(curs::AbstractCursor, callsite::Callsite) = error("""
+missing `$AbstractCursor` API:
+`$(typeof(curs))` is required to implement the `$navigate(::$(typeof(curs)), ::Callsite) -> AbstractCursor` interface.
+""")
+function navigate(curs::CthulhuCursor, callsite::Callsite)
+    CthulhuCursor(get_mi(callsite))
+end
 
 # This method is optional, but should be implemented if there is
 # a sensible default cursor for a MethodInstance
 AbstractCursor(interp::AbstractInterpreter, mi::MethodInstance) =
     CthulhuCursor(mi)
 
-get_mi(curs::CthulhuCursor) = curs.mi
-
-function get_remarks(interp::CthulhuInterpreter, curs::CthulhuCursor)
-    get(interp.remarks, mi, nothing)
-end
-
 function get_effects(interp::CthulhuInterpreter, mi::MethodInstance, opt::Bool)
     get_effects(opt ? interp.opt : interp.unopt, mi)
-end
-
-function navigate(curs::AbstractCursor, callsite)
-    typeof(curs)(get_mi(callsite))
-end
-
-function can_descend(interp::CthulhuInterpreter, key, optimize::Bool)
-    haskey(optimize ? interp.opt : interp.unopt, key)
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,0 +1,36 @@
+abstract type AbstractCursor; end
+struct CthulhuCursor <: AbstractCursor
+    mi::MethodInstance
+end
+
+function update_mi(curs::CthulhuCursor, mi::MethodInstance)
+    CthulhuCursor(mi)
+end
+
+# This method is optional, but should be implemented if there is
+# a sensible default cursor for a MethodInstance
+AbstractCursor(interp::CthulhuInterpreter, mi::MethodInstance) =
+    CthulhuCursor(mi)
+
+function get_optimized_code(interp::CthulhuInterpreter,
+                                curs::CthulhuCursor)
+    return interp.opt[curs.mi].inferred
+end
+
+get_mi(curs::CthulhuCursor) = curs.mi
+
+function get_remarks(interp::CthulhuInterpreter, curs::CthulhuCursor)
+    get(interp.remarks, mi, nothing)
+end
+
+function get_effects(interp::CthulhuInterpreter, mi::MethodInstance, opt::Bool)
+    get_effects(opt ? interp.opt : interp.unopt, mi)
+end
+
+function navigate(curs::AbstractCursor, callsite)
+    typeof(curs)(get_mi(callsite))
+end
+
+function can_descend(interp::CthulhuInterpreter, key, optimize::Bool)
+    haskey(optimize ? interp.opt : interp.unopt, key)
+end

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -1,4 +1,4 @@
-using Core.Compiler: AbstractInterpreter, NativeInterpreter, InferenceState,
+import Core.Compiler: AbstractInterpreter, NativeInterpreter, InferenceState,
     OptimizationState, CodeInfo, CodeInstance, InferenceResult, WorldRange,
     IRCode, SSAValue, inlining_policy
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -107,8 +107,8 @@ function find_callsites(interp::AbstractInterpreter, CI::Union{Core.CodeInfo, IR
     return callsites
 end
 
-function process_info(interp, @nospecialize(info), argtypes::ArgTypes, @nospecialize(rt), optimize::Bool)
-    is_cached(@nospecialize(key)) = can_descend(interp, key, optimize)
+function process_info(interp::AbstractInterpreter, @nospecialize(info), argtypes::ArgTypes, @nospecialize(rt), optimize::Bool)
+    is_cached(@nospecialize(key)) = haskey(optimize ? interp.opt : interp.unopt, key)
     process_recursive(@nospecialize(newinfo)) = process_info(interp, newinfo, argtypes, rt, optimize)
 
     if isa(info, MethodResultPure)


### PR DESCRIPTION
This is intended to allow Diffactor to provide a Cthulhu interfaces
for navigating between different differentiation levels. The core
interface is the introduction of `Cthulhu.AbstractCursor`, which
downstream packages can extend to provide additional information
beyond an mi to identify the frame that's currently being displayed.
These interfaces will probably need to evolve a bit, but I think this
is a reasonable start.

Also strengthen the tests a bit to make failures more obvious and
easier to debug.