### PR TITLE
Handle `@nospecialize`

### DIFF
--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.7"
+version = "1.0.8"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -109,17 +109,21 @@ function TypedSyntaxNode(rootnode::SyntaxNode, src::CodeInfo, mappings, symtyps)
                     error("unexpected number of children: ", children(arg))
                 end
             end
+            outerarg = arg
+            if kind(outerarg) == K"macrocall"
+                arg = last(children(outerarg))
+            end
             kind(arg) == K"Identifier" || @show sig arg
             @assert kind(arg) == K"Identifier"
             if i > length(src.slotnames)
                 @assert defaultval != no_default_value
-                arg.typ = Core.Typeof(unwrapinternal(defaultval.val))
+                outerarg.typ = Core.Typeof(unwrapinternal(defaultval.val))
                 continue
             end
             argname = arg.val
             while i <= length(src.slotnames)
                 if src.slotnames[i] == argname
-                    arg.typ = unwrapinternal(src.slottypes[i])
+                    outerarg.typ = unwrapinternal(src.slottypes[i])
                     i += 1
                     break
                 end

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -101,6 +101,14 @@ include("test_module.jl")
     @test has_name_typ(child(body, 2, 2, 2), :t, Tuple{Int,Int})
     @test has_name_typ(child(body, 2, 3), :x, Char)
 
+    # signature macros
+    tsn = TypedSyntaxNode(TSN.nospec, (Any,))
+    sig, body = children(tsn)
+    node = child(sig, 2)
+    @test node.typ === Any && kind(node) == K"macrocall"
+    @test child(node, 1).val == Symbol("@nospecialize")
+    @test body.typ === Any
+
     # `ref` indexing
     st = """
         function setlist!(listset, listget, i, j)

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -105,8 +105,18 @@ include("test_module.jl")
     tsn = TypedSyntaxNode(TSN.nospec, (Any,))
     sig, body = children(tsn)
     node = child(sig, 2)
-    @test node.typ === Any && kind(node) == K"macrocall"
+    @test kind(node) == K"macrocall"
     @test child(node, 1).val == Symbol("@nospecialize")
+    @test has_name_typ(child(node, 2), :x, Any)
+    @test body.typ === Any
+    tsn = TypedSyntaxNode(TSN.nospec2, (AbstractVecOrMat,))
+    sig, body = children(tsn)
+    node = child(sig, 2)
+    @test kind(node) == K"macrocall"
+    @test child(node, 1).val == Symbol("@nospecialize")
+    arg = child(node, 2)
+    @test kind(arg) == K"::"
+    @test has_name_typ(child(arg, 1), :x, AbstractVecOrMat)
     @test body.typ === Any
 
     # `ref` indexing

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -109,4 +109,7 @@ nestedgenerators(j, k) = (a^2 for a = 1:j for _ = 1:k)
 nestedgenerators(j) = (a^2 for a = 1:j for _ = 1:j)
 nestedexplicit(k) = [Base.Generator(identity, 1:3) for _ = 1:k]
 
+# Argument annotations
+nospec(@nospecialize(x)) = 2x
+
 end

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -111,5 +111,6 @@ nestedexplicit(k) = [Base.Generator(identity, 1:3) for _ = 1:k]
 
 # Argument annotations
 nospec(@nospecialize(x)) = 2x
+nospec2(@nospecialize(x::AbstractVecOrMat)) = first(x)
 
 end


### PR DESCRIPTION
This handles argument-annotations in the signature.