### PR TITLE
Handle codelocs=0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "2.8.3"
+version = "2.8.4"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.10"
+version = "1.0.11"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -658,7 +658,7 @@ function symloc_key(sym::Symbol)
 end
 
 function getline(lt, j)
-    linfo = lt[j]
+    linfo = j == 0 ? first(lt) : lt[j]
     linfo.inlined_at == 0 && return linfo.line
     @assert linfo.method == Symbol("macro expansion")
     linfo = lt[linfo.inlined_at]
@@ -666,6 +666,7 @@ function getline(lt, j)
 end
 
 function getnextline(lt, j)
+    j == 0 && return typemax(Int)
     j += 1
     while j <= length(lt)
         linfo = lt[j]

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -113,6 +113,9 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
             # We empty the body when filling kwargs
             istruncated = isempty(children(body))
             idxend = istruncated ? JuliaSyntax.last_byte(sig) : lastindex(tsn.source)
+            if any(iszero, src.codelocs)
+                @warn "Some line information is missing, type-assignment may be incomplete"
+            end
             printstyled(lambda_io, tsn; type_annotations, iswarn, hide_type_stable, idxend)
             println(lambda_io)
             istruncated && @info "This method only fills in default arguments; descend into the body method to see the full source."


### PR DESCRIPTION
It's possible that the warning will be triggered spuriously, but for now it seems better to have it.

Fixes #379