### PR TITLE
add a `[v]iew` config option to always call `edit` on descend/ascend

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -49,6 +49,7 @@ Base.@kwdef mutable struct CthulhuConfig
     with_effects::Bool = false
     inline_cost::Bool = false
     type_annotations::Bool = true
+    always_edit::Bool=false
 end
 
 """
@@ -75,6 +76,7 @@ end
 - `with_effects::Bool` Intial state of "effects" toggle. Defaults to `false`.
 - `inline_cost::Bool` Initial state of "inlining costs" toggle. Defaults to `false`.
 - `type_annotations::Bool` Initial state of "type annnotations" toggle. Defaults to `true`.
+- `always_edit::Bool` Initial state of "always edit" toggle. Defaults to `false`.
 """
 const CONFIG = CthulhuConfig()
 
@@ -416,7 +418,8 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
     remarks::Bool                            = CONFIG.remarks&!CONFIG.optimize,      # default is false
     with_effects::Bool                       = CONFIG.with_effects,                  # default is false
     inline_cost::Bool                        = CONFIG.inline_cost&CONFIG.optimize,   # default is false
-    type_annotations::Bool                   = CONFIG.type_annotations               # default is true
+    type_annotations::Bool                   = CONFIG.type_annotations,               # default is true
+    always_edit::Bool = CONFIG.always_edit  
     )
 
     if isnothing(hide_type_stable)
@@ -488,6 +491,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
             @assert length(src.code) == length(infos)
         end
         callsites = find_callsites(interp, src, infos, mi, slottypes, optimize)
+        always_edit && edit(whereis(mi.def::Method)...)
 
         if display_CI
             pc2remarks = remarks ? get_remarks(interp, override !== nothing ? override : mi) : nothing

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -35,7 +35,7 @@ function save_config!(config::CthulhuConfig=CONFIG)
         "with_effects" => config.with_effects,
         "inline_cost" => config.inline_cost,
         "type_annotations" => config.type_annotations,
-        "always_edit" => config.always_edit,
+        "view_always" => config.view_always,
     )
 end
 
@@ -52,5 +52,5 @@ function read_config!(config::CthulhuConfig)
     config.with_effects = @load_preference("with_effects", config.with_effects)
     config.inline_cost = @load_preference("inline_cost", config.inline_cost)
     config.type_annotations = @load_preference("type_annotations", config.type_annotations)
-    config.always_edit = @load_preference("always_edit", config.always_edit)
+    config.view_always = @load_preference("view_always", config.view_always)
 end

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -35,6 +35,7 @@ function save_config!(config::CthulhuConfig=CONFIG)
         "with_effects" => config.with_effects,
         "inline_cost" => config.inline_cost,
         "type_annotations" => config.type_annotations,
+        "always_edit" => config.always_edit,
     )
 end
 
@@ -51,4 +52,5 @@ function read_config!(config::CthulhuConfig)
     config.with_effects = @load_preference("with_effects", config.with_effects)
     config.inline_cost = @load_preference("inline_cost", config.inline_cost)
     config.type_annotations = @load_preference("type_annotations", config.type_annotations)
+    config.always_edit = @load_preference("always_edit", config.always_edit)
 end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -59,7 +59,7 @@ function stringify(@nospecialize(f), context::IOContext)
 end
 
 const debugcolors = (:nothing, :light_black, :yellow)
-function usage(@nospecialize(view_cmd), optimize, iswarn, hide_type_stable, debuginfo, remarks, with_effects, inline_cost, type_annotations, highlight,
+function usage(@nospecialize(view_cmd), optimize, iswarn, hide_type_stable, debuginfo, remarks, with_effects, inline_cost, type_annotations, highlight, view_always,
     custom_toggles::Vector{CustomToggle})
     colorize(use_color::Bool, c::Char) = stringify() do io
         use_color ? printstyled(io, c; color=:cyan) : print(io, c)
@@ -80,7 +80,8 @@ function usage(@nospecialize(view_cmd), optimize, iswarn, hide_type_stable, debu
         colorize(with_effects, 'e'), "]ffects, [",
         colorize(inline_cost, 'i'), "]nlining costs, [",
         colorize(type_annotations, 't'), "]ype annotations, [",
-        colorize(highlight, 's'), "]yntax highlight for Source/LLVM/Native")
+        colorize(highlight, 's'), "]yntax highlight for Source/LLVM/Native, [",
+        colorize(view_always, 'v'), "]iew source in editor always")
     for i = 1:length(custom_toggles)
         ct = custom_toggles[i]
         print(ioctx, ", [", colorize(ct.onoff, Char(ct.key)), ']', ct.description)
@@ -111,6 +112,7 @@ const TOGGLES = Dict(
     UInt32('i') => :inline_cost,
     UInt32('t') => :type_annotations,
     UInt32('s') => :highlighter,
+    UInt32('v') => :view_always,
     UInt32('S') => :source,
     UInt32('A') => :ast,
     UInt32('T') => :typed,


### PR DESCRIPTION
this makes interactive IDE usage a lot nicer IMO and aligns more closely to how i used to descend, which was basically continually option clicking function calls within VSCode and manually picking the right dispatch.

i couldn't get the behavior for adding it as a toggle to work quite right though, which is why i have the `view_always` default to true currently. 

