### PR TITLE
Support `ascend(err)`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.8.2"
+version = "2.8.3"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -791,6 +791,7 @@ FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.wri
 
 function ascend(term, mi; interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
     root = treelist(mi)
+    root === nothing && return
     menu = TreeMenu(root)
     choice = menu.current
     while choice !== nothing

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -540,5 +540,6 @@ function maybe_callsite(info::MultiCallInfo, callee::MethodInstance)
     return false
 end
 maybe_callsite(info::PureCallInfo, mi::MethodInstance) = mi.specTypes <: Tuple{mapany(Core.Typeof ∘ unwrapconst, info.argtypes)...}
+maybe_callsite(info::RTCallInfo, mi::MethodInstance) = false
 
 unwrapconst(@nospecialize(arg)) = arg isa Core.Const ? arg.val : arg


### PR DESCRIPTION
Julia now has the global REPL varible `err`, and it's nice to be able to `ascend(err)`. This seems particularly handy for debugging MethodErrors as `ascend`/`descend` make the types visible.