### PR TITLE
SnoopPrecompile + pipe handling

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ FoldingTrees = "1eca21be-9b9b-4ed8-839a-6d8ae26b1781"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Preferences = "21216c6a-2e73-6563-6e65-726566657250"
 REPL = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
@@ -16,6 +17,7 @@ Unicode = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 CodeTracking = "0.5, 1"
 FoldingTrees = "1"
 Preferences = "1"
+SnoopPrecompile = "1"
 julia = "1.7"
 
 [extras]

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -818,9 +818,14 @@ using SnoopPrecompile
         descend(gcd, (Int, Int); terminal=term)
         readuntil(output.out, "↩")
     end
-    close(input.in)
-    close(output.in)
-    close(err.in)
+    @sync begin
+        @async read(output.out, String)
+        @async begin
+            close(input.in)
+            close(output.in)
+            close(err.in)
+        end
+    end
     nothing
 end
 


### PR DESCRIPTION
This switches to SnoopPrecompile and uses more careful handling of pipes to ensure tasks run to completion (see comment in #343).

Would be grateful if you could check if this is now correct, @vtjnash.

On Julia 1.9+, switching to SnoopPrecompile has an unexpectedly-large benefit for a `compile=min` package: `descend(gcd, (Int, Int))` now feels practically instantaneous. 
