### PR TITLE
read runtime preferences at runtime

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -80,7 +80,7 @@ const CONFIG = CthulhuConfig()
 
 using Preferences
 include("preferences.jl")
-read_config!(CONFIG)
+__init__() = read_config!(CONFIG)
 
 module DInfo
     @enum DebugInfo none compact source


### PR DESCRIPTION
Preferences are not supposed to be read during compilation, since it invalidates the compilation cache.