### PR TITLE
Fix `copy`

### DIFF
--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -279,7 +279,7 @@ function gettyp(node2ssa, node, src)
     return unwrapinternal(src.ssavaluetypes[i])
 end
 
-Base.copy(tsd::TypedSyntaxData) = TypedSyntaxData(tsd.source, tsd.typedsource, tsd.raw, tsd.position, tsd.val, tsd.typ)
+Base.copy(tsd::TypedSyntaxData) = TypedSyntaxData(tsd.source, tsd.typedsource, tsd.raw, tsd.position, tsd.val, tsd.typ, tsd.runtime)
 
 gettyp(node::AbstractSyntaxNode) = gettyp(node.data)
 gettyp(::JuliaSyntax.SyntaxData) = nothing

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -610,6 +610,10 @@ include("test_module.jl")
     tsn = TypedSyntaxNode(TSN.unnamedargs, (Type{Matrix{Float32}}, Type{Int}))
     sig, body = children(tsn)
     @test isa(TypedSyntax.map_signature!(sig, fill(Symbol(""), 3), Any[Any, Core.Const(2), Any]), TypedSyntaxNode)
+
+    # issue #435
+    tsnc = copy(tsn)
+    @test isa(tsnc, TypedSyntaxNode)
 end
 
 if parse(Bool, get(ENV, "CI", "false"))


### PR DESCRIPTION
Was never updated to incorporate the `runtime` arg.
Fixes #435