### PR TITLE
Fixes for `MethodInstance` objects that do not come from a Method

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -511,7 +511,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
                     ioctx = IOContext(iostream,
                         :color => true,
                         :displaysize => displaysize(iostream), # displaysize doesn't propagate otherwise
-                        :SOURCE_SLOTNAMES => Base.sourceinfo_slotnames(codeinf),
+                        :SOURCE_SLOTNAMES => codeinf === nothing ? false : Base.sourceinfo_slotnames(codeinf),
                         :with_effects => with_effects)
                     stringify(ioctx) do lambda_io
                         cthulhu_typed(lambda_io, debuginfo, annotate_source ? codeinf : src, rt, effects, mi;

--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -103,7 +103,8 @@ instance(ipframes::Vector{IPFrames}) = isempty(ipframes) ? CC.Timings.ROOTmi : i
 backedges(ipframes::Vector{IPFrames}) = (ret = ipframes[2:end]; isempty(ret) ? () : (ret,))
 
 function callstring(io::IO, obj)
-    show_tuple_as_call(nonconcrete_red, IOContext(io, :color=>true), method(obj).name, specTypes(obj))
+    name = isa(method(obj), Method) ? method(obj).name : :toplevel
+    show_tuple_as_call(nonconcrete_red, IOContext(io, :color=>true), name, specTypes(obj))
     return String(take!(io))
 end
 function callstring(io::IO, sfs::Vector{StackTraces.StackFrame})

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -253,7 +253,11 @@ end
 function show_callinfo(limiter, mici::MICallInfo)
     mi = mici.mi
     tt = (Base.unwrap_unionall(mi.specTypes)::DataType).parameters[2:end]
-    name = (mi.def::Method).name
+    if !isa(mi.def, Method)
+        name = ":toplevel"
+    else
+        name = mi.def.name
+    end
     rt = get_rt(mici)
     __show_limited(limiter, name, tt, rt, get_effects(mici))
 end

--- a/test/test_Cthulhu.jl
+++ b/test/test_Cthulhu.jl
@@ -973,7 +973,7 @@ end
     end
 end
 
-@testset "Bare-bones MIs" begin
+@static VERSION ≥ v"1.9-" && @testset "Bare-bones MIs" begin
     # Get IR for a function, wrap it in a minimal methodinstance
     (ir, rt) = only(Base.code_ircode(sqrt, (Float64,)))
     mi = ccall(:jl_new_method_instance_uninit, Ref{Core.MethodInstance}, ());


### PR DESCRIPTION
When running `descend()` on a MethodInstance that does not come from a `Method`, we need to avoid attempting to tie back to the original source or method definition names.  This is the case when you have a chunk of IR that you have generated, but no real method to map back to it with.