### PR TITLE
implement integration for exception type inference

### DIFF
--- a/src/interface.jl
+++ b/src/interface.jl
@@ -68,13 +68,14 @@ missing `$AbstractCursor` API:
 """)
 navigate(curs::CthulhuCursor, callsite::Callsite) = CthulhuCursor(get_mi(callsite))
 
-get_remarks(::AbstractInterpreter, ::Union{MethodInstance,InferenceResult}) = nothing
-get_remarks(interp::CthulhuInterpreter, key::Union{MethodInstance,InferenceResult}) = get(interp.remarks, key, nothing)
-get_remarks(::AbstractInterpreter, ::SemiConcreteCallInfo) = PC2Remarks()
+get_remarks(::AbstractInterpreter, ::InferenceKey) = nothing
+get_remarks(interp::CthulhuInterpreter, key::InferenceKey) = get(interp.remarks, key, nothing)
 
-get_effects(::AbstractInterpreter, ::Union{MethodInstance,InferenceResult}) = nothing
-get_effects(interp::CthulhuInterpreter, key::Union{MethodInstance,InferenceResult}) = get(interp.effects, key, nothing)
-get_effects(::AbstractInterpreter, ::SemiConcreteCallInfo) = PC2Effects()
+get_effects(::AbstractInterpreter, ::InferenceKey) = nothing
+get_effects(interp::CthulhuInterpreter, key::InferenceKey) = get(interp.effects, key, nothing)
+
+get_excts(::AbstractInterpreter, ::InferenceKey) = nothing
+get_excts(interp::CthulhuInterpreter, key::InferenceKey) = get(interp.exception_types, key, nothing)
 
 # This method is optional, but should be implemented if there is
 # a sensible default cursor for a MethodInstance

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -20,7 +20,8 @@ end
 
 function find_callsites(interp::AbstractInterpreter, CI::Union{Core.CodeInfo, IRCode},
                         stmt_infos::Union{Vector{CCCallInfo}, Nothing}, mi::Core.MethodInstance,
-                        slottypes::Vector{Any}, optimize::Bool=true, annotate_source::Bool=false)
+                        slottypes::Vector{Any}, optimize::Bool=true, annotate_source::Bool=false,
+                        pc2excts::Union{Nothing,PC2Excts}=nothing)
     sptypes = sptypes_from_meth_instance(mi)
     callsites, sourcenodes = Callsite[], Union{TypedSyntax.MaybeTypedSyntaxNode,Callsite}[]
     if isa(CI, IRCode)
@@ -53,7 +54,8 @@ function find_callsites(interp::AbstractInterpreter, CI::Union{Core.CodeInfo, IR
                                       t = argextype(arg, CI, sptypes, slottypes)
                                       return ignorelimited(t)
                                   end, args)
-                callinfos = process_info(interp, info, argtypes, rt, optimize)
+                exct = isnothing(pc2excts) ? nothing : get(pc2excts, id, nothing)
+                callinfos = process_info(interp, info, argtypes, rt, optimize, exct)
                 isempty(callinfos) && continue
                 callsite = let
                     if length(callinfos) == 1
@@ -116,7 +118,8 @@ function find_callsites(interp::AbstractInterpreter, CI::Union{Core.CodeInfo, IR
 end
 
 function process_const_info(interp::AbstractInterpreter, @nospecialize(thisinfo),
-    argtypes::ArgTypes, @nospecialize(rt), @nospecialize(result), optimize::Bool)
+    argtypes::ArgTypes, @nospecialize(rt), @nospecialize(result), optimize::Bool,
+    @nospecialize(exct))
     is_cached(@nospecialize(key)) = can_descend(interp, key, optimize)
 
     if isnothing(result)
@@ -128,55 +131,57 @@ function process_const_info(interp::AbstractInterpreter, @nospecialize(thisinfo)
     elseif isa(result, CC.ConcreteResult)
         linfo = result.mi
         effects = get_effects(result)
-        mici = MICallInfo(linfo, rt, effects)
+        mici = MICallInfo(linfo, rt, effects, exct)
         return ConcreteCallInfo(mici, argtypes)
     elseif isa(result, CC.ConstPropResult)
         result = result.result
         linfo = result.linfo
         effects = get_effects(result)
-        mici = MICallInfo(linfo, rt, effects)
+        mici = MICallInfo(linfo, rt, effects, exct)
         return ConstPropCallInfo(is_cached(optimize ? linfo : result) ? mici : UncachedCallInfo(mici), result)
     elseif isa(result, CC.SemiConcreteResult)
         linfo = result.mi
         effects = get_effects(result)
-        mici = MICallInfo(linfo, rt, effects)
+        mici = MICallInfo(linfo, rt, effects, exct)
         return SemiConcreteCallInfo(mici, result.ir)
     else
         @assert isa(result, CC.InferenceResult)
         linfo = result.linfo
         effects = get_effects(result)
-        mici = MICallInfo(linfo, rt, effects)
+        mici = MICallInfo(linfo, rt, effects, exct)
         return ConstPropCallInfo(is_cached(optimize ? linfo : result) ? mici : UncachedCallInfo(mici), result)
     end
 end
 
-function process_info(interp::AbstractInterpreter, @nospecialize(info::CCCallInfo), argtypes::ArgTypes, @nospecialize(rt), optimize::Bool)
+function process_info(interp::AbstractInterpreter, @nospecialize(info::CCCallInfo),
+                      argtypes::ArgTypes, @nospecialize(rt), optimize::Bool,
+                      @nospecialize(exct))
     is_cached(@nospecialize(key)) = can_descend(interp, key, optimize)
-    process_recursive(@nospecialize(newinfo)) = process_info(interp, newinfo, argtypes, rt, optimize)
+    process_recursive(@nospecialize(newinfo)) = process_info(interp, newinfo, argtypes, rt, optimize, exct)
 
     if isa(info, MethodResultPure)
         if isa(info.info, CC.ReturnTypeCallInfo)
             # xref: https://github.com/JuliaLang/julia/pull/45299#discussion_r871939049
             info = info.info # cascade to the special handling below
         else
-            return Any[PureCallInfo(argtypes, rt)]
+            return CallInfo[PureCallInfo(argtypes, rt)]
         end
     end
     if isa(info, MethodMatchInfo)
         if info.results === missing
-            return []
+            return CallInfo[]
         end
         matches = info.results.matches
-        return mapany(matches) do match::Core.MethodMatch
+        return CallInfo[let
             mi = specialize_method(match)
             effects = get_effects(interp, mi, false)
-            mici = MICallInfo(mi, rt, effects)
-            return is_cached(mi) ? mici : UncachedCallInfo(mici)
-        end
+            mici = MICallInfo(mi, rt, effects, exct)
+            is_cached(mi) ? mici : UncachedCallInfo(mici)
+        end for match::Core.MethodMatch in matches]
     elseif isa(info, UnionSplitInfo)
-        return mapreduce(process_recursive, vcat, info.matches; init=[])::Vector{Any}
+        return mapreduce(process_recursive, vcat, info.matches; init=CallInfo[])::Vector{CallInfo}
     elseif isa(info, UnionSplitApplyCallInfo)
-        return mapreduce(process_recursive, vcat, info.infos; init=[])::Vector{Any}
+        return mapreduce(process_recursive, vcat, info.infos; init=CallInfo[])::Vector{CallInfo}
     elseif isa(info, ApplyCallInfo)
         # XXX: This could probably use its own info. For now,
         # we ignore any implicit iterate calls.
@@ -184,32 +189,32 @@ function process_info(interp::AbstractInterpreter, @nospecialize(info::CCCallInf
     elseif isa(info, ConstCallInfo)
         infos = process_recursive(info.call)
         @assert length(infos) == length(info.results)
-        return mapany(enumerate(info.results)) do (i, result)
-            process_const_info(interp, infos[i], argtypes, rt, result, optimize)
-        end
+        return CallInfo[let
+            process_const_info(interp, infos[i], argtypes, rt, result, optimize, exct)
+        end for (i, result) in enumerate(info.results)]
     elseif isa(info, CC.InvokeCallInfo)
         mi = specialize_method(info.match; preexisting=true)
         effects = get_effects(interp, mi, false)
         thisinfo = MICallInfo(mi, rt, effects)
-        innerinfo = process_const_info(interp, thisinfo, argtypes, rt, info.result, optimize)
+        innerinfo = process_const_info(interp, thisinfo, argtypes, rt, info.result, optimize, exct)
         info = InvokeCallInfo(innerinfo)
-        return Any[info]
+        return CallInfo[info]
     elseif isa(info, CC.OpaqueClosureCallInfo)
         mi = specialize_method(info.match; preexisting=true)
         effects = get_effects(interp, mi, false)
         thisinfo = MICallInfo(mi, rt, effects)
-        innerinfo = process_const_info(interp, thisinfo, argtypes, rt, info.result, optimize)
+        innerinfo = process_const_info(interp, thisinfo, argtypes, rt, info.result, optimize, exct)
         info = OCCallInfo(innerinfo)
-        return Any[info]
+        return CallInfo[info]
     elseif isa(info, CC.OpaqueClosureCreateInfo)
         # TODO: Add ability to descend into OCs at creation site
-        return []
+        return CallInfo[]
     elseif isa(info, CC.FinalizerInfo)
         # TODO: Add ability to descend into finalizers at creation site
-        return []
+        return CallInfo[]
     elseif isa(info, CC.ReturnTypeCallInfo)
         newargtypes = argtypes[2:end]
-        callinfos = process_info(interp, info.info, newargtypes, unwrapType(widenconst(rt)), optimize)
+        callinfos = process_info(interp, info.info, newargtypes, unwrapType(widenconst(rt)), optimize, exct)
         if length(callinfos) == 1
             vmi = only(callinfos)
         else
@@ -218,13 +223,13 @@ function process_info(interp::AbstractInterpreter, @nospecialize(info::CCCallInf
             sig = Tuple{widenconst(newargtypes[1]), argt.parameters...}
             vmi = FailedCallInfo(sig, Union{})
         end
-        return Any[ReturnTypeCallInfo(vmi)]
+        return CallInfo[ReturnTypeCallInfo(vmi)]
     elseif info == NoCallInfo()
         f = unwrapconst(argtypes[1])
-        isa(f, Core.Builtin) && return []
-        return [RTCallInfo(f, argtypes[2:end], rt)]
+        isa(f, Core.Builtin) && return CallInfo[]
+        return CallInfo[RTCallInfo(f, argtypes[2:end], rt, exct)]
     elseif info === false
-        return []
+        return CallInfo[]
     else
         @eval Main begin
             interp = $interp
@@ -352,7 +357,6 @@ function get_typed_sourcetext(mi::MethodInstance, src::CodeInfo, @nospecialize(r
     meth = mi.def::Method
     tsn, mappings = TypedSyntax.tsn_and_mappings(meth, src, rt; warn, strip_macros=true)
     return truncate_if_defaultargs!(tsn, mappings, meth)
-    return tsn, mappings
 end
 
 function get_typed_sourcetext(mi::MethodInstance, ::IRCode, @nospecialize(rt); kwargs...)

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -13,7 +13,7 @@ mutable struct CthulhuMenu <: TerminalMenus.ConfiguredMenu{TerminalMenus.Config}
     custom_toggles::Vector{CustomToggle}
 end
 
-function show_as_line(callsite::Callsite, with_effects::Bool, optimize::Bool, iswarn::Bool)
+function show_as_line(callsite::Callsite, with_effects::Bool, exception_type::Bool, optimize::Bool, iswarn::Bool)
     reduced_displaysize = displaysize(stdout)::Tuple{Int,Int} .- (0, 3)
     sprint() do io
         show(IOContext(io,
@@ -21,15 +21,17 @@ function show_as_line(callsite::Callsite, with_effects::Bool, optimize::Bool, is
             :displaysize  => reduced_displaysize,
             :optimize     => optimize,
             :iswarn       => iswarn,
-            :color        => iswarn | with_effects,
-            :with_effects => with_effects),
+            :color        => iswarn | with_effects | exception_type,
+            :with_effects => with_effects,
+            :exception_type => exception_type),
             callsite)
     end
 end
 
-function CthulhuMenu(callsites, with_effects::Bool, optimize::Bool, iswarn::Bool, hide_type_stable::Bool,
+function CthulhuMenu(callsites, with_effects::Bool, exception_type::Bool,
+                     optimize::Bool, iswarn::Bool, hide_type_stable::Bool,
                      custom_toggles::Vector{CustomToggle}; pagesize::Int=10, sub_menu = false, kwargs...)
-    options = build_options(callsites, with_effects, optimize, iswarn, hide_type_stable)
+    options = build_options(callsites, with_effects, exception_type, optimize, iswarn, hide_type_stable)
     length(options) < 1 && error("CthulhuMenu must have at least one option")
 
     # if pagesize is -1, use automatic paging
@@ -47,15 +49,15 @@ function CthulhuMenu(callsites, with_effects::Bool, optimize::Bool, iswarn::Bool
     return CthulhuMenu(options, pagesize, pageoffset, selected, nothing, sub_menu, config, custom_toggles)
 end
 
-build_options(callsites::Vector{Callsite}, with_effects::Bool, optimize::Bool, iswarn::Bool, ::Bool) =
-    vcat(map(callsite->show_as_line(callsite, with_effects, optimize, iswarn), callsites), ["↩"])
-function build_options(callsites, with_effects::Bool, optimize::Bool, iswarn::Bool, hide_type_stable::Bool)
+build_options(callsites::Vector{Callsite}, with_effects::Bool, exception_type::Bool, optimize::Bool, iswarn::Bool, ::Bool) =
+    vcat(map(callsite->show_as_line(callsite, with_effects, exception_type, optimize, iswarn), callsites), ["↩"])
+function build_options(callsites, with_effects::Bool, exception_type::Bool, optimize::Bool, iswarn::Bool, hide_type_stable::Bool)
     reduced_displaysize::Int = (displaysize(stdout)::Tuple{Int,Int})[2] - 3
     nd::Int = -1
 
     shown_callsites = map(callsites) do node
         if isa(node, Callsite)
-            show_as_line(node, with_effects, optimize, iswarn)
+            show_as_line(node, with_effects, exception_type, optimize, iswarn)
         else
             if nd == -1
                 nd = TypedSyntax.ndigits_linenumbers(node)
@@ -92,8 +94,10 @@ function stringify(@nospecialize(f), context::IOContext)
 end
 
 const debugcolors = (:nothing, :light_black, :yellow)
-function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_type_stable, debuginfo, remarks, with_effects, inline_cost, type_annotations, highlight, 
-    inlay_types_vscode, diagnostics_vscode, jump_always, custom_toggles::Vector{CustomToggle})
+function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_type_stable,
+               debuginfo, remarks, with_effects, exception_type, inline_cost,
+               type_annotations, highlight, inlay_types_vscode, diagnostics_vscode,
+               jump_always, custom_toggles::Vector{CustomToggle})
     colorize(use_color::Bool, c::Char) = stringify() do io
         use_color ? printstyled(io, c; color=:cyan) : print(io, c)
     end
@@ -123,7 +127,8 @@ function usage(@nospecialize(view_cmd), annotate_source, optimize, iswarn, hide_
                 printstyled(io, 'd'; color=debugcolors[Int(debuginfo)+1])
             end, "]ebuginfo, [",
             colorize(remarks, 'r'), "]emarks, [",
-            colorize(with_effects, 'e'), "]ffects, [",
+            colorize(with_effects, 'e'), "]ffects, ",
+            "e[", colorize(exception_type, 'x'), "]ception types, [",
             colorize(inline_cost, 'i'), "]nlining costs")
     end
     for i = 1:length(custom_toggles)
@@ -157,6 +162,7 @@ const TOGGLES = Dict(
     UInt32('d') => :debuginfo,
     UInt32('r') => :remarks,
     UInt32('e') => :with_effects,
+    UInt32('x') => :exception_type,
     UInt32('i') => :inline_cost,
     UInt32('t') => :type_annotations,
     UInt32('s') => :highlighter,

--- a/test/generate_irshow.jl
+++ b/test/generate_irshow.jl
@@ -11,7 +11,7 @@ function generate_test_cases(f, tt, fname=string(nameof(f)))
     outputs = Dict()
     tf = (true, false)
     for optimize in tf
-        (; src, infos, mi, rt, effects, slottypes) = cthulhu_info(f, tt; optimize);
+        (; src, infos, mi, rt, exct, effects, slottypes) = cthulhu_info(f, tt; optimize);
         for (debuginfo, iswarn, hide_type_stable, inline_cost, type_annotations) in Iterators.product(
             instances(Cthulhu.DInfo.DebugInfo), tf, tf, tf, tf,
         )
@@ -20,7 +20,7 @@ function generate_test_cases(f, tt, fname=string(nameof(f)))
 
             s = sprint(; context=:color=>true) do io
                 Cthulhu.cthulhu_typed(io, debuginfo,
-                                      src, rt, effects, mi;
+                                      src, rt, exct, effects, mi;
                                       iswarn, hide_type_stable, inline_cost, type_annotations)
             end
             s = strip_base_linenums(s)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -5,11 +5,11 @@ end
 
 function cthulhu_info(@nospecialize(f), @nospecialize(TT=()); optimize=true)
     (interp, mi) = Cthulhu.mkinterp(Core.Compiler.NativeInterpreter(), f, TT)
-    (; src, rt, infos, slottypes, effects) = Cthulhu.lookup(interp, mi, optimize; allow_no_src=true)
+    (; src, rt, exct, infos, slottypes, effects) = Cthulhu.lookup(interp, mi, optimize; allow_no_src=true)
     if src !== nothing
         src = Cthulhu.preprocess_ci!(src, mi, optimize, Cthulhu.CthulhuConfig(dead_code_elimination=true))
     end
-    (; interp, src, infos, mi, rt, slottypes, effects)
+    (; interp, src, infos, mi, rt, exct, slottypes, effects)
 end
 
 function find_callsites_by_ftt(@nospecialize(f), @nospecialize(TT=Tuple{}); optimize=true)

--- a/test/test_Cthulhu.jl
+++ b/test/test_Cthulhu.jl
@@ -357,11 +357,7 @@ end
         callsites, _ = Cthulhu.find_callsites(interp, src, infos, mi, slottypes, false)
         @test isa(callsites[1].info, Cthulhu.SemiConcreteCallInfo)
         @test occursin("= < semi-concrete eval > getproperty(::ComplexF64,::Core.Const(:re))::Float64", string(callsites[1]))
-
         @test Cthulhu.get_rt(callsites[end].info) == Core.Const(sin(1.0))
-
-        @test Cthulhu.get_remarks(interp, callsites[1].info) == Cthulhu.PC2Remarks()
-        @test Cthulhu.get_effects(interp, callsites[1].info) == Cthulhu.PC2Effects()
     end
 end
 
@@ -677,9 +673,9 @@ end
         end
     end
     function doprint(f)
-        (; src, mi, rt, effects) = cthulhu_info(f)
+        (; src, mi, rt, exct, effects) = cthulhu_info(f)
         io = IOBuffer()
-        Cthulhu.cthulhu_typed(io, :none, src, rt, effects, mi; iswarn=false)
+        Cthulhu.cthulhu_typed(io, :none, src, rt, exct, effects, mi; iswarn=false)
         return String(take!(io))
     end
     @test occursin("invoke f1()::…\n", doprint(getfield(m, :f1)))

--- a/test/test_codeview.jl
+++ b/test/test_codeview.jl
@@ -10,7 +10,7 @@ using .TestCodeViewSandbox
 Revise.track(TestCodeViewSandbox, normpath(@__DIR__, "TestCodeViewSandbox.jl"))
 
 @testset "printer test" begin
-    (; interp, src, infos, mi, rt, effects, slottypes) = cthulhu_info(testf_revise);
+    (; interp, src, infos, mi, rt, exct, effects, slottypes) = cthulhu_info(testf_revise);
     tf = (true, false)
 
     @testset "codeview: $codeview" for codeview in Cthulhu.CODEVIEWS
@@ -35,7 +35,7 @@ Revise.track(TestCodeViewSandbox, normpath(@__DIR__, "TestCodeViewSandbox.jl"))
                     @testset "type_annotations: $type_annotations" for type_annotations in tf
                         io = IOBuffer()
                         Cthulhu.cthulhu_typed(io, debuginfo,
-                            src, rt, effects, mi;
+                            src, rt, exct, effects, mi;
                             iswarn, hide_type_stable, inline_cost, type_annotations)
                         @test !isempty(String(take!(io))) # just check it works
                     end
@@ -47,7 +47,7 @@ end
 
 @testset "hide type-stable statements" begin
     let # optimize code
-        (; src, infos, mi, rt, effects, slottypes) = @eval Module() begin
+        (; src, infos, mi, rt, exct, effects, slottypes) = @eval Module() begin
             const globalvar = Ref(42)
             $cthulhu_info() do
                 a = sin(globalvar[])
@@ -57,7 +57,7 @@ end
         end
         function prints(; kwargs...)
             io = IOBuffer()
-            Cthulhu.cthulhu_typed(io, :none, src, rt, effects, mi; kwargs...)
+            Cthulhu.cthulhu_typed(io, :none, src, rt, exct, effects, mi; kwargs...)
             return String(take!(io))
         end
 
@@ -74,7 +74,7 @@ end
     end
 
     let # unoptimize code
-        (; src, infos, mi, rt, effects, slottypes) = @eval Module() begin
+        (; src, infos, mi, rt, exct, effects, slottypes) = @eval Module() begin
             const globalvar = Ref(42)
             $cthulhu_info(; optimize=false) do
                 a = sin(globalvar[])
@@ -84,7 +84,7 @@ end
         end
         function prints(; kwargs...)
             io = IOBuffer()
-            Cthulhu.cthulhu_typed(io, :none, src, rt, effects, mi; kwargs...)
+            Cthulhu.cthulhu_typed(io, :none, src, rt, exct, effects, mi; kwargs...)
             return String(take!(io))
         end
 

--- a/test/test_irshow.jl
+++ b/test/test_irshow.jl
@@ -10,7 +10,7 @@ include("IRShowSandbox.jl")
     tf = (true, false)
 
     @testset "optimize: $optimize" for optimize in tf
-        (; src, infos, mi, rt, effects, slottypes) = cthulhu_info(IRShowSandbox.foo, (Int, Int); optimize);
+        (; src, infos, mi, rt, exct, effects, slottypes) = cthulhu_info(IRShowSandbox.foo, (Int, Int); optimize);
 
         @testset "debuginfo: $debuginfo" for debuginfo in instances(Cthulhu.DInfo.DebugInfo)
             @testset "iswarn: $iswarn" for iswarn in tf
@@ -22,7 +22,7 @@ include("IRShowSandbox.jl")
 
                             s = sprint(; context=:color=>true) do io
                                 Cthulhu.cthulhu_typed(io, debuginfo,
-                                                      src, rt, effects, mi;
+                                                      src, rt, exct, effects, mi;
                                                       iswarn, hide_type_stable, inline_cost, type_annotations)
                             end
                             s = strip_base_linenums(s)


### PR DESCRIPTION
Integration for JuliaLang/julia#51754.
Statement-wise and call-wise information is available only after `v"1.11.0-DEV.1127"`.
![Screenshot 2023-12-20 at 7 57 01 PM](https://github.com/JuliaDebug/Cthulhu.jl/assets/40514306/05290aa5-49a4-413a-92cc-90f4b49a1b5f)
