### PR TITLE
Check type of sourcenode before calling `children`

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -578,7 +578,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
                     show_sub_callsites = let callsite=callsite
                         map(info.callinfos) do ci
                             p = Base.unwrap_unionall(get_mi(ci).specTypes).parameters
-                            if length(p) == length(JuliaSyntax.children(sourcenode)) + 1
+                            if isa(sourcenode, TypedSyntax.MaybeTypedSyntaxNode) && length(p) == length(JuliaSyntax.children(sourcenode)) + 1
                                 newnode = copy(sourcenode)
                                 for (i, child) in enumerate(JuliaSyntax.children(newnode))
                                     child.typ = p[i+1]


### PR DESCRIPTION
xref #443

This fixes the immediate error, but descending further triggers another one that we probably need @aviatesk to help debug.