### PR TITLE
Pass codeinf to find callsites (annotate_source)

### DIFF
--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -441,7 +441,7 @@ function map_ssas_to_source(src::CodeInfo, rootnode::SyntaxNode, Δline::Int)
                     arg = stmt.args[1]
                     @assert is_slot(arg)
                     sym = src.slotnames[arg.id]
-                    if sym != Symbol("")
+                    if !is_gensym(sym)
                         lhsnode = node
                         while !is_prec_assignment(lhsnode)
                             lhsnode = lhsnode.parent

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -493,7 +493,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
         else
             @assert length(src.code) == length(infos)
         end
-        callsites, sourcenodes = find_callsites(interp, src, infos, mi, slottypes, optimize & !annotate_source, annotate_source)
+        callsites, sourcenodes = find_callsites(interp, annotate_source ? codeinf : src, infos, mi, slottypes, optimize & !annotate_source, annotate_source)
 
         if display_CI
             pc2remarks = remarks ? get_remarks(interp, override !== nothing ? override : mi) : nothing


### PR DESCRIPTION
Workaround for #364 (which may or may not be a bug)