### PR TITLE
Unwrap multiple layers of `where`

### DIFF
--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -13,6 +13,7 @@ JuliaSyntax = "0.3.2"
 julia = "1"
 
 [extras]
+Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 MethodAnalysis = "85b6ec6f-f7df-4429-9514-a64bcd9ee824"
@@ -20,4 +21,4 @@ ProgressMeter = "92933f4c-e287-5a05-a399-4b506db050ca"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["InteractiveUtils", "Logging", "MethodAnalysis", "ProgressMeter", "Test"]
+test = ["Dates", "InteractiveUtils", "Logging", "MethodAnalysis", "ProgressMeter", "Test"]

--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -333,7 +333,7 @@ end
 function num_positional_args(tsn::AbstractSyntaxNode)
     TypedSyntax.is_function_def(tsn) || return 0
     sig, _ = children(tsn)
-    if kind(sig) == K"where"
+    while kind(sig) == K"where"
         sig = child(sig, 1)
     end
     @assert kind(sig) == K"call"

--- a/TypedSyntax/src/show.jl
+++ b/TypedSyntax/src/show.jl
@@ -52,7 +52,7 @@ function Base.printstyled(io::IO, rootnode::MaybeTypedSyntaxNode;
 end
 Base.printstyled(rootnode::MaybeTypedSyntaxNode; kwargs...) = printstyled(stdout, rootnode; kwargs...)
 
-ndigits_linenumbers(node, idxend = last_byte(node)) = ndigits(node.source.first_line + nlines(node.source, idxend))
+ndigits_linenumbers(node, idxend = last_byte(node)) = ndigits(node.source.first_line + nlines(node.source, idxend) - 1)
 
 function show_src_expr(io::IO, node::MaybeTypedSyntaxNode, position::Int, pre::String, pre2::String; type_annotations::Bool=true, iswarn::Bool=false, hide_type_stable::Bool=false, nd::Int)
     _lastidx = last_byte(node)

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -1,6 +1,6 @@
 using JuliaSyntax: JuliaSyntax, SyntaxNode, children, child, sourcetext, kind, @K_str
 using TypedSyntax: TypedSyntax, TypedSyntaxNode, getsrc
-using InteractiveUtils, Test
+using Dates, InteractiveUtils, Test
 
 has_name_typ(node, name::Symbol, @nospecialize(T)) = kind(node) == K"Identifier" && node.val === name && node.typ === T
 has_name_notyp(node, name::Symbol) = has_name_typ(node, name, nothing)
@@ -532,6 +532,9 @@ include("test_module.jl")
     # issue #397
     tsn = TypedSyntaxNode(TSN.f397, (typeof(view([1,2,3], 1:2)),))
     @test TypedSyntax.num_positional_args(tsn) == 2 # the function is arg1, x is arg2
+    # issue #426
+    tsn = TypedSyntaxNode(getindex, (typeof(TSN.T426), Type{Year},))
+    @test TypedSyntax.num_positional_args(tsn) == 3
 
     # Display
     tsn = TypedSyntaxNode(TSN.mysin, (Int,))
@@ -589,10 +592,10 @@ include("test_module.jl")
         printstyled(io, obj; hide_type_stable=false)
     end
     @test str === """
-        4 function simplef(a::Int64, b::Float64)::Float64
-        5     z::Int64 = (a::Int64 * a::Int64)::Int64
-        6     return (z::Int64 + b::Float64)::Float64
-        7 end"""
+        5 function simplef(a::Int64, b::Float64)::Float64
+        6     z::Int64 = (a::Int64 * a::Int64)::Int64
+        7     return (z::Int64 + b::Float64)::Float64
+        8 end"""
     tsn = TypedSyntaxNode(TSN.myabs, (Float64,))
     str = sprint(tsn; context=:color=>false) do io, obj
         printstyled(io, obj; hide_type_stable=false)

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -1,4 +1,5 @@
 module TSN
+using Dates
 
 # with two uses of the same slot in the same call. Must start on line 4 (or update the corresponding test)
 function simplef(a, b)
@@ -205,5 +206,11 @@ end
 struct ReadOnly end
 fname = :eltype
 @eval Base.@propagate_inbounds @inline Base.$fname(::ReadOnly) = Int
+
+# Issue #426
+const T426 = Dict{Type{<:Dates.Period}, Bool}(
+    Dates.Year => true,
+    Dates.Month => false,
+)
 
 end


### PR DESCRIPTION
Fixes #426

Also fixes a small bug in computing the width needed for line numbers.