### PR TITLE
Don't assign statements to unused SSAValues

### DIFF
--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.3"
+version = "1.0.4"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -60,6 +60,12 @@ getchar1(idx) = charset1[idx]
 const charset2 = 'a':'z'
 getchar2(idx) = charset2[idx]
 
+# unused statements
+function mycheckbounds(A, i)
+    checkbounds(Bool, A, i) || Base.throw_boundserror(A, i)
+    return nothing
+end
+
 # Implementation of a struct & interface
 struct DefaultArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parentarray::A
@@ -311,6 +317,17 @@ end
     @test body.typ === Vector{Int}
     @test has_name_typ(child(body, 2, 1), :x, Tuple{Int,Int})
     @test has_name_typ(child(body, 3, 1), :y, Tuple{Int})
+
+    # Unused statements
+    tsn = TypedSyntaxNode(TSN.mycheckbounds, (Vector{Int}, Int))
+    @test tsn.typ === Nothing
+    sig, body = children(tsn)
+    errnode = child(body, 1, 2)
+    errf = child(errnode, 1)
+    @test errnode.typ === nothing && errf.typ === typeof(Base.throw_boundserror)
+    retnode = child(body, 2)
+    @test kind(retnode) == K"return"
+    @test retnode.typ === nothing || retnode.typ === Nothing
 
     # DataTypes
     tsn = TypedSyntaxNode(TSN.myoftype, (Float64, Int))


### PR DESCRIPTION
Inference stops at unreachable statements, and the ::Any annotations
could be quite confusing.