### PR TITLE
make `remarks` feature respect constprop' and DCE

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -474,7 +474,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
         callsites = find_callsites(interp, src, infos, mi, slottypes, optimize)
 
         if display_CI
-            _remarks = remarks ? get_remarks(interp, mi) : nothing
+            pc2remarks = remarks ? get_remarks(interp, override !== nothing ? override : mi) : nothing
             if with_effects
                 printstyled(IOContext(iostream, :limit=>true), '[', effects, ']', mi.def, '\n'; bold=true)
             else
@@ -483,13 +483,13 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
             if debuginfo == DInfo.compact
                 str = let debuginfo=debuginfo, src=src, codeinf=codeinf, rt=rt, mi=mi,
                           iswarn=iswarn, hide_type_stable=hide_type_stable,
-                          remarks=_remarks, inline_cost=inline_cost, type_annotations=type_annotations
+                          pc2remarks=pc2remarks, inline_cost=inline_cost, type_annotations=type_annotations
                     ioctx = IOContext(iostream, :color=>true, :displaysize=>displaysize(iostream)) # displaysize doesn't propagate otherwise
                     stringify(ioctx) do io
                         lambda_io = IOContext(io, :SOURCE_SLOTNAMES => Base.sourceinfo_slotnames(codeinf))
                         cthulhu_typed(lambda_io, debuginfo, src, rt, mi;
                                       iswarn, hide_type_stable,
-                                      remarks, inline_cost, type_annotations,
+                                      pc2remarks, inline_cost, type_annotations,
                                       interp)
                     end
                 end
@@ -503,7 +503,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
                 lambda_io = IOContext(iostream, :SOURCE_SLOTNAMES => Base.sourceinfo_slotnames(codeinf))
                 cthulhu_typed(lambda_io, debuginfo, src, rt, mi;
                               iswarn, hide_type_stable,
-                              remarks=_remarks, inline_cost, type_annotations,
+                              pc2remarks, inline_cost, type_annotations,
                               interp)
             end
             view_cmd = cthulhu_typed

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -61,8 +61,8 @@ missing `$AbstractCursor` API:
 """)
 navigate(curs::CthulhuCursor, callsite::Callsite) = CthulhuCursor(get_mi(callsite))
 
-get_remarks(::AbstractInterpreter, ::MethodInstance) = nothing
-get_remarks(interp::CthulhuInterpreter, mi::MethodInstance) = get(interp.remarks, mi, nothing)
+get_remarks(::AbstractInterpreter, ::Union{MethodInstance,InferenceResult}) = nothing
+get_remarks(interp::CthulhuInterpreter, key::Union{MethodInstance,InferenceResult}) = get(interp.remarks, key, nothing)
 
 # This method is optional, but should be implemented if there is
 # a sensible default cursor for a MethodInstance


### PR DESCRIPTION
This requires JuliaLang/julia#46554.

```julia
using Cthulhu

Base.@constprop :none invokesin(x) = sin(x)

function constprop_remarks(cnd, x)
    if cnd
        v = sin(x), invokesin(x)
    else
        v, w = invokesin(x), sin(x)
    end
    println(v)
    return v
end

descend(; optimize=false, remarks=true) do
    constprop_remarks(false, 42)
end
```

> before (pretty much confused)
```
∘ ─ %0 = invoke constprop_remarks(::Bool,::Int64)::Float64
    @ REPL[3]:2 within `constprop_remarks`
1 ─      Core.NewvarNode(:(w))::Any
│        Core.NewvarNode(:(v))::Any
└──      goto #2
    @ REPL[3]:5 within `constprop_remarks`
2 ─ %4 = Main.invokesin(x)::Float64 [constprop] Disabled by argument and rettype heuristics
│   %5 = Main.sin(x)::Core.Const(-0.9165215479156338) [constprop] Disabled by method parameter
│        (v = %4)::Float64
│        (w = %5)::Core.Const(-0.9165215479156338)
│   @ REPL[3]:7 within `constprop_remarks`
│        Main.println(v)::Any [constprop] Disabled by method parameter
│   @ REPL[3]:8 within `constprop_remarks`
└──      return v
```

> after
```
∘ ─ %0 = invoke constprop_remarks(::Bool,::Int64)::Float64
    @ none:2 within `constprop_remarks`
1 ─      Core.NewvarNode(:(w))::Any
│        Core.NewvarNode(:(v))::Any
└──      goto #2
    @ none:5 within `constprop_remarks`
2 ─ %4 = Main.invokesin(x)::Float64 [constprop] Disabled by method parameter
│   %5 = Main.sin(x)::Core.Const(-0.9165215479156338)
│        (v = %4)::Float64
│        (w = %5)::Core.Const(-0.9165215479156338)
│   @ none:7 within `constprop_remarks`
│        Main.println(v)::Any Call result type was widened because the return value is unused [constprop] Disabled by argument and rettype heuristics
│   @ none:8 within `constprop_remarks`
└──      return v
```