### PR TITLE
Add RTCallInfo for runtime calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -21,7 +21,7 @@ FoldingTrees = "1"
 JuliaSyntax = "0.3.2"
 Preferences = "1"
 SnoopPrecompile = "1"
-TypedSyntax = "1.0.1"
+TypedSyntax = "1.0.2"
 julia = "1.7"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -78,8 +78,17 @@ In the final section, you see:
 ![calls](images_readme/descend_calls.png)
 
 This is a menu of calls that you can further descend into. Move the dot `•` with the up and down
-arrow keys, and hit Enter to descend into a particular call. Calls that start with `%nn = ...`
-are in Julia's internal [Abstract Syntax Tree (AST)](https://docs.julialang.org/en/v1/devdocs/ast/) form;
+arrow keys, and hit Enter to descend into a particular call. Any calls that are made at runtime ([dynamic dispatch](https://en.wikipedia.org/wiki/Dynamic_dispatch)) cannot be descended into;
+if you select one, you'll see
+
+```
+[ Info: This is a runtime call. You cannot descend into it.
+```
+
+and the call menu will be printed again.
+
+Calls that start with `%nn = ...` are in Julia's internal
+[Abstract Syntax Tree (AST)](https://docs.julialang.org/en/v1/devdocs/ast/) form;
 for these calls, Cthulhu and/or [TypedSyntax](TypedSyntax/README.md) (a sub-package living inside the Cthulhu repository) failed to "map" the call back to the original source code.
 
 As a word of warning, **mapping type inference results back to the source is hard, and there may be errors or omissions in this mapping**. See the [TypedSyntax README](TypedSyntax/README.md) for further details about the challenges. When you think there are reasons to doubt what you're seeing, a reliable but harder-to-interpret strategy is to directly view the [`[T]yped code`](#viewing-the-internal-representation-of-julia-code) rather than the `[S]ource code`.

--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.1"
+version = "1.0.2"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -5,9 +5,10 @@ mutable struct TypedSyntaxData <: AbstractSyntaxData
     raw::GreenNode{SyntaxHead}
     position::Int
     val::Any
-    typ::Any    # can either be a Type or `nothing`
+    typ::Any        # can either be a Type or `nothing`
+    runtime::Bool   # true if this represents a call made by runtime dispatch (Cthulhu callsite annotation)
 end
-TypedSyntaxData(sd::SyntaxData, src::CodeInfo, typ=nothing) = TypedSyntaxData(sd.source, src, sd.raw, sd.position, sd.val, typ)
+TypedSyntaxData(sd::SyntaxData, src::CodeInfo, typ=nothing) = TypedSyntaxData(sd.source, src, sd.raw, sd.position, sd.val, typ, false)
 
 const TypedSyntaxNode = TreeNode{TypedSyntaxData}
 const MaybeTypedSyntaxNode = Union{SyntaxNode,TypedSyntaxNode}
@@ -554,3 +555,6 @@ function is_tuple_stmt(@nospecialize(stmt))
     f = stmt.args[1]
     return isa(f, GlobalRef) && f.mod === Core && f.name == :tuple
 end
+
+is_runtime(node::TypedSyntaxNode) = node.runtime
+is_runtime(::AbstractSyntaxNode) = false

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -613,6 +613,11 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
                 """
                 additional_descend(get_mi(info)::MethodInstance)
                 continue
+            elseif info isa RTCallInfo
+                @info """
+                This is a runtime call. You cannot descend into it.
+                """
+                @goto show_menu
             end
 
             # recurse

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -388,8 +388,9 @@ function print_callsite_info(limiter::IO, info::Union{MultiCallInfo, FailedCallI
 end
 
 function print_callsite_info(limiter::IO, info::RTCallInfo)
-    print(limiter, "RT call ")
+    print(limiter, "runtime < ")
     show_callinfo(limiter, info)
+    print(limiter, " >")
 end
 
 function print_callsite_info(limiter::IO, info::TaskCallInfo)

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -33,6 +33,15 @@ struct LimitedCallInfo <: WrappedCallInfo
     wrapped::CallInfo
 end
 
+# Runtime CallInfo
+struct RTCallInfo <: CallInfo
+    f
+    argtyps
+    rt
+end
+get_mi(ci::RTCallInfo) = nothing
+get_effects(ci::RTCallInfo) = Effects()
+
 # uncached callsite, we can't recurse into this call
 struct UncachedCallInfo <: WrappedCallInfo
     wrapped::CallInfo
@@ -319,6 +328,8 @@ function show_callinfo(limiter, ci::Union{MultiCallInfo, FailedCallInfo, Generat
     __show_limited(limiter, name::String, tt, get_rt(ci), get_effects(ci))
 end
 
+show_callinfo(limiter, ci::RTCallInfo) = __show_limited(limiter, "$(ci.f)", ci.argtyps, get_rt(ci), get_effects(ci))
+
 function show_callinfo(limiter, pci::PureCallInfo)
     ft, tt... = pci.argtypes
     f = CC.singleton_type(ft)
@@ -373,6 +384,11 @@ end
 
 function print_callsite_info(limiter::IO, info::Union{MultiCallInfo, FailedCallInfo, GeneratedCallInfo})
     print(limiter, "call ")
+    show_callinfo(limiter, info)
+end
+
+function print_callsite_info(limiter::IO, info::RTCallInfo)
+    print(limiter, "RT call ")
     show_callinfo(limiter, info)
 end
 

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -33,26 +33,28 @@ function find_callsites(interp::AbstractInterpreter, CI::Union{Core.CodeInfo, IR
         callsite = nothing
         if stmt_infos !== nothing && is_call_expr(stmt, optimize)
             info = stmt_infos[id]
-            rt = ignorelimited(argextype(SSAValue(id), CI, sptypes, slottypes))
-            # in unoptimized IR, there may be `slot = rhs` expressions, which `argextype` doesn't handle
-            # so extract rhs for such an case
-            local args = stmt.args
-            if !optimize
-                args = (ignorelhs(stmt)::Expr).args
-            end
-            argtypes = mapany(function (@nospecialize(arg),)
-                                    t = argextype(arg, CI, sptypes, slottypes)
-                                    return ignorelimited(t)
-                                end, args)
-            callinfos = process_info(interp, info, argtypes, rt, optimize)
-            isempty(callinfos) && continue
-            callsite = let
-                if length(callinfos) == 1
-                    callinfo = callinfos[1]
-                else
-                    callinfo = MultiCallInfo(argtypes_to_type(argtypes), rt, callinfos)
+            if info !== nothing
+                rt = ignorelimited(argextype(SSAValue(id), CI, sptypes, slottypes))
+                # in unoptimized IR, there may be `slot = rhs` expressions, which `argextype` doesn't handle
+                # so extract rhs for such an case
+                local args = stmt.args
+                if !optimize
+                    args = (ignorelhs(stmt)::Expr).args
                 end
-                Callsite(id, callinfo, stmt.head)
+                argtypes = mapany(function (@nospecialize(arg),)
+                                        t = argextype(arg, CI, sptypes, slottypes)
+                                        return ignorelimited(t)
+                                    end, args)
+                callinfos = process_info(interp, info, argtypes, rt, optimize)
+                isempty(callinfos) && continue
+                callsite = let
+                    if length(callinfos) == 1
+                        callinfo = callinfos[1]
+                    else
+                        callinfo = MultiCallInfo(argtypes_to_type(argtypes), rt, callinfos)
+                    end
+                    Callsite(id, callinfo, stmt.head)
+                end
             end
         end
 
@@ -218,11 +220,11 @@ function process_info(interp::AbstractInterpreter, @nospecialize(info::CCCallInf
             vmi = FailedCallInfo(sig, Union{})
         end
         return Any[ReturnTypeCallInfo(vmi)]
-    elseif info == NoCallInfo()
+    elseif info == NoCallInfo() && info !== nothing
         f = unwrapconst(argtypes[1])
         isa(f, Core.Builtin) && return []
         return [RTCallInfo(f, argtypes[2:end], rt)]
-    elseif info === false
+    elseif info === nothing || info === false
         return []
     else
         @eval Main begin

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -42,9 +42,9 @@ function find_callsites(interp::AbstractInterpreter, CI::Union{Core.CodeInfo, IR
                     args = (ignorelhs(stmt)::Expr).args
                 end
                 argtypes = mapany(function (@nospecialize(arg),)
-                                        t = argextype(arg, CI, sptypes, slottypes)
-                                        return ignorelimited(t)
-                                    end, args)
+                                      t = argextype(arg, CI, sptypes, slottypes)
+                                      return ignorelimited(t)
+                                  end, args)
                 callinfos = process_info(interp, info, argtypes, rt, optimize)
                 isempty(callinfos) && continue
                 callsite = let

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -97,7 +97,7 @@ function find_callsites(interp::AbstractInterpreter, CI::Union{Core.CodeInfo, IR
             if annotate_source
                 if mappings !== nothing
                     mapped = mappings[id]
-                    push!(sourcenodes, length(mapped) == 1 ? mapped[1] : callsite)
+                    push!(sourcenodes, length(mapped) == 1 ? tag_runtime(mapped[1], callsite.info) : callsite)
                 else
                     push!(sourcenodes, callsite)
                 end
@@ -363,3 +363,9 @@ function get_typed_sourcetext(mi, src, rt; warn::Bool=true)
     end
     return tsn, mappings
 end
+
+function tag_runtime(node::TypedSyntaxNode, info)
+    node.runtime = isa(info, RTCallInfo)
+    return node
+end
+tag_runtime(node, info) = node

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -220,11 +220,11 @@ function process_info(interp::AbstractInterpreter, @nospecialize(info::CCCallInf
             vmi = FailedCallInfo(sig, Union{})
         end
         return Any[ReturnTypeCallInfo(vmi)]
-    elseif info == NoCallInfo() && info !== nothing
+    elseif info == NoCallInfo()
         f = unwrapconst(argtypes[1])
         isa(f, Core.Builtin) && return []
         return [RTCallInfo(f, argtypes[2:end], rt)]
-    elseif info === nothing || info === false
+    elseif info === false
         return []
     else
         @eval Main begin

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -61,9 +61,17 @@ function build_options(callsites, with_effects::Bool, optimize::Bool, iswarn::Bo
                 nd = TypedSyntax.ndigits_linenumbers(node)
                 reduced_displaysize -= nd + 1
             end
-            string(chomp(sprint(node; context=:color=>true) do io, node
-                            printstyled(TextWidthLimiter(io, reduced_displaysize), node; iswarn, hide_type_stable)
-                         end))
+            string(chomp(
+                sprint(node; context=:color=>true) do io, node
+                    if TypedSyntax.is_runtime(node)
+                        if iswarn
+                            printstyled(io, "runtime "; color=:red)
+                        else
+                            print(io, "runtime ")
+                        end
+                    end
+                    printstyled(TextWidthLimiter(io, reduced_displaysize), node; iswarn, hide_type_stable)
+                end))
         end
     end
     push!(shown_callsites, "↩")

--- a/test/test_terminal.jl
+++ b/test/test_terminal.jl
@@ -204,8 +204,9 @@ end
                 Base.text_colors[Base.error_color()]
             end
             @test occursin("$(warncolor)%\e[39m2 = call → fmulti(::Any)::Union{Float32, Int64}", lines)
+            write(in, keydict[:down])
             write(in, keydict[:enter])
-            lines = cread1(out)
+            lines = cread(out)
             @test occursin("%2 = fmulti(::Int32)::Union{Float32, $Int}", lines)
             @test occursin("%2 = fmulti(::Float32)::Union{Float32, $Int}", lines)
             @test occursin("%2 = fmulti(::Char)::Union{Float32, $Int}", lines)

--- a/test/test_terminal.jl
+++ b/test/test_terminal.jl
@@ -204,9 +204,14 @@ end
                 Base.text_colors[Base.error_color()]
             end
             @test occursin("$(warncolor)%\e[39m2 = call → fmulti(::Any)::Union{Float32, Int64}", lines)
-            write(in, keydict[:down])
-            write(in, keydict[:enter])
-            lines = cread(out)
+            if isdefined(Core.Compiler, :NoCallInfo)
+                write(in, keydict[:down])
+                write(in, keydict[:enter])
+                lines = cread(out)
+            else
+                write(in, keydict[:enter])
+                lines = cread1(out)
+            end
             @test occursin("%2 = fmulti(::Int32)::Union{Float32, $Int}", lines)
             @test occursin("%2 = fmulti(::Float32)::Union{Float32, $Int}", lines)
             @test occursin("%2 = fmulti(::Char)::Union{Float32, $Int}", lines)


### PR DESCRIPTION
The list of call sites serves two purposes:

- it gives you options to descend into
- it summarizes the calls made by your function

Given the second purpose, I've sometimes been confused by the absence of an entry for the "worst" of all cases, runtime dispatch. This seems particularly accute for #345, but may have value even when examining the CodeInfo/IRCode.

Here's a demo: on `master`,
```julia
julia> function summer(list)
           s = 0      # deliberately not `zero(eltype(list))`
           for x in list
               s += x
           end
           return s
       end;

julia> @descend optimize=false summer([1.0, 2.0])
 ⋮
 • %3 = iterate(::Vector{Float64})::Union{Nothing, Tuple{Float64, Int64}}
   %10 = call → +(::Union{Float64, Int64},::Float64)::Float64
   %11 = iterate(::Vector{Float64},::Int64)::Union{Nothing, Tuple{Float64, Int64}}
   ↩
```
but
```julia
julia> @descend optimize=false summer(Any[1.0, 2.0])
 ⋮
 • %3 = iterate(::Vector{Any})::Union{Nothing, Tuple{Any, Int64}}
   %11 = iterate(::Vector{Any},::Int64)::Union{Nothing, Tuple{Any, Int64}}
   ↩
```
The absence of any "acknowledgement" of the call to `+` gave me pause.

In contrast, on this branch the first case is unchanged, whereas the second is
```julia
 • %3 = iterate(::Vector{Any})::Union{Nothing, Tuple{Any, Int64}}
   %10 = RT call +(::Any,::Any)::Any
   %11 = iterate(::Vector{Any},::Int64)::Union{Nothing, Tuple{Any, Int64}}
   ↩
```

I've set it up so that attempting to descend into the RT call gives this:
```
   %3 = iterate(::Vector{Any})::Union{Nothing, Tuple{Any, Int64}}
 • %10 = RT call +(::Any,::Any)::Any
   %11 = iterate(::Vector{Any},::Int64)::Union{Nothing, Tuple{Any, Int64}}
   ↩
[ Info: This is a runtime call. You cannot descend into it.
Select a call to descend into or ↩ to ascend. [q]uit. [b]ookmark.
Toggles: [o]ptimize, [w]arn, [h]ide type-stable statements, [d]ebuginfo, [r]emarks, [e]ffects, [i]nlining costs, [t]ype annotations, [s]yntax highlight for Source/LLVM/Native.
Show: [S]ource code, [A]ST, [T]yped code, [L]LVM IR, [N]ative code
Actions: [E]dit source code, [R]evise and redisplay
Advanced: dump [P]arams cache.
 • %3 = iterate(::Vector{Any})::Union{Nothing, Tuple{Any, Int64}}
   %10 = RT call +(::Any,::Any)::Any
   %11 = iterate(::Vector{Any},::Int64)::Union{Nothing, Tuple{Any, Int64}}
   ↩
```

I *think* filtering out all the `Core.Builtin` calls will prevent this from being too "noisy," but I'd be grateful for the thoughts of those who know much more about inference than me.