### PR TITLE
Add exhaustive Base-parsing test and fix errors

### DIFF
--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -14,7 +14,10 @@ julia = "1"
 
 [extras]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
+MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
+ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "Test"]
+test = ["InteractiveUtils", "Logging", "MethodAnalysis", "ProgressMeter", "Test"]

--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.1.2"
+version = "1.1.3"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -300,7 +300,7 @@ end
 
 function is_function_def(node)  # this is not `Base.is_function_def`
     kind(node) == K"function" && return true
-    if kind(node) == K"="
+    if kind(node) == K"=" && length(children(node)) >= 1
         sig = child(node, 1)
         while(kind(sig) ∈ KSet"where ::")   # allow MyType{T}(args...) and return-type annotations
             sig = child(sig, 1)

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -465,11 +465,10 @@ function map_ssas_to_source(src::CodeInfo, rootnode::SyntaxNode, Δline::Int)
         elseif isa(stmt, Core.ReturnNode)
             append_targets_for_line!(mapped, i, append_targets_for_arg!(argmapping, i, stmt.val))
         elseif isa(stmt, Expr)
-            if stmt.head == :(=)
+            if stmt.head == :(=) && is_slot(stmt.args[1])
                 # We defer setting up `symtyps` for the LHS because processing the RHS first might eliminate ambiguities
                 # # Update `symtyps` for this assignment
                 lhs = stmt.args[1]
-                @assert is_slot(lhs)
                 # For `mappings` we're interested only in the right hand side of this assignment
                 stmt = stmt.args[2]
                 if is_slot(stmt) || isa(stmt, SSAValue) || is_src_literal(stmt) # generic calls are handled below. Here, can we just look up the answer?
@@ -590,10 +589,9 @@ function map_ssas_to_source(src::CodeInfo, rootnode::SyntaxNode, Δline::Int)
                 # Because lowering can build methods that take a different number of arguments than appear in the
                 # source text, don't try to count arguments. Instead, find a symbol that is part of
                 # `node` or, for the LHS of a `slot = callexpr` statement, one that shares a parent with `node`.
-                if stmt.head == :(=)
+                if stmt.head == :(=) && is_slot(stmt.args[1])
                     # Tag the LHS of this expression
                     arg = stmt.args[1]
-                    @assert is_slot(arg)
                     sym = src.slotnames[arg.id]
                     if !is_gensym(sym)
                         lhsnode = node

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -122,6 +122,7 @@ function map_signature!(sig::TypedSyntaxNode, src::CodeInfo)
         if kind(arg) == K"curly"
             arg = first(children(arg))
         end
