### PR TITLE
Suppress annotation of types

### DIFF
--- a/TypedSyntax/src/show.jl
+++ b/TypedSyntax/src/show.jl
@@ -99,6 +99,12 @@ function type_annotation_mode(node, @nospecialize(T); type_annotations::Bool, hi
     type_annotate = is_show_annotation(T; type_annotations, hide_type_stable)
     pre = pre2 = post = ""
     if type_annotate
+        if T <: Type
+            # Don't annotate `String::Type{String}`
+            if replace(sourcetext(node), r"\s" => "") == replace(sprint(show, T.parameters[1]), r"\s" => "")
+                return false, pre, pre2, post
+            end
+        end
         if kind(node) ∈ KSet":: where" || is_infix_op_call(node) || (is_prec_assignment(node) && kind(node) != K"=")
             pre, post = "(", ")"
         elseif is_prefix_op_call(node) # insert parens after prefix op and before type-annotating

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -616,6 +616,18 @@ include("test_module.jl")
         printstyled(io, obj; hide_type_stable=false)
     end
     @test occursin("-(x::Float64)::Float64", str)
+    # Issue #482
+    arg = ["key"=>7]
+    tsn = TypedSyntaxNode(TSN.f482a, (typeof(arg),))
+    str = sprint(tsn; context=:color=>false) do io, obj
+        printstyled(io, obj; hide_type_stable=false)
+    end
+    @test occursin("::Type{Dict{String, Any}}", str)
+    tsn = TypedSyntaxNode(TSN.f482b, (typeof(arg),))
+    str = sprint(tsn; context=:color=>false) do io, obj
+        printstyled(io, obj; hide_type_stable=false)
+    end
+    @test !occursin("::Type{Dict{String, Any}}", str)
 
     # issue #413
     @test TypedSyntax.is_small_union_or_tunion(Union{})

--- a/TypedSyntax/test/test_module.jl
+++ b/TypedSyntax/test/test_module.jl
@@ -229,4 +229,9 @@ function fVSCode(x)
     return y + (x > 0 ? -1 : 1.0)
 end
 
+# Issue #482 & #465
+MyDict{T} = Dict{T,Any}
+f482a(x) = MyDict{String}(x)
+f482b(x) = Dict{String,Any}(x)
+
 end

--- a/test/test_codeview_vscode.jl
+++ b/test/test_codeview_vscode.jl
@@ -14,7 +14,7 @@ include("test_vscode_example_functions.jl")
     end
 
     function equal_upto_ordering(x, y)
-        if length(x) != length(y) 
+        if length(x) != length(y)
             return false
         end
 
@@ -41,7 +41,7 @@ include("test_vscode_example_functions.jl")
                 write(in, 'q')
                 wait(t)
             end
-            
+
             if inlay_types_vscode
                 @test length(VSCodeServer.inlay_hints) == 2
                 @test isempty(VSCodeServer.inlay_hints[2])
@@ -90,7 +90,7 @@ include("test_vscode_example_functions.jl")
                 write(in, 'q')
                 wait(t)
             end
-            
+
             if inlay_types_vscode
                 @test length(VSCodeServer.inlay_hints) == 2
                 @test isempty(VSCodeServer.inlay_hints[2])
@@ -168,7 +168,7 @@ include("test_vscode_example_functions.jl")
                         TypedSyntax.InlayHint(7, 19, "::Union{Float64, Int64}", 1)
                         TypedSyntax.InlayHint(10, 11, "(", 1)
                         TypedSyntax.InlayHint(10, 33, ")::Union{Float64, Int64}", 1)
-                    ])                
+                    ])
                 end
             end
         end
@@ -185,7 +185,7 @@ include("test_vscode_example_functions.jl")
                 write(in, 'q')
                 wait(t)
             end
-            
+
             if inlay_types_vscode
                 @test length(VSCodeServer.inlay_hints) == 2
                 @test isempty(VSCodeServer.inlay_hints[2])
@@ -207,7 +207,6 @@ include("test_vscode_example_functions.jl")
                 @test equal_upto_ordering(first(values(VSCodeServer.inlay_hints[1])), [
                     TypedSyntax.InlayHint(14, 18, "::Float64", 1)
                     TypedSyntax.InlayHint(14, 19, "::Int64", 1)
-                    TypedSyntax.InlayHint(15, 13, "::Type{Int64}", 1)
                     TypedSyntax.InlayHint(15, 15, "::Float64", 1)
                     TypedSyntax.InlayHint(15, 16, "::Int64", 1)
                     TypedSyntax.InlayHint(16, 9, "::Float64", 1)
@@ -230,7 +229,7 @@ include("test_vscode_example_functions.jl")
                 write(in, 'q')
                 wait(t)
             end
-            
+
             if inlay_types_vscode
                 @test length(VSCodeServer.inlay_hints) == 2
                 @test isempty(VSCodeServer.inlay_hints[2])
@@ -251,7 +250,6 @@ include("test_vscode_example_functions.jl")
                 @test equal_upto_ordering(first(values(VSCodeServer.inlay_hints[1])), [
                     TypedSyntax.InlayHint(14, 18, "::Int64", 1)
                     TypedSyntax.InlayHint(14, 19, "::Int64", 1)
-                    TypedSyntax.InlayHint(15, 13, "::Type{Int64}", 1)
                     TypedSyntax.InlayHint(15, 15, "::Int64", 1)
                     TypedSyntax.InlayHint(15, 16, "::Int64", 1)
                     TypedSyntax.InlayHint(16, 9, "::Int64", 1)


### PR DESCRIPTION
When a type like `String` appears explicitly in the source,
we don't need to annotate it as `String::Type{String}`.

Fixes #482
Fixes #465