### PR TITLE
Improve callsites for SemiConcrete

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -493,7 +493,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
         else
             @assert length(src.code) == length(infos)
         end
-        callsites, sourcenodes = find_callsites(interp, annotate_source ? codeinf : src, infos, mi, slottypes, optimize & !annotate_source, annotate_source)
+        callsites, sourcenodes = find_callsites(interp, src, infos, mi, slottypes, optimize & !annotate_source, annotate_source)
 
         if display_CI
             pc2remarks = remarks ? get_remarks(interp, override !== nothing ? override : mi) : nothing


### PR DESCRIPTION
When handling  SemiConcrete call, it turns out that passing the CodeInfo
instead of the IRCode causes mistakes in the callsite menu---some
calls to Builtins instead get tagged as runtime. Revert to always passing
whatever code Cthulhu would rather work with, and handle IRCode
for fetching the source-text.