+        kind(arg) == K"tuple" && return nothing, defaultval     # FIXME? see extrema2 test
         @assert kind(arg) == K"Identifier" || is_operator(arg)
         return arg, defaultval
     end

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -31,7 +31,10 @@ function tsn_and_mappings(m::Method, src::CodeInfo, @nospecialize(rt); warn::Boo
         warn && @warn "couldn't retrieve source of $m"
         return nothing, nothing
     end
-    sourcetext, lineno = def
+    return tsn_and_mappings(m, src, rt, def...; warn, strip_macros, kwargs...)
+end
+
+function tsn_and_mappings(m::Method, src::CodeInfo, @nospecialize(rt), sourcetext::AbstractString, lineno::Integer; warn::Bool=true, strip_macros::Bool=false, kwargs...)
     rootnode = JuliaSyntax.parse(SyntaxNode, sourcetext; filename=string(m.file), first_line=lineno, kwargs...)
     if strip_macros
         rootnode = get_function_def(rootnode)

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -654,7 +654,8 @@ function map_ssas_to_source(src::CodeInfo, rootnode::SyntaxNode, Δline::Int)
                                 id = arg.args[1]
                                 name = sparam_name(mi, id)
                                 for t in symlocs[name]
-                                    symtyps[t] = Type{mi.sparam_vals[id]}
+                                    T = mi.sparam_vals[id]
+                                    symtyps[t] = Base.isvarargtype(T) ? T : Type{T}
                                 end
                             elseif isa(arg, GlobalRef)
                                 T = nothing

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -742,6 +742,7 @@ end
 
 function skipped_parent(node::SyntaxNode)
     pnode = node.parent
+    pnode === nothing && return node
     if pnode.parent !== nothing
         if kind(pnode) ∈ KSet"... quote"   # might need to add more things here
             pnode = pnode.parent

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -258,6 +258,12 @@ include("test_module.jl")
         @test_broken kind(node) == K"dotcall" && node.typ === Vector{String}
     end
 
+    # Misc lowering
+    tsn = TypedSyntaxNode(TSN.myunique, (AbstractRange,))
+    sig, body = children(tsn)
+    @test has_name_typ(child(body, 2), :r, AbstractRange)
+    @test_broken has_name_typ(child(body, 3, 2), :r, AbstractRange)
+
     # kwfuncs
     st = """
     function avoidzero(x; avoid_zero=true)

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -190,6 +190,10 @@ include("test_module.jl")
     @test has_name_typ(child(lhs, 2, 1), :b1, Any)
     @test has_name_typ(child(lhs, 2, 2), :b2, Any)
 
+    tsn = TypedSyntaxNode(TSN.extrema2, (Tuple{Int,Int}, Tuple{Int,Int}))
+    sig, body = children(tsn)
+    @test child(sig, 2).typ == Tuple{Int,Int}
+
     g = Base.Generator(identity, 1.0:4.0)
     tsn = TypedSyntaxNode(TSN.typeof_first_item, (typeof(g),))
     sig, body = children(tsn)

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -540,3 +540,7 @@ include("test_module.jl")
     end
     @test occursin("-(x::Float64)::Float64", str)
 end
+
+if parse(Bool, get(ENV, "CI", "false"))
+    include("exhaustive.jl")
+end

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -120,6 +120,16 @@ include("test_module.jl")
     @test has_name_typ(child(arg, 1), :x, AbstractVecOrMat)
     @test body.typ === Any
 
+    # signature return-type annotations
+    tsn = TypedSyntaxNode(TSN.withrt, (IO,))
+    @test tsn.typ === Bool
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 1, 2, 1), :io, IO)
+    tsn = TypedSyntaxNode(TSN.mytimes, (Bool,Float16))
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 1, 1, 2, 1), :x, Bool)
+    @test has_name_typ(child(sig, 1, 1, 3, 1), :y, Float16)
+
     # operators
     tsn = TypedSyntaxNode(+, (TSN.MyInt, TSN.MyInt))
     sig, body = children(tsn)

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -431,6 +431,12 @@ include("test_module.jl")
     @test kind(retnode) == K"return"
     @test retnode.typ === nothing || retnode.typ === Nothing
 
+    # Globals & scoped assignment
+    tsn = TypedSyntaxNode(TSN.setglobal, (Char,))
+    # Agnostic about whether it's good to tag the type of `myglobal`, but at least `val` should be tagged
+    sig, body = children(tsn)
+    @test has_name_typ(child(body, 1, 1, 2), :val, Char)
+
     # DataTypes
     tsn = TypedSyntaxNode(TSN.myoftype, (Float64, Int))
     sig, body = children(tsn)

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -440,6 +440,11 @@ include("test_module.jl")
     sig, body = children(tsn)
     @test child(body, 2, 1).typ <: Base.Pairs
 
+    # quoted symbols that could be confused for function definition
+    tsn = TypedSyntaxNode(TSN.isexpreq, (Expr,))
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 2, 1), :ex, Expr)
+
     # Unused statements
     tsn = TypedSyntaxNode(TSN.mycheckbounds, (Vector{Int}, Int))
     @test tsn.typ === Nothing

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -243,6 +243,16 @@ include("test_module.jl")
     cnodef = child(cnode, 1, 2, 1)
     @test kind(cnodef) == K"Identifier" && cnodef.val == :broadcasted
     @test cnode.typ <: Broadcast.Broadcasted
+    tsn = TypedSyntaxNode(TSN.fbroadcast2, (Vector{Int},))
+    sig, body = children(tsn)
+    node = child(body, 2)
+    src = tsn.typedsource
+    if isa(src.code[1], GlobalRef)
+        @test kind(node) == K"dotcall" && node.typ === Vector{String}
+    else
+        # We aren't quite handling this properly yet
+        @test_broken kind(node) == K"dotcall" && node.typ === Vector{String}
+    end
 
     # kwfuncs
     st = """

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -341,6 +341,12 @@ include("test_module.jl")
     @test child(sig, 1, 2).typ === Vector{Int16}
     @test body.typ === Int16
     @test has_name_typ(child(body, 2), :T, Type{Int16})
+    # tsn = TypedSyntaxNode(TSN.vaparam, (Matrix{Float32}, (String, Bool)))    # fails on `which`
+    m = @which TSN.vaparam(rand(3,3), ("hello", false))
+    mi = m.specializations[1]
+    tsn = TypedSyntaxNode(mi)
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 1, 3, 1), :I, Tuple{String, Bool})
     tsn = TypedSyntaxNode(TSN.cb, (Vector{Int16}, Int))
     sig, body = children(tsn)
     @test has_name_typ(child(body, 2), :Bool, Type{Bool})

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -126,6 +126,12 @@ fbroadcast_explicit(list) = sum(Base.materialize(Base.broadcasted(sin, list)))
 nospec(@nospecialize(x)) = 2x
 nospec2(@nospecialize(x::AbstractVecOrMat)) = first(x)
 
