### PR TITLE
Fixes bug in type parameter extraction

### DIFF
--- a/TypedSyntax/src/show.jl
+++ b/TypedSyntax/src/show.jl
@@ -94,17 +94,16 @@ function is_show_annotation(@nospecialize(T); type_annotations::Bool, hide_type_
     return isa(T, Type) && is_type_unstable(T)
 end
 
-extract_inner_type(x) = nothing
-extract_inner_type(::Type{Type{T}}) where T = T
 function type_annotation_mode(node, @nospecialize(T); type_annotations::Bool, hide_type_stable::Bool)
     kind(node) == K"return" && return false, "", "", ""
     type_annotate = is_show_annotation(T; type_annotations, hide_type_stable)
     pre = pre2 = post = ""
     if type_annotate
-        inner_type = extract_inner_type(T)
-        if T !== nothing && replace(sourcetext(node), r"\s" => "") == replace(sprint(show, inner_type), r"\s" => "")
-            return false, pre, pre2, post
-        end 
+        if T isa DataType && T <: Type && isassigned(T.parameters, 1)
+            if replace(sourcetext(node), r"\s" => "") == replace(sprint(show, T.parameters[1]), r"\s" => "")
+                return false, pre, pre2, post
+            end
+        end
         if kind(node) ∈ KSet":: where" || is_infix_op_call(node) || (is_prec_assignment(node) && kind(node) != K"=")
             pre, post = "(", ")"
         elseif is_prefix_op_call(node) # insert parens after prefix op and before type-annotating

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -666,6 +666,12 @@ include("test_module.jl")
     @test_nowarn str = sprint(tsn; context=:color=>false) do io, obj
         printstyled(io, obj; hide_type_stable=false)
     end
+
+    # issue 506
+    tsn, _ = TypedSyntax.tsn_and_mappings(collect, (typeof(Base.Generator(+, 1:2)),))
+    @test_nowarn str = sprint(tsn; context=:color=>false) do io, obj
+        printstyled(io, obj; hide_type_stable=false)
+    end
 end
 
 if parse(Bool, get(ENV, "CI", "false"))


### PR DESCRIPTION
Fixes #506 which was due to calling `extract_inner_type` with `Type{AbstractArray{var"#s91"<:Real, 1}}`. Uses suggestions from https://github.com/JuliaDebug/Cthulhu.jl/pull/493, this also removes the specialisation compared to the current implementation.