### PR TITLE
Warn color for small unions

### DIFF
--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -403,6 +403,12 @@ function print_callsite_info(limiter::IO, info::OCCallInfo)
     show_callinfo(limiter, info.ci)
 end
 
+@static if VERSION >= v"1.9.0-beta2"
+    is_expected_union = InteractiveUtils.is_expected_union
+else
+    is_expected_union = Base.is_expected_union
+end
+
 function Base.show(io::IO, c::Callsite)
     limit = get(io, :limit, false)::Bool
     cols = limit ? (displaysize(io)::Tuple{Int,Int})[2] : typemax(Int)
@@ -411,7 +417,12 @@ function Base.show(io::IO, c::Callsite)
     info = c.info
     rt = get_rt(info)
     if iswarn && is_type_unstable(rt)
-        printstyled(io, '%'; color=:red)
+        color = if rt isa Union && is_expected_union(rt)
+            Base.warn_color()
+        else
+            Base.error_color()
+        end
+        printstyled(io, '%'; color)
     else
         print(io, '%')
     end

--- a/test/test_terminal.jl
+++ b/test/test_terminal.jl
@@ -198,7 +198,12 @@ end
             @test occursin("\nBody\e[", lines)
             @test occursin("\e[1m::Union{Float32, $Int}\e[22m\e[39m", lines)
             @test occursin("Base.getindex(c)\e[91m\e[1m::Any\e[22m\e[39m", lines)
-            @test occursin("\e[31m%\e[39m2 = call → fmulti(::Any)::Union{Float32, Int64}", lines)
+            warncolor = if Cthulhu.is_expected_union(Union{Float32, Int64})
+                Base.text_colors[Base.warn_color()]
+            else
+                Base.text_colors[Base.error_color()]
+            end
+            @test occursin("$(warncolor)%\e[39m2 = call → fmulti(::Any)::Union{Float32, Int64}", lines)
             write(in, keydict[:enter])
             lines = cread1(out)
             @test occursin("%2 = fmulti(::Int32)::Union{Float32, $Int}", lines)


### PR DESCRIPTION
This PR uses the color scheme from `@code_warntype` in `@descend_code_warntype`. Currently, the `%` signs for non-inferred return types are always displayed in red, but these are largely distractions for small unions.

After this,

![Screenshot from 2023-01-10 20-15-45](https://user-images.githubusercontent.com/10461665/211604296-e1f69e7c-3711-4244-adf8-3511f2da0e15.png)

The color of the `%` in `%3` is yellow instead of red.

Tests pass locally on v1.8, but fail on v1.9.0-beta2 with the same errors as on master, so I don't think this PR introduces errors.