### PR TITLE
Import `typesof` as workaround

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
-version = "2.8.11"
+version = "2.8.12"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -17,6 +17,8 @@ import .CC: MethodMatch, LimitedAccuracy, ignorelimited
 import Base: unwrapva, isvarargtype, unwrap_unionall, rewrap_unionall
 const mapany = Base.mapany
 
+using Base: typesof    # workaround for https://github.com/JuliaLang/julia/issues/47606
+
 const ArgTypes = Vector{Any}
 
 @static if !isdefined(CC, :Effects)


### PR DESCRIPTION
Workaround for https://github.com/JuliaLang/julia/issues/47606 on
older Julia versions.