### PR TITLE
Refactor arg-matching in the signature

### DIFF
--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -530,7 +530,9 @@ function map_ssas_to_source(src::CodeInfo, rootnode::SyntaxNode, Δline::Int)
                             # For each candidate source-node, push its parent-node into `stmtmapping`.
                             # The true call-node should be among these.
                             foreach(argmapping) do t
-                                push!(stmtmapping, skipped_parent(t))
+                                if t.parent !== nothing
+                                    push!(stmtmapping, skipped_parent(t))
+                                end
                             end
                         else
                             # Second or later matched argument

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -46,6 +46,8 @@ function summer_iterate(list)
 end
 
 zerowhere(::AbstractArray{T}) where T<:Real = zero(T)
+unnamedargs(::Type{<:AbstractMatrix{T}}, ::Type{Int}, c=1; a=1) where T<:Real = a
+unnamedargs2(::Type{Matrix}, op::Symbol; padding::Bool=false) = padding
 cb(a, i) = checkbounds(Bool, a, i)
 
 add2(x) = x[1] + x[2]


### PR DESCRIPTION
The handling of unnamed arguments was revealed to have
multiple problems; the majority of the new tests
in this PR failed on the previous version. This
redesigns how arguments are matched, notably increasing
the precision of how unnamed arguments like
`::Type{Bool}` are handled.

Fixes #392