### PR TITLE
Add TypedSyntax package

### DIFF
--- a/TypedSyntax/LICENSE
+++ b/TypedSyntax/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Tim Holy <tim.holy@gmail.com> and contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,0 +1,19 @@
+name = "TypedSyntax"
+uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
+authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
+version = "1.0.0"
+
+[deps]
+CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
+
+[compat]
+CodeTracking = "1"
+JuliaSyntax = "0.3.2"
+julia = "1"
+
+[extras]
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Test"]

--- a/TypedSyntax/README.md
+++ b/TypedSyntax/README.md
@@ -1,0 +1,133 @@
+# TypedSyntax
+
+This package aims to map types, as determined via type-inference, back to the source code as written by the developer. It can be used to understand program behavior and identify causes of "type instability" (inference failures) without the need to read [intermediate representations](https://docs.julialang.org/en/v1/devdocs/ast/) of Julia code.
+
+This package is built on [JuliaSyntax](https://github.com/JuliaLang/JuliaSyntax.jl) and extends it by attaching type annotations to the nodes of its syntax trees. Here's a demo:
+
+```julia
+julia> using TypedSyntax
+
+julia> f(x, y, z) = x + y * z;
+
+julia> node = TypedSyntaxNode(f, (Float64, Int, Float32))
+line:col│ tree                                   │ type
+   1:1  │[=]                                     │Float64
+   1:1  │  [call]
+   1:1  │    f
+   1:3  │    x                                   │Float64
+   1:6  │    y                                   │Int64
+   1:9  │    z                                   │Float32
+   1:13 │  [call-i]                              │Float64
+   1:14 │    x                                   │Float64
+   1:16 │    +
+   1:17 │    [call-i]                            │Float32
+   1:18 │      y                                 │Int64
+   1:20 │      *
+   1:22 │      z                                 │Float32
+```
+
+The right hand column is the new information added by `TypedSyntaxNode`, indicating the type assigned to each variable or function call.
+
+You can also display this in a form closer to the original source code, but with type-annotations:
+
+```julia
+julia> printstyled(stdout, node; hide_type_stable=false)
+f(x::Float64, y::Int64, z::Float32)::Float64 = (x::Float64 + (y::Int64 * z::Float32)::Float32)::Float64
+```
+
+`hide_type_stable=true` (which is the default) will suppress printing of concrete types, so you need to set it to `false` if you want to see all the types.
+
+The default is aimed at identifying sources of "type instability" (poor inferrability):
+
+```julia
+julia> printstyled(stdout, TypedSyntaxNode(f, (Float64, Int, Real)))
+```
+
+which produces
+
+<code>f(x, y, z::<b>Real</b>)::<b>Any</b> = (x + (y * z::<b>Real</b>)::<b>Any</b>)::<b>Any</b></code>
+
+The boldfaced text above is typically printed in color in the REPL:
+
+- red indicates non-concrete types
+- yellow indicates a "small union" of concrete types. These usually pose no issues, unless there are too many combinations of such unions.
+
+Printing with color can be suppressed with the keyword argument `iswarn=false`.
+
+## Caveats
+
+TypedSyntax aims for accuracy, but there are a number of factors that pose challenges.
+First, anonymous and internal functions appear as part of the source text, but internally Julia handles these as separate type-inferred methods, and these are hidden from the annotator.
+Therefore, in
+
+```julia
+julia> sumfirst(c) = sum(x -> first(x), c);    # better to use `sum(first, c)` but this is just an illustration
+
+julia> printstyled(stdout, TypedSyntaxNode(sumfirst, (Vector{Any},)))
+sumfirst(c)::Any = sum(x -> first(x), c)::Any
+```
+
+`x` and `first(x)` both have type `Any`, but they are not annotated as such because they are hidden inside the anonymous function.
+
+Second, this package works by attempting to "reconstruct history": starting from the type-inferred code, it tries to map calls back to the source. It would be much safer to instead keep track of the source during inference, but at present this is not possible (see [this Julia issue](https://github.com/JuliaLang/julia/issues/31162)). There are cases where this mapping fails: for example, with
+
+```julia
+julia> function summer(list)
+           s = 0
+           for x in list
+               s += x
+           end
+           return s
+       end;
+```
+then (on Julia 1.9)
+```
+julia> tsn, mappings = TypedSyntax.tsn_and_mappings(summer, (Vector{Float64},));
+
+julia> hcat(tsn.typedsource.code, mappings)
+16×2 Matrix{Any}:
+ :(_4 = 0)                     Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(_2)                         Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[list]
+ :(_3 = Base.iterate(%2))      Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[(= x list)]
+ :(_3 === nothing)             Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(Base.not_int(%4))           Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(goto %16 if not %5)         Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(_3::Tuple{Float64, Int64})  Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(_5 = Core.getfield(%7, 1))  Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(Core.getfield(%7, 2))       Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(_4 = _4 + _5)               Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[(+= s x)]
+ :(_3 = Base.iterate(%2, %9))  Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(_3 === nothing)             Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(Base.not_int(%12))          Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(goto %16 if not %13)        Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(goto %7)                    Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[]
+ :(return _4)                  Union{TreeNode{SyntaxData}, TreeNode{TypedSyntaxData}}[s]
+```
+The left column contains the statements of the type-inferred code, the right column the mappings back to the source.
+You can see that the majority of these mappings are empty, indicating either no good match or that there were multiple possible matches. This is because lowering changes the implementation so significantly that there are few calls that relate directly to the source.
+
+Nevertheless, many statements in the source can be annotated:
+
+```julia
+julia> tsn
+line:col│ tree                                   │ type
+   1:1  │[function]                              │Union{Float64, Int64}
+   1:10 │  [call]
+   1:10 │    summer
+   1:17 │    list                                │Vector{Float64}
+   1:22 │  [block]
+   2:5  │    [=]
+   2:5  │      s
+   2:9  │      0
+   3:5  │    [for]
+   3:8  │      [=]                               │Union{Nothing, Tuple{Float64, Int64}}
+   3:9  │        x
+   3:14 │        list                            │Vector{Float64}
+   3:18 │      [block]
+   4:9  │        [+=]                            │Float64
+   4:9  │          s                             │Float64
+   4:14 │          x                             │Float64
+   6:5  │    [return]                            │Union{Float64, Int64}
+   6:12 │      s                                 │Union{Float64, Int64}
+```
+This is largely because just the named-variables provide considerable information.

--- a/TypedSyntax/src/TypedSyntax.jl
+++ b/TypedSyntax/src/TypedSyntax.jl
@@ -1,0 +1,16 @@
+module TypedSyntax
+
+using Core: CodeInfo, MethodInstance, SlotNumber, SSAValue
+using Core.Compiler: TypedSlot
+using JuliaSyntax: JuliaSyntax, TreeNode, AbstractSyntaxData, SyntaxData, SyntaxNode, GreenNode, AbstractSyntaxNode, SyntaxHead, SourceFile,
+                   head, kind, child, children, haschildren, untokenize, first_byte, last_byte, source_line, source_location,
+                   sourcetext, @K_str, @KSet_str, is_infix_op_call, is_prefix_op_call, is_prec_assignment, is_operator, is_literal
+using Base.Meta: isexpr
+using CodeTracking
+
+export TypedSyntaxNode
+
+include("node.jl")
+include("show.jl")
+
+end

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -1,0 +1,432 @@
+
+mutable struct TypedSyntaxData <: AbstractSyntaxData
+    source::SourceFile
+    typedsource::CodeInfo
+    raw::GreenNode{SyntaxHead}
+    position::Int
+    val::Any
+    typ::Any    # can either be a Type or `nothing`
+end
+TypedSyntaxData(sd::SyntaxData, src::CodeInfo, typ=nothing) = TypedSyntaxData(sd.source, src, sd.raw, sd.position, sd.val, typ)
+
+const TypedSyntaxNode = TreeNode{TypedSyntaxData}
+const MaybeTypedSyntaxNode = Union{SyntaxNode,TypedSyntaxNode}
+
+# These are TypedSyntaxNode constructor helpers
+# Call these directly if you want both the TypedSyntaxNode and the `mappings` list,
+# where `mappings[i]` corresponds to the list of nodes matching `(src::CodeInfo).code[i]`.
+function tsn_and_mappings(@nospecialize(f), @nospecialize(t); kwargs...)
+    m = which(f, t)
+    src, rt = getsrc(f, t)
+    tsn_and_mappings(m, src, rt; kwargs...)
+end
+
+function tsn_and_mappings(m::Method, src::CodeInfo, @nospecialize(rt); warn::Bool=true, strip_macros::Bool=false, kwargs...)
+    def = definition(String, m)
+    if isnothing(def)
+        warn && @warn "couldn't retrieve source of $m"
+        return nothing, nothing
+    end
+    sourcetext, lineno = def
+    rootnode = JuliaSyntax.parse(SyntaxNode, sourcetext; filename=string(m.file), first_line=lineno, kwargs...)
+    if strip_macros
+        rootnode = get_function_def(rootnode)
+        if !is_function_def(rootnode)
+            warn && @warn "couldn't retrieve source of $m"
+            return nothing, nothing
+        end
+    end
+    Δline = lineno - m.line   # offset from original line number (Revise)
+    mappings, symtyps = map_ssas_to_source(src, rootnode, Δline)
+    node = TypedSyntaxNode(rootnode, src, mappings, symtyps)
+    node.typ = rt
+    return node, mappings
+end
+
+TypedSyntaxNode(@nospecialize(f), @nospecialize(t); kwargs...) = tsn_and_mappings(f, t; kwargs...)[1]
+
+TypedSyntaxNode(rootnode::SyntaxNode, src::CodeInfo, Δline::Integer=0) =
+    TypedSyntaxNode(rootnode, src, map_ssas_to_source(src, rootnode, Δline)...)
+
+function TypedSyntaxNode(rootnode::SyntaxNode, src::CodeInfo, mappings, symtyps)
+    # There may be ambiguous assignments back to the source; preserve just the unambiguous ones
+    node2ssa = IdDict{SyntaxNode,Int}(only(list) => i for (i, list) in pairs(mappings) if length(list) == 1)
+    # Copy `rootnode`, adding type annotations
+    trootnode = TreeNode(nothing, nothing, TypedSyntaxData(rootnode.data, src, gettyp(node2ssa, rootnode, src)))
+    addchildren!(trootnode, rootnode, src, node2ssa, symtyps, mappings)
+    # Add argtyps to signature
+    fnode = get_function_def(trootnode)
+    if is_function_def(fnode)
+        sig, body = children(fnode)
+        if kind(sig) == K"where"
+            sig = child(sig, 1)
+        end
+        @assert kind(sig) == K"call"
+        i = 1
+        for arg in Iterators.drop(children(sig), 1)
+            kind(arg) == K"parameters" && break   # kw args
+            if kind(arg) == K"..."
+                arg = only(children(arg))
+            end
+            if kind(arg) == K"::"
+                nchildren = length(children(arg))
+                if nchildren == 1
+                    # unnamed argument
+                    found = false
+                    while i <= length(src.slotnames)
+                        if src.slotnames[i] == Symbol("#unused#")
+                            arg.typ = src.slottypes[i]
+                            i += 1
+                            found = true
+                            break
+                        end
+                        i += 1
+                    end
+                    @assert found
+                    continue
+                elseif nchildren == 2
+                    arg = child(arg, 1)  # extract the name
+                else
+                    error("unexpected number of children: ", children(arg))
+                end
+            end
+            @assert kind(arg) == K"Identifier"
+            argname = arg.val
+            while i <= length(src.slotnames)
+                if src.slotnames[i] == argname
+                    arg.typ = src.slottypes[i]
+                    i += 1
+                    break
+                end
+                i += 1
+            end
+        end
+    end
+    return trootnode
+end
+
+# Recursive construction of the TypedSyntaxNode tree from the SyntaxNodeTree
+function addchildren!(tparent, parent, src::CodeInfo, node2ssa, symtyps, mappings)
+    if haschildren(parent) && tparent.children === nothing
+        tparent.children = TypedSyntaxNode[]
+    end
+    for child in children(parent)
+        tnode = TreeNode(tparent, nothing, TypedSyntaxData(child.data, src, gettyp(node2ssa, child, src)))
+        if tnode.typ === nothing && kind(child) == K"Identifier"
+            tnode.typ = get(symtyps, child, nothing)
+        end
+        push!(tparent, tnode)
+        addchildren!(tnode, child, src, node2ssa, symtyps, mappings)
+    end
+    # In `return f(args..)`, copy any types assigned to `f(args...)` up to the `[return]` node
+    if kind(tparent) == K"return" && haschildren(tparent)
+        tparent.typ = only(children(tparent)).typ
+    end
+    # Replace the entry in `mappings` to be the typed node
+    i = get(node2ssa, parent, nothing)
+    if i !== nothing
+        @assert length(mappings[i]) == 1
+        mappings[i][1] = tparent
+    end
+    return tparent
+end
+
+function gettyp(node2ssa, node, src)
+    i = get(node2ssa, node, nothing)
+    i === nothing && return nothing
+    stmt = src.code[i]
+    if isa(stmt, Core.ReturnNode)
+        arg = stmt.val
+        isa(arg, SSAValue) && return src.ssavaluetypes[arg.id]
+        is_slot(arg) && return src.slottypes[arg.id]
+    end
+    return src.ssavaluetypes[i]
+end
+
+Base.copy(tsd::TypedSyntaxData) = TypedSyntaxData(tsd.source, tsd.typedsource, tsd.raw, tsd.position, tsd.val, tsd.typ)
+
+gettyp(node::AbstractSyntaxNode) = gettyp(node.data)
+gettyp(::JuliaSyntax.SyntaxData) = nothing
+gettyp(data::TypedSyntaxData) = data.typ
+
+# function sparam_name(mi::MethodInstance, i::Int)
+#     sig = (mi.def::Method).sig::UnionAll
+#     while true
+#         i == 1 && break
+#         sig = sig.body::UnionAll
+#         i -= 1
+#     end
+#     return sig.var.name
+# end
+
+function getsrc(@nospecialize(f), @nospecialize(t))
+    srcrts = code_typed(f, t; debuginfo=:source, optimize=false)
+    return only(srcrts)
+end
+
+function is_function_def(node)  # this is not `Base.is_function_def`
+    kind(node) == K"function" && return true
+    kind(node) == K"=" && kind(child(node, 1)) ∈ KSet"call where" && return true
+    return false
+end
+
+# Strip macros and return the function-definition node
+function get_function_def(rootnode)
+    while kind(rootnode) == K"macrocall"
+        idx = findlast(node -> is_function_def(node) || kind(node) == K"macrocall", children(rootnode))
+        idx === nothing && break
+        rootnode = child(rootnode, idx)
+    end
+    return rootnode
+end
+
+# Recursively traverse `rootnode` and its children, and put all the instances in which
+# a given symbol appears into `symlocs[val]`.
+# This includes function names, operators, and literal values (like `1`, `"hello"`, etc.)
+# These will be used to do argument-matching in calls.
+function collect_symbol_nodes(rootnode)
+    rootnode = get_function_def(rootnode)
+    is_function_def(rootnode) || error("expected function definition, got ", sourcetext(rootnode))
+    symlocs = Dict{Any,Vector{typeof(rootnode)}}()
+    return collect_symbol_nodes!(symlocs, child(rootnode, 2))
+end
+
+function collect_symbol_nodes!(symlocs::AbstractDict, node)
+    kind(node) == K"->" && return symlocs     # skip inner functions (including `do` blocks below)
+    is_function_def(node) && return symlocs
+    if kind(node) == K"Identifier" || is_operator(node)
+        name = node.val
+        if isa(name, Symbol)
+            locs = get!(Vector{typeof(node)}, symlocs, name)
+            push!(locs, node)
+        end
+    end
+    if is_literal(node) && node.val !== nothing    # FIXME: distinguish literal `nothing` from source `nothing`
+        locs = get!(Vector{typeof(node)}, symlocs, node.val)
+        push!(locs, node)
+    end
+    if haschildren(node)
+        for c in (kind(node) == K"do" ? (child(node, 1),) : children(node))  # process only `g(args...)` in `g(args...) do ... end`
+            collect_symbol_nodes!(symlocs, c)
+        end
+    end
+    return symlocs
+end
+
+# Main logic for mapping `src.code[i]` to node(s) in the SyntaxNode tree
+# Success: when we map it to a unique node
+# Δline is the (Revise) offset of the line number
+function map_ssas_to_source(src::CodeInfo, rootnode::SyntaxNode, Δline::Int)
+    # Find all leaf-nodes for a given symbol
+    symlocs = collect_symbol_nodes(rootnode)      # symlocs = Dict(:name => [node1, node2, ...])
+    # Initialize the type-assignment of each slot at each use location
+    symtyps = IdDict{typeof(rootnode),Any}()                     # symtyps = IdDict(node => typ)
+    # Initialize the (possibly ambiguous) attributions for each stmt in `src` (`stmt = src.code[i]`)
+    mappings = [MaybeTypedSyntaxNode[] for _ in eachindex(src.code)]  # mappings[i] = [node1, node2, ...]
+
+    # Append (to `mapped`) all nodes in `targets` that are consistent with the line number of the `i`th stmt
+    # (Essentially `copy!(mapped, filter(predicate, targets))`)
+    function append_targets_for_line!(mapped#=::Vector{nodes}=#, i::Int, targets#=::Vector{nodes}=#)
+        j = src.codelocs[i]
+        linerange = src.linetable[j].line + Δline : (
+                    j < length(src.linetable) ? src.linetable[j+1].line - 1  + Δline : typemax(Int))
+        for t in targets
+            source_line(t) ∈ linerange && push!(mapped, t)
+        end
+        return mapped
+    end
+    # For a call argument `arg`, find all source statements that match
+    function append_targets_for_arg!(mapped#=::Vector{nodes}=#, i::Int, @nospecialize(arg))
+        targets = get_targets(arg)
+        if targets !== nothing
+            append_targets_for_line!(mapped, i, targets)        # select the subset consistent with the line number
+        end
+        return mapped
+    end
+    function get_targets(@nospecialize(arg))
+        return if is_slot(arg)
+            # If `arg` is a variable, e.g., the `x` in `f(x)`
+            get(symlocs, src.slotnames[arg.id], nothing)  # find all places this variable is used
+        elseif isa(arg, GlobalRef)
+            get(symlocs, arg.name, nothing)  # find all places this name is used
+        elseif isa(arg, SSAValue)
+            # If `arg` is the result from a call, e.g., the `g(x)` in `f(g(x))`
+            mappings[arg.id]
+        elseif isa(arg, Core.Const)
+            get(symlocs, arg.val, nothing)   # FIXME: distinguish this `nothing` from a literal `nothing`
+        elseif is_src_literal(arg)
+            get(symlocs, arg, nothing)   # FIXME: distinguish this `nothing` from a literal `nothing`
+        else
+            nothing
+        end
+    end
+    # This is used in matching nodes to `:=` stmts.
+    # In cases where there is more than one match, let's try to eliminate some of them.
+    # We know this stmt is an assignment, so look for a parent node that is an assignment
+    # and for which argnode is in the correct side of the assignment
+    function filter_assignment_targets!(targets, is_rhs::Bool)
+        length(targets) > 1 && filter!(targets) do argnode
+            if kind(argnode.parent) == K"tuple"  # tuple-structuring (go up one more node to see if it's an assignment)
+                argnode = argnode.parent
+            end
+            is_prec_assignment(argnode.parent) && argnode == child(argnode.parent, 1 + is_rhs)  # is it the correct side of an assignment?
+        end
+        return targets
+    end
+
+    argmapping = typeof(rootnode)[]   # temporary storage
+    for (i, mapped, stmt) in zip(eachindex(mappings), mappings, src.code)
+        empty!(argmapping)
+        if is_slot(stmt) || isa(stmt, SSAValue)
+            append_targets_for_arg!(mapped, i, stmt)
+        elseif isa(stmt, Core.ReturnNode)
+            append_targets_for_line!(mapped, i, append_targets_for_arg!(argmapping, i, stmt.val))
+        elseif isa(stmt, Expr)
+            if stmt.head == :(=)
+                # We defer setting up `symtyps` for the LHS because processing the RHS first might eliminate ambiguities
+                # # Update `symtyps` for this assignment
+                lhs = stmt.args[1]
+                @assert is_slot(lhs)
+                # For `mappings` we're interested only in the right hand side of this assignment
+                stmt = stmt.args[2]
+                if is_slot(stmt) || isa(stmt, SSAValue)  # generic calls are handled below. Here, can we just look up the answer?
+                    append_targets_for_arg!(mapped, i, stmt)
+                    filter_assignment_targets!(mapped, true)   # match the RHS of assignments
+                    if length(mapped) == 1
+                        symtyps[only(mapped)] = is_slot(stmt) ? src.slottypes[stmt.id] : src.ssavaluetypes[stmt.id]
+                    end
+                    # Now try to assign types to the LHS of the assignment
+                    append_targets_for_arg!(argmapping, i, lhs)
+                    filter_assignment_targets!(argmapping, false)  # match the LHS of assignments
+                    if length(argmapping) == 1
+                        symtyps[only(argmapping)] = src.ssavaluetypes[i]
+                    end
+                    empty!(argmapping)
+                    continue
+                end
+                isa(stmt, Expr) || continue
+                # The right hand side was an expression. Fall through to the generic `call` analysis.
+            end
+            if stmt.head == :call && is_indexed_iterate(stmt.args[1])
+                id = stmt.args[2]
+                @assert isa(id, SSAValue)
+                append!(mapped, mappings[id.id])
+                continue
+            end
+            # When analyzing calls, we start with the symbols. For any that have been attributed to one or more
+            # nodes in the source, we make a consistency argument: which *parent* nodes take all of these as arguments?
+            # In many cases this allows unique assignment.
+            # Let's take a simple example: `x + sin(x + π / 4)`: in this case, `x + ` appears in two places but
+            # you can disambiguate it by noting that `x + π / 4` only occurs in one place.
+            # Note that the function name (e.g., `:sin`) is not special, we can effectively treat all as
+            # `invoke(f, args...)` and consider `f` just like any other argument.
+            # TODO?: handle gensymmed names, e.g., kw bodyfunctions?
+            # The advantage of this approach is precision: we don't depend on ordering of statements,
+            # so when it works you know you are correct.
+            stmtmapping = Set{typeof(rootnode)}()
+            for arg in stmt.args
+                # Collect all source-nodes that use this argument
+                append_targets_for_arg!(argmapping, i, arg)
+                if !isempty(argmapping)
+                    if isempty(stmtmapping)
+                        # First matched argument
+                        # For each candidate source-node, push its parent-node into `stmtmapping`.
+                        # The true call-node should be among these.
+                        foreach(argmapping) do t
+                            push!(stmtmapping, t.parent)
+                        end
+                    else
+                        # Second or later matched argument
+                        # A matching caller node needs to use all `stmt.args`,
+                        # so we `intersect` to find the common node(s)
+                        intersect!(stmtmapping, map(t->t.parent, argmapping))
+                    end
+                end
+                empty!(argmapping)
+            end
+            append!(mapped, stmtmapping)
+            sort!(mapped; by=t->t.position)   # since they went into a set, best to order them within the source
+            stmt = src.code[i]   # re-get the statement so we process slot-assignment
+            if length(mapped) == 1 && isa(stmt, Expr)
+                # We've mapped the call uniquely (i.e., we found the right match)
+                node = only(mapped)
+                # Final step: set up symtyps for all the user-visible variables
+                # Because lowering can build methods that take a different number of arguments than appear in the
+                # source text, don't try to count arguments. Instead, find a symbol that is part of
+                # `node` or, for the LHS of a `slot = callexpr` statement, one that shares a parent with `node`.
+                if stmt.head == :(=)
+                    # Tag the LHS of this expression
+                    arg = stmt.args[1]
+                    @assert is_slot(arg)
+                    sym = src.slotnames[arg.id]
+                    if sym != Symbol("")
+                        lhsnode = node
+                        while !is_prec_assignment(lhsnode)
+                            lhsnode = lhsnode.parent
+                        end
+                        lhsnode = child(lhsnode, 1)
+                        if kind(lhsnode) == K"tuple"   # tuple destructuring
+                            found = false
+                            for child in children(lhsnode)
+                                if kind(child) == K"Identifier"
+                                    if child.val == sym
+                                        lhsnode = child
+                                        found = true
+                                        break
+                                    end
+                                end
+                            end
+                            @assert found
+                        end
+                        symtyps[lhsnode] = src.ssavaluetypes[i]
+                    end
+                    # Now process the RHS
+                    stmt = stmt.args[2]
+                end
+                # Process the call expr
+                if isa(stmt, Expr)
+                    for arg in stmt.args
+                        # For arguments that are slots, follow them backwards.
+                        # (We're not assigning type to node, we're assigning nodes to ssavalues.)
+                        # Arguments can locally be SSAValues but ultimately map back to slots
+                        j = 0
+                        while isa(arg, SSAValue)
+                            j = arg.id
+                            arg = src.ssavaluetypes[j]   # keep trying in case it maps back to a slot
+                        end
+                        if is_slot(arg)
+                            sym = src.slotnames[arg.id]
+                            sym == Symbol("") && continue
+                            for t in symlocs[sym]
+                                haskey(symtyps, t) && continue
+                                if t.parent == node
+                                    is_prec_assignment(node) && t == child(node, 1) && continue
+                                    symtyps[t] = if j > 0
+                                        src.ssavaluetypes[j]
+                                    else
+                                        # We failed to find it as an SSAValue, it must have type assigned at function entry
+                                        j = findfirst(==(sym), src.slotnames)
+                                        src.slottypes[j]
+                                    end
+                                    break
+                                end
+                            end
+                        end
+                    end
+                end
+            end
+        end
+    end
+    return mappings, symtyps
+end
+map_ssas_to_source(src::CodeInfo, rootnode::SyntaxNode, Δline::Integer) = map_ssas_to_source(src, rootnode, Int(Δline))
+
+function is_indexed_iterate(arg)
+    isa(arg, GlobalRef) || return false
+    arg.mod == Base || return false
+    return arg.name == :indexed_iterate
+end
+
+is_slot(@nospecialize(arg)) = isa(arg, SlotNumber) || isa(arg, TypedSlot)
+
+is_src_literal(x) = isa(x, Integer) || isa(x, AbstractFloat) || isa(x, String) || isa(x, Char) || isa(x, Symbol)

--- a/TypedSyntax/src/show.jl
+++ b/TypedSyntax/src/show.jl
@@ -1,0 +1,165 @@
+function Base.show(io::IO, ::MIME"text/plain", node::TypedSyntaxNode; show_byte_offsets=false)
+    println(io, "line:col│$(show_byte_offsets ? " byte_range  │" : "") tree                                   │ type")
+    JuliaSyntax._show_syntax_node(io, Ref{Union{Nothing,String}}(nothing), node, "", show_byte_offsets)
+end
+
+function JuliaSyntax._show_syntax_node(io, current_filename, node::TypedSyntaxNode, indent, show_byte_offsets)
+    fname = node.source.filename
+    line, col = source_location(node.source, node.position)
+    posstr = "$(lpad(line, 4)):$(rpad(col,3))│"
+    if show_byte_offsets
+        posstr *= "$(lpad(first_byte(node),6)):$(rpad(last_byte(node),6))│"
+    end
+    val = node.val
+    nodestr = haschildren(node) ? "[$(untokenize(head(node)))]" :
+    isa(val, Symbol) ? string(val) : repr(val)
+    treestr = string(indent, nodestr)
+    if node.typ !== nothing
+        treestr = string(rpad(treestr, 40), "│$(node.typ)")
+    end
+    println(io, posstr, treestr)
+    if haschildren(node)
+        new_indent = indent*"  "
+        for n in children(node)
+            JuliaSyntax._show_syntax_node(io, current_filename, n, new_indent, show_byte_offsets)
+        end
+    end
+end
+
+
+function Base.printstyled(io::IO, rootnode::MaybeTypedSyntaxNode;
+                          type_annotations::Bool=true, iswarn::Bool=true, hide_type_stable::Bool=true,
+                          idxend = last_byte(rootnode), kwargs...)
+    rt = gettyp(rootnode)
+    rootnode = get_function_def(rootnode)
+    position = first_byte(rootnode) - 1
+    if is_function_def(rootnode)
+        # We're printing a MethodInstance
+        @assert length(children(rootnode)) == 2
+        sig, body = children(rootnode)
+        position = show_src_expr(io, sig, position; type_annotations, iswarn, hide_type_stable)
+        type_annotations && maybe_show_annotation(io, rt; iswarn, hide_type_stable)
+        rootnode = body
+    end
+    position = show_src_expr(io, rootnode, position; type_annotations, iswarn, hide_type_stable)
+    println(io, rootnode.source[position+1:idxend])
+    return nothing
+end
+Base.printstyled(rootnode::MaybeTypedSyntaxNode; kwargs...) = printstyled(stdout, rootnode; kwargs...)
+
+function show_src_expr(io::IO, node::MaybeTypedSyntaxNode, lastidx::Int; type_annotations::Bool=true, iswarn::Bool=false, hide_type_stable::Bool=false)
+    lastidx = catchup(io, node, lastidx)
+    _lastidx = last_byte(node)
+    if kind(node) == K"Identifier" || (kind(node) == K"::" && is_prefix_op_call(node))
+        print_with_linenumber(io, node, lastidx+1:_lastidx)
+        type_annotations && maybe_show_annotation(io, gettyp(node); iswarn, hide_type_stable)
+        return _lastidx
+    end
+    # We only handle "call" nodes. For anything else, just print the node (recursing into children)
+    if kind(node) ∉ KSet"call ref"
+        for child in children(node)
+            lastidx = show_src_expr(io, child, lastidx; type_annotations, iswarn, hide_type_stable)
+        end
+        print_with_linenumber(io, node, lastidx+1:_lastidx)
+        return _lastidx
+    end
+    pre = prepost = post = ""
+    if is_infix_op_call(node)   # wrap infix calls in parens before type-annotating
+        pre, post = "(", ")"
+        lastidx = catchup(io, first(children(node)), lastidx)
+    elseif is_prefix_op_call(node) # insert parens after prefix op and before type-annotating
+        prepost, post = "(", ")"
+    end
+    T = gettyp(node)
+    # should we print a type-annotation?
+    type_annotate = type_annotations & (isa(T, Vector{Int}) || (isa(T, Type) && (!hide_type_stable || is_type_unstable(T))))
+    type_annotate && print(io, pre)
+    for (childid, child) in enumerate(children(node))
+        childid == 2 && type_annotate && print(io, prepost)
+        lastidx = show_src_expr(io, child, lastidx; type_annotations, iswarn, hide_type_stable)
+    end
+    print(io, node.source[lastidx+1:_lastidx])
+    if type_annotate && T !== nothing
+        show_annotation(io, T, post; iswarn)
+    end
+    return _lastidx
+end
+
+function maybe_show_annotation(io, @nospecialize(T); iswarn, hide_type_stable)
+    T === nothing && return
+    if isa(T, Core.Const)
+        T = typeof(T.val)
+    end
+    if isa(T, Type) && (!hide_type_stable || is_type_unstable(T))   # should we print a type-annotation?
+        show_annotation(io, T; iswarn)
+    end
+end
+
+function show_annotation(io, @nospecialize(T), post=""; iswarn::Bool)
+    print(io, post)
+    if isa(T, Vector{Int})
+        isempty(T) && return
+        if iswarn
+            printstyled(io, "::NF"; color=:yellow)
+        else
+            print(io, "::NF")
+        end
+        return
+    end
+    if iswarn
+        color = !is_type_unstable(T) ? :cyan :
+                 is_small_union_or_tunion(T) ? :yellow : :red
+        printstyled(io, "::", T; color)
+    else
+        printstyled(io, "::", T; color=:cyan)
+    end
+end
+
+function catchup(io::IO, node::MaybeTypedSyntaxNode, lastidx::Int)
+    # Do any "overdue" printing now. Mostly, this catches whitespace
+    firstidx = first_byte(node)
+    if lastidx + 1 < firstidx
+        print_with_linenumber(io, node, lastidx+1:firstidx-1)
+        lastidx = firstidx-1
+    end
+    return lastidx
+end
+
+function print_with_linenumber(io::IO, node::AbstractSyntaxNode, byterange)
+    nd = ndigits(node.source.first_line + nlines(node.source) - 1)
+    offset = first(byterange) - 1
+    if offset == 0
+        # This is the first line, print the line number first
+        printstyled(io, lpad(source_line(node.source, 1), nd), " "; color=:light_black)
+    end
+    for (i, c) in pairs(node.source[byterange])
+        print(io, c)
+        if c == '\n'
+            printstyled(io, lpad(source_line(node.source, i + offset + 1), nd), " "; color=:light_black)
+        end
+    end
+end
+
+nlines(source) = length(source.line_starts)
+
+is_type_unstable(@nospecialize(type)) = type isa Type && (!Base.isdispatchelem(type) || type == Core.Box)
+function is_small_union_or_tunion(@nospecialize(T))
+    Base.isvarargtype(T) && return false
+    if T <: Tuple   # is it Tuple{U}
+        return all(is_small_union_or_tunion, Base.unwrap_unionall(T).parameters)
+    end
+    isa(T, Union) || return false
+    n, isc = countconcrete(T)
+    return isc & (n <= 3)
+end
+
+function countconcrete(@nospecialize(T))
+    if Base.isdispatchelem(T)
+        return 1, true
+    elseif isa(T, Union)
+        na, isca = countconcrete(T.a)
+        nb, iscb = countconcrete(T.b)
+        return na + nb, isca & iscb
+    end
+    return 0, false
+end

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -1,0 +1,267 @@
+using JuliaSyntax: JuliaSyntax, SyntaxNode, children, child, sourcetext, kind, @K_str
+using TypedSyntax: TypedSyntax, TypedSyntaxNode, getsrc
+using Test
+
+has_name_typ(node, name::Symbol, @nospecialize(T)) = kind(node) == K"Identifier" && node.val === name && node.typ === T
+
+module TSN
+
+function has2xa(x)
+    x &= x
+end
+function has2xb(x)
+    x -= x
+    return x
+end
+
+# This is taken from the definition of `sin(::Int)` in Base, copied here for testing purposes
+# in case the implementation changes
+for f in (:mysin,)
+    @eval function ($f)(x::Real)
+        xf = float(x)
+        x === xf && throw(MethodError($f, (x,)))
+        return ($f)(xf)
+    end
+end
+
+function summer(list)
+    s = 0                    # deliberately ::Int to test type-changes
+    for x in list
+        s += x
+    end
+    return s
+end
+
+zerowhere(::AbstractArray{T}) where T<:Real = zero(T)
+
+# with two uses of the same slot in the same call
+function simplef(a, b)
+    z = a * a
+    return z + b + y
+end
+
+add2(x) = x[1] + x[2]
+
+likevect(X::T...) where {T} = T[ X[i] for i = 1:length(X) ]
+
+end
+
+@testset "TypedSyntax.jl" begin
+    st = """
+    f(x, y, z) = x * y + z
+    """
+    rootnode = JuliaSyntax.parse(SyntaxNode, st; filename="TSN1.jl")
+    TSN.eval(Expr(rootnode))
+    src, _ = getsrc(TSN.f, (Float32, Int, Float64))
+    tsn = TypedSyntaxNode(rootnode, src)
+    sig, body = children(tsn)
+    @test children(sig)[2].typ === Float32
+    @test children(sig)[3].typ === Int
+    @test children(sig)[4].typ === Float64
+    @test body.typ === Float64   # aggregate output
+    @test children(body)[1].typ === Float32
+
+    # Multiline
+    st = """
+    function g(a, b, c)
+        x = a + b
+        return x + c
+    end
+    """
+    rootnode = JuliaSyntax.parse(SyntaxNode, st; filename="TSN2.jl")
+    TSN.eval(Expr(rootnode))
+    src, _ = getsrc(TSN.g, (Int16, Int16, Int32))
+    tsn = TypedSyntaxNode(rootnode, src)
+    sig, body = children(tsn)
+    @test length(children(sig)) == 4
+    @test children(body)[2].typ === Int32
+    # Check that `x` gets an assigned type
+    nodex = child(body, 1, 1)
+    @test nodex.typ === Int16
+
+    # Target ambiguity
+    st = "math(x) = x + sin(x + π / 4)"
+    rootnode = JuliaSyntax.parse(SyntaxNode, st; filename="TSN2.jl")
+    TSN.eval(Expr(rootnode))
+    src, _ = getsrc(TSN.math, (Int,))
+    tsn = TypedSyntaxNode(rootnode, src)
+    sig, body = children(tsn)
+    @test has_name_typ(child(body, 1), :x, Int)
+    @test has_name_typ(child(body, 3, 2, 1), :x, Int)
+    pi4 = child(body, 3, 2, 3)
+    @test kind(pi4) == K"call" && pi4.typ == Core.Const(π / 4)
+    tsn = TypedSyntaxNode(TSN.has2xa, (Real,))
+    @test tsn.typ === Any
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 2), :x, Real)
+    @test has_name_typ(child(body, 1, 2), :x, Real)
+    @test has_name_typ(child(body, 1, 1), :x, Any)
+    tsn = TypedSyntaxNode(TSN.has2xb, (Real,))
+    @test tsn.typ === Any
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 2), :x, Real)
+    @test has_name_typ(child(body, 1, 2), :x, Real)
+    @test has_name_typ(child(body, 1, 1), :x, Any)
+
+    # Target duplication
+    st = "math2(x) = sin(x) + sin(x)"
+    rootnode = JuliaSyntax.parse(SyntaxNode, st; filename="TSN2.jl")
+    TSN.eval(Expr(rootnode))
+    src, _ = getsrc(TSN.math2, (Int,))
+    tsn = TypedSyntaxNode(rootnode, src)
+    sig, body = children(tsn)
+    @test body.typ === Float64
+    @test_broken child(body, 1).typ === Float64
+    tsn = TypedSyntaxNode(TSN.simplef, Tuple{Float32, Int32})
+    sig, body = children(tsn)
+    @test has_name_typ(child(body, 1, 2, 1), :a, Float32)
+    @test has_name_typ(child(body, 1, 2, 3), :a, Float32)
+
+    # Inner functions
+    for (st, idxsinner, idxsouter) in (
+        ("firstfirst(c) = map(x -> first(x), first(c))", (2, 2), (3,)),
+        ("""
+        firstfirst(c) = map(first(c)) do x
+            first(x)
+        end
+        """, (3, 1), (1, 2))
+        )
+        rootnode = JuliaSyntax.parse(SyntaxNode, st; filename="TSN3.jl")
+        TSN.eval(Expr(rootnode))
+        src, _ = getsrc(TSN.firstfirst, (Vector{Vector{Real}},))
+        tsn = TypedSyntaxNode(rootnode, src)
+        sig, body = children(tsn)
+        @test child(body, idxsinner...).typ === nothing
+        @test child(body, idxsouter...).typ === Vector{Real}
+    end
+
+    # `ref` indexing
+    st = """
+        function setlist!(listset, listget, i, j)
+            listset[i+1][j+1] = listget[i][j]
+        end
+        """
+    rootnode = JuliaSyntax.parse(SyntaxNode, st; filename="TSN4.jl")
+    TSN.eval(Expr(rootnode))
+    src, rt = getsrc(TSN.setlist!, (Vector{Vector{Float32}}, Vector{Vector{UInt8}}, Int, Int))
+    tsn = TypedSyntaxNode(rootnode, src)
+    sig, body = children(tsn)
+    nodelist = child(body, 1, 2, 1, 1)                             # `listget`
+    @test sourcetext(nodelist) == "listget" && nodelist.typ === Vector{Vector{UInt8}}
+    @test nodelist.parent.typ === Vector{UInt8}                    # `listget[i]`
+    @test sourcetext(child(nodelist.parent, 2)) == "i"
+    @test nodelist.parent.parent.typ === UInt8                     # `listget[i][j]`
+
+    nodelist = child(body, 1, 1, 1, 1)                             # `listset`
+    @test sourcetext(nodelist) == "listset" && nodelist.typ === Vector{Vector{Float32}}
+    @test sourcetext(child(nodelist.parent, 2)) == "i+1"
+    @test nodelist.parent.typ === Vector{Float32}                  # `listset[i+1]`
+    @test kind(nodelist.parent.parent.parent) == K"="              # the `setindex!` call
+
+    # tuple-destructuring
+    st = """
+        function callfindmin(list)
+            val, idx = findmin(list)
+            x, y = idx, val
+            return y
+        end
+    """
+    rootnode = JuliaSyntax.parse(SyntaxNode, st; filename="TSN5.jl")
+    TSN.eval(Expr(rootnode))
+    src, rt = getsrc(TSN.callfindmin, (Vector{Float64},))
+    tsn = TypedSyntaxNode(rootnode, src)
+    sig, body = children(tsn)
+    t = child(body, 1, 1)
+    @test kind(t) == K"tuple"
+    @test has_name_typ(child(t, 1), :val, Float64)
+    @test has_name_typ(child(t, 2), :idx, Int)
+    t = child(body, 2, 1)
+    @test kind(t) == K"tuple"
+    @test has_name_typ(child(t, 1), :x, Int)
+    @test has_name_typ(child(t, 2), :y, Float64)
+
+    # kwfuncs
+    st = """
+    function avoidzero(x; avoid_zero=true)
+        fx = float(x)
+        return iszero(x) ? oftype(fx, NaN) : fx
+    end
+    """
+    rootnode = JuliaSyntax.parse(SyntaxNode, st; filename="TSN6.jl")
+    TSN.eval(Expr(rootnode))
+    src, rt = getsrc(TSN.avoidzero, (Int,))
+    # src looks like this:
+    #   %1 = Main.TSN.:(var"#avoidzero#6")(true, #self#, x)::Float64
+    #        return %1
+    # Consequently there is nothing to match, but at least we shouldn't error
+    tsn = TypedSyntaxNode(rootnode, src)
+    @test isa(tsn, TypedSyntaxNode)
+    @test rt === Float64
+    # Try the kwbodyfunc
+    m = which(TSN.avoidzero, (Int,))
+    src, rt = getsrc(Base.bodyfunction(m), (Bool, typeof(TSN.avoidzero), Int,))
+    tsn = TypedSyntaxNode(rootnode, src)
+    sig, body = children(tsn)
+    isz = child(body, 2, 1, 1)
+    @test kind(isz) == K"call" && child(isz, 1).val == :iszero
+    @test isz.typ === Bool
+    @test child(body, 2, 1, 2).typ == Core.Const(NaN)
+
+    # macros in function definition
+    tsn = TypedSyntaxNode(TSN.mysin, (Int,))
+    @test kind(tsn) == K"macrocall"
+    sig, body = children(child(tsn, 2))
+    @test has_name_typ(child(sig, 2, 1), :x, Int)
+    @test has_name_typ(child(body, 1, 1), :xf, Float64)
+
+    # `for` loops
+    tsn = TypedSyntaxNode(TSN.summer, (Vector{Float64},))
+    @test tsn.typ == Union{Int,Float64}
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 2), :list, Vector{Float64})
+    @test_broken has_name_typ(child(body, 1, 1), :s, Int)
+    @test_broken has_name_typ(child(body, 2, 1, 1), :x, Float64)
+    node = child(body, 2, 2, 1)
+    @test kind(node) == K"+="
+    @test has_name_typ(child(node, 1), :s, Float64)   # if this line runs, the LHS now has type `Float64`
+    @test has_name_typ(child(node, 2), :x, Float64)
+    @test has_name_typ(child(body, 3, 1), :s, Union{Float64, Int})
+
+    # `where` and unnamed arguments
+    tsn = TypedSyntaxNode(TSN.zerowhere, (Vector{Int16},))
+    sig, body = children(tsn)
+    @test child(sig, 1, 2).typ === Vector{Int16}
+    @test body.typ === Core.Const(Int16(0))
+
+    # varargs
+    tsn = TypedSyntaxNode(TSN.likevect, (Int, Int))
+    sig, body = children(tsn)
+    nodeva = child(sig, 1, 2)
+    @test kind(nodeva) == K"..."
+    @test has_name_typ(child(nodeva, 1, 1), :X, Tuple{Int,Int})
+
+    # Display
+    tsn = TypedSyntaxNode(TSN.summer, (Vector{Any},))
+    str = sprint(tsn; context=:color=>true) do io, obj
+        printstyled(io, obj; iswarn=true, hide_type_stable=false)
+    end
+    @test occursin("summer(list\e[36m::Vector{Any}\e[39m)\e[31m::Any", str)
+    @test occursin("s\e[31m::Any\e[39m += x\e[31m::Any\e[39m", str)
+    str = sprint(tsn; context=:color=>true) do io, obj
+        printstyled(io, obj; type_annotations=false)
+    end
+    @test occursin("summer(list)", str)
+    @test occursin("s += x", str)
+    tsn = TypedSyntaxNode(TSN.zerowhere, (Vector{Int16},))
+    str = sprint(tsn; context=:color=>true) do io, obj
+        printstyled(io, obj; iswarn=true, hide_type_stable=false)
+    end
+    @test occursin("AbstractArray{T}\e[36m::Vector{Int16}\e[39m", str)
+    @test occursin("Real\e[36m::Int16\e[39m", str)
+    tsn = TypedSyntaxNode(TSN.add2, (Vector{Float32},))
+    str = sprint(tsn; context=:color=>true) do io, obj
+        printstyled(io, obj; iswarn=true, hide_type_stable=false)
+    end
+    @test occursin("[1]\e[36m::Float32\e[39m", str)
+    @test occursin("[2]\e[36m::Float32\e[39m", str)
+end


### PR DESCRIPTION
This package attempts to map statements in type-inferred code back to the source code as written by the programmer.

The intention is to use this in Cthulhu to present the results of inference in an easier-to-digest form. There are, of course, potential additional applications of this source-mapping, which is why it is developed as a semi-independent package.

This is part of #345, split out so it can be registered before making Cthulhu dependent on it.