### PR TITLE
sigs: pop `where` nodes to compute nargs

### DIFF
--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.1.1"
+version = "1.1.2"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -308,6 +308,10 @@ end
 function num_positional_args(tsn::AbstractSyntaxNode)
     TypedSyntax.is_function_def(tsn) || return 0
     sig, _ = children(tsn)
+    if kind(sig) == K"where"
+        sig = child(sig, 1)
+    end
+    @assert kind(sig) == K"call"
     for (i, node) in enumerate(children(sig))
         kind(node) == K"parameters" && return i-1
     end

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -447,6 +447,11 @@ include("test_module.jl")
     node = child(body, 1)
     @test node.typ === Type{Float64}
 
+    # Counting arguments (needed for Cthulhu)
+    # issue #397
+    tsn = TypedSyntaxNode(TSN.f397, (typeof(view([1,2,3], 1:2)),))
+    @test TypedSyntax.num_positional_args(tsn) == 2 # the function is arg1, x is arg2
+
     # Display
     tsn = TypedSyntaxNode(TSN.mysin, (Int,))
     str = sprint(tsn; context=:color=>false) do io, obj

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -146,4 +146,7 @@ function _generate_body385(N::Int)
 end
 @eval generated385(dest::AbstractVector) = $(_generate_body385(1))
 
+# Computing the number of args in the signature (issue #397)
+f397(x::SubArray{T, N, P, I, L}) where {T,N,P,I,L} = isempty(x)
+
 end


### PR DESCRIPTION
Cthulhu relies on the TypedSyntaxNode to determine whether default
args are being filled in. This depends on an accurate counting of the
number of arguments. However, this function was treating
`[where]` nodes as `[call]` nodes and counting children.
This peels off the `[where]` before counting.

Fixes #397