### PR TITLE
allow `src.slottypes === nothing` for unoptimized `src`

### DIFF
--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -135,24 +135,9 @@ function CC.type_annotate!(interp::CthulhuInterpreter, sv::InferenceState, run_o
 end
 end
 
-function annotate_slottypes!(sv::InferenceState)
-    slottypes = sv.slottypes
-    for i = 1:length(slottypes)
-        slottypes[i] = CC.widenconditional(slottypes[i])
-    end
-    CC.record_slot_assign!(sv)
-    return sv.src.slottypes
-end
-
 function InferredSource(state::InferenceState)
     unoptsrc = copy(state.src)
-    @static if VERSION ≥ v"1.10.0-DEV.1033"
-        if unoptsrc.slottypes === nothing
-            # `slottypes::Vector{Any}` hasn't been generated due to recursion,
-            # so manually generate it here
-            unoptsrc.slottypes = annotate_slottypes!(state)
-        end
-    else
+    @static if VERSION < v"1.10.0-DEV.1033"
         # xref: https://github.com/JuliaLang/julia/pull/49378
         unoptsrc.slottypes = let slottypes = unoptsrc.slottypes
             slottypes === nothing ? nothing : copy(slottypes)


### PR DESCRIPTION
On nightly Cthulhu.jl tries to generate `src.slottypes::Vector{Any}` even when there is heavy recursion detected (xref #418), but it turns out that `record_slot_assign!(sv)` works only when `sv.ssavaluetypes` does not contain any `LimitedAccuracy`ies (#442).

Luckily, while working on #418, we added the support in TypedSyntax for the `src.slottypes === nothing` case, so we can use it and remove the code to generate `src.slottypes::Vector{Any}`

Fixes #442.