+# Return-type annotation
+withrt(io::IO)::Bool = eof(io)
+function mytimes(x::Bool, y::T)::promote_type(Bool,T) where T<:AbstractFloat
+    return ifelse(x, y, copysign(zero(y), y))
+end
+
 # Operators
 struct MyInt x::Int end
 Base.:+(a::MyInt, b::MyInt) = MyInt(a.x + b.x)

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -156,6 +156,7 @@ function bar381(foo)
     a, (b1, b2) = foo.a, foo.b
     return b1
 end
+extrema2((min1, max1), (min2, max2)) = (min(min1, min2), max(max1, max2))
 
 # Generated functions (issue #385)
 function _generate_body385(N::Int)

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -169,6 +169,9 @@ function _generate_body385(N::Int)
 end
 @eval generated385(dest::AbstractVector) = $(_generate_body385(1))
 
+# quoted `=`
+isexpreq(ex::Expr) = ex.head ∈ (:(=), :(.=))
+
 # Computing the number of args in the signature (issue #397)
 f397(x::SubArray{T, N, P, I, L}) where {T,N,P,I,L} = isempty(x)
 

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -75,6 +75,12 @@ function mycheckbounds(A, i)
     return nothing
 end
 
+# Globals & scoped assignment
+myglobal = nothing
+function setglobal(val)
+    global myglobal = val
+end
+
 # Implementation of a struct & interface
 struct DefaultArray{T,N,A<:AbstractArray{T,N}} <: AbstractArray{T,N}
     parentarray::A

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -131,6 +131,9 @@ fbroadcast(list) = sum(sin.(list))
 fbroadcast_explicit(list) = sum(Base.materialize(Base.broadcasted(sin, list)))
 fbroadcast2(list) = join("; value: " .* string.(list))   # double-broadcasted (.* and string.)
 
+# Lowered to `firstindex`
+myunique(r::AbstractRange) = allunique(r) ? r : oftype(r, r[begin:begin])
+
 # Argument annotations
 nospec(@nospecialize(x)) = 2x
 nospec2(@nospecialize(x::AbstractVecOrMat)) = first(x)

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -46,6 +46,8 @@ function summer_iterate(list)
 end
 
 zerowhere(::AbstractArray{T}) where T<:Real = zero(T)
+vaparam(a::AbstractArray{T,N}, I::NTuple{N,Any}) where {T,N} = N
+
 unnamedargs(::Type{<:AbstractMatrix{T}}, ::Type{Int}, c=1; a=1) where T<:Real = a
 unnamedargs2(::Type{Matrix}, op::Symbol; padding::Bool=false) = padding
 cb(a, i) = checkbounds(Bool, a, i)

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -127,6 +127,7 @@ nestedexplicit(k) = [Base.Generator(identity, 1:3) for _ = 1:k]
 # Broadcasting
 fbroadcast(list) = sum(sin.(list))
 fbroadcast_explicit(list) = sum(Base.materialize(Base.broadcasted(sin, list)))
+fbroadcast2(list) = join("; value: " .* string.(list))   # double-broadcasted (.* and string.)
 
 # Argument annotations
 nospec(@nospecialize(x)) = 2x


### PR DESCRIPTION
This adds a test that tries to construct TypedSyntaxNodes from all MethodInstances in Base or its submodules. It succeeds for more than 60,000, and fails for only 460, and as far as I can tell all of these are actually failures in CodeTracking.

This also fixes 6+ categories of previous errors, including:
- return-type annotations
- scoped assignment
- `f.(g.(list))`
- plain `Vararg` (which is not `<:Type`) in signatures
- signatures where variables are assigned by type-destructuring (e.g., `f((x, y)) = ...`)
- a couple of corner cases with poor matches between source and lowered code

This should give @jishnub less work to do in reporting bugs! I'd thought of a test along these lines from the beginning, but at the time I was bothered that there was no good way to evaluate whether the type-assignments were correct (no ground truth to compare against). But recently we haven't received reports about messed-up type assignments, and almost all recent bugs have been triggered by `@assert`s I sprinkled throughout the code to make sure I am thinking of all the possible cases. Consequently, a "does it even run?" test seems merited as a supplement to our tests that more carefully check outcome.

The new test takes a couple of minutes, so by default it only runs on CI.