### PR TITLE
show effects per statement

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -482,8 +482,8 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
                           iswarn=iswarn, hide_type_stable=hide_type_stable,
                           pc2remarks=pc2remarks, pc2effects=pc2effects, inline_cost=inline_cost, type_annotations=type_annotations
                     ioctx = IOContext(iostream,
-                        :color=>true,
-                        :displaysize=>displaysize(iostream), # displaysize doesn't propagate otherwise
+                        :color => true,
+                        :displaysize => displaysize(iostream), # displaysize doesn't propagate otherwise
                         :SOURCE_SLOTNAMES => Base.sourceinfo_slotnames(codeinf),
                         :with_effects => with_effects)
                     stringify(ioctx) do lambda_io

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -64,6 +64,9 @@ navigate(curs::CthulhuCursor, callsite::Callsite) = CthulhuCursor(get_mi(callsit
 get_remarks(::AbstractInterpreter, ::Union{MethodInstance,InferenceResult}) = nothing
 get_remarks(interp::CthulhuInterpreter, key::Union{MethodInstance,InferenceResult}) = get(interp.remarks, key, nothing)
 
+get_effects(::AbstractInterpreter, ::Union{MethodInstance,InferenceResult}) = nothing
+get_effects(interp::CthulhuInterpreter, key::Union{MethodInstance,InferenceResult}) = get(interp.effects, key, nothing)
+
 # This method is optional, but should be implemented if there is
 # a sensible default cursor for a MethodInstance
 AbstractCursor(interp::AbstractInterpreter, mi::MethodInstance) = CthulhuCursor(mi)

--- a/test/irshow.jl
+++ b/test/irshow.jl
@@ -19,7 +19,7 @@ end
     tf = (true, false)
 
     @testset "optimize: $optimize" for optimize in tf
-        _, src, infos, mi, rt, slottypes = process(m.foo, (Int, Int); optimize);
+        (; src, infos, mi, rt, effects, slottypes) = cthulhu_info(m.foo, (Int, Int); optimize);
 
         @testset "debuginfo: $debuginfo" for debuginfo in instances(Cthulhu.DInfo.DebugInfo)
             @testset "iswarn: $iswarn" for iswarn in tf
@@ -31,7 +31,7 @@ end
 
                             s = sprint(; context=:color=>true) do io
                                 Cthulhu.cthulhu_typed(io, debuginfo,
-                                                      src, rt, mi;
+                                                      src, rt, effects, mi;
                                                       iswarn, hide_type_stable, inline_cost, type_annotations)
                             end
                             s = strip_base_linenums(s)


### PR DESCRIPTION
This allows us to see effects on builtin calls, `:foreigncall`s, `GotoNode`/`GotoIfNot`.
Also tweaked the effects printing, mostly showing them after return types.

Requires JuliaLang/julia#46574

E.g.:
```julia
julia> descend(; optimize=false, with_effects=true, debuginfo=:none) do
           a = Int[]
           push!(a, 42)
           length(a)
       end
(::var"#27#28")() @ Main none:2
Variables
  #self#::Core.Const(var"#27#28"())
  a::Vector{Int64}

∘ ─ %0 = invoke #27()::Int64 (!c,!e,!n,!t,!s,!m)
1 ─      (a = Base.getindex(Main.Int))::Vector{Int64} (?c,+e,+n,+t,+s,+m) [constprop] Disabled by argument and rettype heuristics
│        Main.push!(a, 42)::Any (!c,!e,!n,!t,!s,!m) Call result type was widened because the return value is unused
│   %3 = Main.length(a)::Int64 (!c,+e,+n,+t,+s,+m) [constprop] Disabled by argument and rettype heuristics
└──      return %3
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [e]ffects, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
   %1 = getindex(::Type{Int64})::Vector{Int64} (?c,+e,+n,+t,+s,+m)
 • %2 = < constprop > push!(::Vector{Int64},::Core.Const(42))::Any (!c,!e,!n,!t,!s,!m)
   %3 = length(::Vector{Int64})::Int64 (!c,+e,+n,+t,+s,+m)
   ↩
push!(a::Vector{T}, item) where T @ Base array.jl:1046
Variables
  #self#::Core.Const(push!)
  a::Vector{Int64}
  item::Core.Const(42)
  val::Int64
  itemT::Int64

∘ ─ %0 = invoke push!(::Vector{Int64},::Int64)::Vector{Int64} (!c,!e,!n,!t,!s,!m)
1 ─      (itemT = Base.convert($(Expr(:static_parameter, 1)), item))::Core.Const(42) (+c,+e,+n,+t,+s,+m)
│        Base._growend!(a, 1)::Any (!c,!e,!n,!t,!s,!m) Call result type was widened because the return value is unused
│        nothing::Core.Const(nothing)
│   %4 = itemT::Core.Const(42)
│   %5 = Base.lastindex(a)::Int64 (!c,+e,+n,+t,+s,+m) [constprop] Disabled by argument and rettype heuristics
│        Base.setindex!(a, %4, %5)::Any (!c,?e,!n,+t,+s,?m) Call result type was widened because the return value is unused [constprop] Disabled by function heuristic
│        (val = itemT::Core.Const(42))::Core.Const(42)
│        nothing::Core.Const(nothing)
│        val::Core.Const(42)
└──      return a
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [e]ffects, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
   %1 = < concrete eval > convert(::Core.Const(Int64),::Core.Const(42))::Core.Const(42) (+c,+e,+n,+t,+s,+m)
 • %2 = < constprop > _growend!(::Vector{Int64},::Core.Const(1))::Any (!c,!e,!n,!t,!s,!m)
   %5 = lastindex(::Vector{Int64})::Int64 (!c,+e,+n,+t,+s,+m)
   %6 = setindex!(::Vector{Int64},::Int64,::Int64)::Any (!c,?e,!n,+t,+s,?m)
   ↩
_growend!(a::Vector, delta::Integer) @ Base array.jl:1002
Variables
  #self#::Core.Const(Base._growend!)
  a::Vector{Int64}
  delta::Core.Const(1)

∘ ─ %0 = invoke _growend!(::Vector{Int64},::Int64)::Core.Const(nothing) (!c,!e,!n,!t,!s,!m)
1 ─ %1 = Base.cconvert(Base.UInt, delta)::Core.Const(0x0000000000000001) (+c,+e,+n,+t,+s,+m)
│   %2 = Base.unsafe_convert(Base.UInt, %1)::Core.Const(0x0000000000000001) (+c,+e,+n,+t,+s,+m)
│   %3 = $(Expr(:foreigncall, :(:jl_array_grow_end), Nothing, svec(Any, UInt64), 0, :(:ccall), :(a), :(%2), :(%1)))::Core.Const(nothing) (!c,!e,!n,!t,!s,!m)
└──      return %3
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [e]ffects, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %1 = < concrete eval > cconvert(::Core.Const(UInt64),::Core.Const(1))::Core.Const(0x0000000000000001) (+c,+e,+n,+t,+s,+m)
   %2 = < concrete eval > unsafe_convert(::Core.Const(UInt64),::Core.Const(0x0000000000000001))::Core.Const(0x0000000000000001) (+c,+e,+n,+t,+s,+m)
   ↩

_growend!(a::Vector, delta::Integer) @ Base array.jl:1002
Variables
  #self#::Core.Const(Base._growend!)
  a::Vector{Int64}
  delta::Core.Const(1)

Body::Core.Const(nothing) (!c,!e,!n,!t,!s,!m)
1 ─ %1 = Base.cconvert(Base.UInt, delta)::Core.Const(0x0000000000000001) (+c,+e,+n,+t,+s,+m)
│   %2 = Base.unsafe_convert(Base.UInt, %1)::Core.Const(0x0000000000000001) (+c,+e,+n,+t,+s,+m)
│   %3 = $(Expr(:foreigncall, :(:jl_array_grow_end), Nothing, svec(Any, UInt64), 0, :(:ccall), :(a), :(%2), :(%1)))::Core.Const(nothing) (!c,!e,!n,!t,!s,!m)
└──      return %3
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [e]ffects, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %1 = < concrete eval > cconvert(::Core.Const(UInt64),::Core.Const(1))::Core.Const(0x0000000000000001) (+c,+e,+n,+t,+s,+m)
   %2 = < concrete eval > unsafe_convert(::Core.Const(UInt64),::Core.Const(0x0000000000000001))::Core.Const(0x0000000000000001) (+c,+e,+n,+t,+s,+m)
   ↩
```