### PR TITLE
Fix displaying inlining costs on nightly

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,8 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1'
+          - '1.8'
+          - '~1.9.0-0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -241,16 +241,12 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
     return nothing
 end
 
-VERSION >= v"1.10.0-DEV.552" && import Core.Compiler: VarState
-function sptypes(sparams)
-    return if VERSION>=v"1.10.0-DEV.552"
-        VarState[Core.Compiler.VarState.(sparams, false)...]
-    else
-        Any[sparams...]
-    end
+@static if VERSION >= v"1.10.0-DEV.552"
+    using Core.Compiler: VarState
+    sptypes(sparams) = VarState[VarState.(sparams, false)...]
+else
+    sptypes(sparams) = Any[sparams...]
 end
-
-
 
 function show_variables(io, src, slotnames)
     println(io, "Variables")

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -135,7 +135,7 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
         code = src isa IRCode ? src.stmts.inst : src.code
         cst = Vector{Int}(undef, length(code))
         params = CC.OptimizationParams(interp)
-        CC.statement_costs!(cst, code, src, Any[mi.sparam_vals...], false, params)
+        CC.statement_costs!(cst, code, src, sptypes(mi.sparam_vals), false, params)
         total_cost = sum(cst)
         nd = ndigits(total_cost)
         _lineprinter = lineprinter(src)
@@ -240,6 +240,17 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
     show_ir(lambda_io, src, irshow_config)
     return nothing
 end
+
+VERSION >= v"1.10.0-DEV.552" && import Core.Compiler: VarState
+function sptypes(sparams)
+    return if VERSION>=v"1.10.0-DEV.552"
+        VarState[Core.Compiler.VarState.(sparams, false)...]
+    else
+        Any[sparams...]
+    end
+end
+
+
 
 function show_variables(io, src, slotnames)
     println(io, "Variables")

--- a/test/test_Cthulhu.jl
+++ b/test/test_Cthulhu.jl
@@ -28,12 +28,12 @@ function empty_func(::Bool) end
 
     # handle pure
     callsites = find_callsites_by_ftt(iterate, Tuple{SVector{3,Int}, Tuple{SOneTo{3}}}; optimize=false)
-    @test occursin("< pure >", string(callsites[1]))
+    @test occursin("::Core.Const((1, 1))", string(callsites[1]))
     @test occursin(r"< (constprop|concrete eval) > getindex\(::.*Const.*,::.*Const\(1\)\)::.*Const\(1\)", string(callsites[2]))
     callsites = @eval find_callsites_by_ftt(; optimize=false) do
         length($(QuoteNode(Core.svec(0,1,2))))
     end
-    @test occursin("< pure >", string(callsites[1]))
+    @test occursin(r"< (pure|concrete eval) >", string(callsites[1]))
 
     # Some weird methods get inferred
     callsites = find_callsites_by_ftt(iterate, (Base.IdSet{Any}, Union{}); optimize=false)
@@ -299,8 +299,8 @@ struct SingletonPureCallable{N} end
     @test occursin("SingletonPureCallable{1}()(::Float64)::Float64", s)
 
     @static if Cthulhu.EFFECTS_ENABLED
-        @test Cthulhu.get_effects(c1) |> Core.Compiler.is_total
-        @test Cthulhu.get_effects(c2) |> Core.Compiler.is_total
+        @test Cthulhu.get_effects(c1) |> is_foldable_nothrow
+        @test Cthulhu.get_effects(c2) |> is_foldable_nothrow
     end
 end
 
@@ -334,8 +334,8 @@ end
     @test occursin("return_type < only_ints(::Float64)::Union{} >", String(take!(io)))
 
     @static if Cthulhu.EFFECTS_ENABLED
-        @test Cthulhu.get_effects(callinfo1) |> Core.Compiler.is_total
-        @test Cthulhu.get_effects(callinfo2) |> Core.Compiler.is_total
+        @test Cthulhu.get_effects(callinfo1) |> is_foldable_nothrow
+        @test Cthulhu.get_effects(callinfo2) |> is_foldable_nothrow
     end
 end
 
@@ -348,7 +348,7 @@ end
         callinfo = only(callsites).info
         @test callinfo isa Cthulhu.OCCallInfo
         @static if Cthulhu.EFFECTS_ENABLED
-            @test Cthulhu.get_effects(callinfo) |> !Core.Compiler.is_total
+            @test Cthulhu.get_effects(callinfo) |> !is_foldable_nothrow
             # TODO not sure what these effects are (and neither is Base.infer_effects yet)
         end
         @test callinfo.ci.rt === Base.return_types((Int,Int)) do a, b
@@ -407,7 +407,7 @@ invoke_constcall(a::Number, c::Bool) = c ? Number : :number
         callsite = only(callsites)
         info = callsite.info
         @test isa(info, Cthulhu.InvokeCallInfo)
-        @static Cthulhu.EFFECTS_ENABLED && Cthulhu.get_effects(info) |> Core.Compiler.is_total
+        @static Cthulhu.EFFECTS_ENABLED && Cthulhu.get_effects(info) |> is_foldable_nothrow
         rt = Core.Compiler.Const(:Integer)
         @test info.ci.rt === rt
         buf = IOBuffer()
@@ -420,7 +420,7 @@ invoke_constcall(a::Number, c::Bool) = c ? Number : :number
         callsite = only(callsites)
         info = callsite.info
         @test isa(info, Cthulhu.InvokeCallInfo)
-        @static Cthulhu.EFFECTS_ENABLED && Cthulhu.get_effects(info) |> Core.Compiler.is_total
+        @static Cthulhu.EFFECTS_ENABLED && Cthulhu.get_effects(info) |> is_foldable_nothrow
         @test info.ci.rt === Core.Compiler.Const(:Int)
     end
 
@@ -431,7 +431,7 @@ invoke_constcall(a::Number, c::Bool) = c ? Number : :number
         callsite = only(callsites)
         info = callsite.info
         @test isa(info, Cthulhu.InvokeCallInfo)
-        @static Cthulhu.EFFECTS_ENABLED && Cthulhu.get_effects(info) |> Core.Compiler.is_total
+        @static Cthulhu.EFFECTS_ENABLED && Cthulhu.get_effects(info) |> is_foldable_nothrow
         inner = info.ci
         rt = Core.Compiler.Const(Any)
         @test Cthulhu.get_rt(info) === rt


### PR DESCRIPTION
Was erroring on nightly with:
```
ERROR: MethodError: no method matching statement_costs!(::Vector{Int64}, ::Vector{Any}, ::Core.Compiler.IRCode, ::Vector{Any}, ::Bool, ::Core.Compiler.OptimizationParams)

Closest candidates are:
  statement_costs!(::Vector{Int64}, ::Vector{Any}, ::Union{Core.Compiler.IRCode, Core.CodeInfo}, ::Vector{Core.Compiler.VarState}, ::Bool, ::Core.Compiler.OptimizationParams)
   @ Core compiler/optimize.jl:768

Stacktrace:
  [1] cthulhu_typed(io::IOContext{IOBuffer}, debuginfo::Symbol, src::Core.Compiler.IRCode, rt::Any, effects::Core.Compiler.Effects, 
mi::Core.MethodInstance; iswarn::Bool, hide_type_stable::Bool, pc2remarks::Nothing, pc2effects::Nothing, inline_cost::Bool, type_annotations::Bool, interp::Cthulhu.CthulhuInterpreter)
```



Same as https://github.com/JuliaDiff/Diffractor.jl/pull/107/files
Credit to @oscardssmith for pointing this out. 