### PR TITLE
Truncate body for default positional arg methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.8.1"
+version = "2.8.2"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
@@ -21,7 +21,7 @@ FoldingTrees = "1"
 JuliaSyntax = "0.3.2"
 Preferences = "1"
 SnoopPrecompile = "1"
-TypedSyntax = "1.0.2"
+TypedSyntax = "1.0.6"
 julia = "1.7"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -55,8 +55,9 @@ for type inference, unless there are so many that Julia stops trying to work
 out all the different combinations (see [this blog post](https://julialang.org/blog/2018/08/union-splitting/)
 for more information).
 
-**Note**: if the function is a keyword-argument function, you'll only see the signature of the function.
-Internally, Julia splits keyword functions into "keyword-filling" and "body" methods. If you're descending into kwarg-function `foo`, then the "body" function might be called something like `#foo#123`. You can select that in the "call" menu described below.
+**Note**: if the function has default positional or keyword arguments, you may see only the signature
+of the function. Internally, Julia creates additional methods to fill in default arguments, which in turn call the "body" method that appears in the source text. If you're descending into one of these "default-filling" functions,
+you won't be able to see types on variables that appear in the body method, so to reduce confusing the entire body is eliminated. You'll have an opportunity to descend further into the "body" method in the "call menu" described below.
 
 In the next section you may see something like
 
@@ -78,7 +79,11 @@ In the final section, you see:
 ![calls](images_readme/descend_calls.png)
 
 This is a menu of calls that you can further descend into. Move the dot `•` with the up and down
-arrow keys, and hit Enter to descend into a particular call. Any calls that are made at runtime ([dynamic dispatch](https://en.wikipedia.org/wiki/Dynamic_dispatch)) cannot be descended into;
+arrow keys, and hit Enter to descend into a particular call. Note that the naming of calls can sometimes
+vary from what you see in the source-text; for example, if you're descending into kwarg-function `foo`,
+then the "body" function might be called something like `#foo#123`.
+
+Any calls that are made at runtime ([dynamic dispatch](https://en.wikipedia.org/wiki/Dynamic_dispatch)) cannot be descended into;
 if you select one, you'll see
 
 ```
@@ -90,6 +95,8 @@ and the call menu will be printed again.
 Calls that start with `%nn = ...` are in Julia's internal
 [Abstract Syntax Tree (AST)](https://docs.julialang.org/en/v1/devdocs/ast/) form;
 for these calls, Cthulhu and/or [TypedSyntax](TypedSyntax/README.md) (a sub-package living inside the Cthulhu repository) failed to "map" the call back to the original source code.
+
+## Caveats
 
 As a word of warning, **mapping type inference results back to the source is hard, and there may be errors or omissions in this mapping**. See the [TypedSyntax README](TypedSyntax/README.md) for further details about the challenges. When you think there are reasons to doubt what you're seeing, a reliable but harder-to-interpret strategy is to directly view the [`[T]yped code`](#viewing-the-internal-representation-of-julia-code) rather than the `[S]ource code`.
 

--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.5"
+version = "1.0.6"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -214,6 +214,15 @@ function get_function_def(rootnode)
     return rootnode
 end
 
+function num_positional_args(tsn::AbstractSyntaxNode)
+    TypedSyntax.is_function_def(tsn) || return 0
+    sig, _ = children(tsn)
+    for (i, node) in enumerate(children(sig))
+        kind(node) == K"parameters" && return i-1
+    end
+    return length(children(sig))
+end
+
 # Recursively traverse `rootnode` and its children, and put all the instances in which
 # a given symbol appears into `symlocs[val]`.
 # This includes function names, operators, and literal values (like `1`, `"hello"`, etc.)

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -7,7 +7,7 @@ using InteractiveUtils
 using UUIDs
 using REPL: REPL, AbstractTerminal
 using JuliaSyntax
-using JuliaSyntax: SyntaxNode, child, children
+using JuliaSyntax: SyntaxNode, AbstractSyntaxNode, child, children
 using TypedSyntax
 
 import Core: MethodInstance

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -349,7 +349,7 @@ function get_typed_sourcetext(mi::MethodInstance, src::CodeInfo, @nospecialize(r
     meth = mi.def::Method
     tsn, mappings = TypedSyntax.tsn_and_mappings(meth, src, rt; warn, strip_macros=true)
     # If we're filling in keyword args, just show the signature
-    if is_kw_dispatch(meth)
+    if tsn !== nothing && (is_kw_dispatch(meth) || meth.nargs < TypedSyntax.num_positional_args(tsn))
         _, body = children(tsn)
         # eliminate the body node
         raw, bodyraw = tsn.raw, body.raw


### PR DESCRIPTION
Like kwarg methods, we should not print the body of the full
method if all we're doing is call a method that fills in default
positional arguments.