### PR TITLE
fix #409/#408, improve `map_signature!`/`truncate_if_defaultargs!` robustness

### DIFF
--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -180,16 +180,18 @@ function map_signature!(sig::TypedSyntaxNode, src::CodeInfo)
                 # Match kwargs
                 argcontainer = children(last(children(sig)))
                 offset = length(children(sig)) - 1
-                names, typs = nt.parameters
-                for j = 1 : length(argcontainer)
-                    if iszero(slotarg[j + offset]) || src.slottypes[slotarg[j + offset]] === Union{}
-                        arg = argcontainer[j]
-                        arg, defaultval = argidentifier(arg)
-                        name = arg.val
-                        i = findfirst(==(name), names)
-                        if i !== nothing
-                            arg.typ = typs.parameters[i]
-                            slotarg[j + offset] = 0   # mark as complete
+                names, typs = Base.unwrap_unionall(nt).parameters
+                if names isa Tuple{Vararg{Symbol}} && typs isa DataType && typs.name === Tuple.name
+                    for j = 1 : length(argcontainer)
+                        if iszero(slotarg[j + offset]) || src.slottypes[slotarg[j + offset]] === Union{}
+                            arg = argcontainer[j]
+                            arg, defaultval = argidentifier(arg)
+                            name = arg.val
+                            i = findfirst(==(name), names)
+                            if i !== nothing
+                                arg.typ = typs.parameters[i]
+                                slotarg[j + offset] = 0   # mark as complete
+                            end
                         end
                     end
                 end

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -508,6 +508,11 @@ include("test_module.jl")
     node = child(body, 1)
     @test node.typ === Type{Float64}
 
+    # UnionAll in signature (issue #409)
+    tsn = TypedSyntaxNode(Core.kwcall, (NamedTuple, typeof(issorted), Vector{Int}))
+    sig, body = children(tsn)
+    @test has_name_typ(child(sig, 2), :itr, Vector{Int})
+
     # Counting arguments (needed for Cthulhu)
     # issue #397
     tsn = TypedSyntaxNode(TSN.f397, (typeof(view([1,2,3], 1:2)),))

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -509,9 +509,11 @@ include("test_module.jl")
     @test node.typ === Type{Float64}
 
     # UnionAll in signature (issue #409)
-    tsn = TypedSyntaxNode(Core.kwcall, (NamedTuple, typeof(issorted), Vector{Int}))
-    sig, body = children(tsn)
-    @test has_name_typ(child(sig, 2), :itr, Vector{Int})
+    @static if isdefined(Core, :kwcall)
+        tsn = TypedSyntaxNode(Core.kwcall, (NamedTuple, typeof(issorted), Vector{Int}))
+        sig, body = children(tsn)
+        @test has_name_typ(child(sig, 2), :itr, Vector{Int})
+    end
 
     # Counting arguments (needed for Cthulhu)
     # issue #397

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -369,7 +369,8 @@ function truncate_if_defaultargs!(tsn, mappings, meth)
             rawargs = raw.args[1:idx-1]
             tsn.raw = typeof(raw)(raw.head, sum(nd -> nd.span, rawargs), rawargs)
             body.raw = typeof(bodyraw)(bodyraw.head, UInt32(0), ())
-            empty!(children(body))
+            cs = children(body)
+            cs !== () && empty!(cs)
         end
         empty!(mappings)
     end


### PR DESCRIPTION
Unfortunately I couldn't make up a test case that exercises this issue (which happens when annotating a keyword method body).