### PR TITLE
Stop matching unsupplied args

### DIFF
--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.0.12"
+version = "1.1.0"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -155,9 +155,6 @@ function map_signature!(sig::TypedSyntaxNode, src::CodeInfo)
             push!(slotarg, idx)
             sigarg[idx] = length(slotarg)
         else
-            if defaultval != no_default_value && arg !== nothing # is this a default positional argument?
-                arg.typ = unwrapinternal(Core.Typeof(defaultval.val))
-            end
             # No match, save an empty spot
             push!(slotarg, 0)
         end
@@ -202,13 +199,6 @@ function map_signature!(sig::TypedSyntaxNode, src::CodeInfo)
                 if i <= length(src.slotnames)
                     slotarg[j] = i
                     sigarg[i] = j
-                else
-                    arg, defaultval = striparg(arg)
-                    @assert defaultval != no_default_value
-                    if kind(defaultval) == K"Identifier"
-                        val = defaultval.val
-                        arg.typ = unwrapinternal(Core.Typeof(val))
-                    end
                 end
             end
             i += 1

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -3,6 +3,7 @@ using TypedSyntax: TypedSyntax, TypedSyntaxNode, getsrc
 using InteractiveUtils, Test
 
 has_name_typ(node, name::Symbol, @nospecialize(T)) = kind(node) == K"Identifier" && node.val === name && node.typ === T
+has_name_notyp(node, name::Symbol) = has_name_typ(node, name, nothing)
 
 include("test_module.jl")
 
@@ -256,7 +257,7 @@ include("test_module.jl")
     tsn = TypedSyntaxNode(TSN.defaultarg, (Float32,))
     sig, body = children(tsn)
     @test has_name_typ(child(sig, 2), :x, Float32)
-    @test has_name_typ(child(sig, 3, 1), :y, Int)
+    @test has_name_notyp(child(sig, 3, 1), :y)
     # there is no argument 2 in tsn.typedsource
     tsn = TypedSyntaxNode(TSN.defaultarg, (Float32,Int))
     sig, body = children(tsn)
@@ -336,8 +337,8 @@ include("test_module.jl")
     sig, body = children(tsn)
     @test child(sig, 1, 2).typ === Type{Matrix{Float32}}
     @test child(sig, 1, 3).typ === Type{Int}
-    @test child(sig, 1, 4, 1).typ === Int
-    @test child(sig, 1, 5, 1, 1).typ === String
+    @test has_name_notyp(child(sig, 1, 4, 1), :c)
+    @test has_name_typ(child(sig, 1, 5, 1, 1), :a, String)
     m = @which TSN.unnamedargs(Matrix{Float32}, Int, :c; a="hello")
     mi = nothing
     for _mi in m.specializations
@@ -372,7 +373,7 @@ include("test_module.jl")
     sig, body = children(tsn)
     @test child(sig, 2).typ === Type{Matrix}
     @test child(sig, 3, 1).typ === Symbol
-    @test child(sig, 4, 1, 1, 1).typ === Bool
+    @test has_name_notyp(child(sig, 4, 1, 1, 1), :padding)
 
     # varargs
     tsn = TypedSyntaxNode(TSN.likevect, (Int, Int))


### PR DESCRIPTION
The function signature is handled specially: we go to effort
to match all arguments, even if they don't have names.
(e.g., `f(::AbstractMatrix)`). Previously, this included arguments
with default values, e.g., if `foo(x, y=2)` then for a call `foo(x)`
we assigned `y::Int`. However, this has two (interwoven) downsides:

- `foo(x)` is actually a different method, and `y` isn't an argument
  for the method we called. So it's a bit weird to give it a type.
- since it is a different method, we can't look up the types in the
  CodeInfo. While we can easily extract the types of literals
  from the source-text, when the default values get more
  complicated, e.g. `y = Int[i^2 for i = 1:3]`, we'd actually have
  run type-inference on that as an expression.

Thus for consistency, restrict type-matching to the arguments we have,
and abandon any attempt to assign types to unsupplied arguments.

While this is a change in behavior, it's analogous to Julia's
type-inference changing its outputs. Consequently I don't view
this as a breaking change. However, let's call this a new "feature"
and bump the TypedSyntax version to 1.1.0.

Closes #392 (again) 