### PR TITLE
Fix `show_src_expr` on 32 bit Julia

### DIFF
--- a/TypedSyntax/src/show.jl
+++ b/TypedSyntax/src/show.jl
@@ -80,7 +80,7 @@ function show_src_expr(io::IO, node::MaybeTypedSyntaxNode, position::Int, pre::S
         position = show_src_expr(io, child, position, cpre, cpre2; type_annotations, iswarn, hide_type_stable, nd)
         ctype_annotate && show_annotation(io, cT, cpost, node.source, position; iswarn)
     end
-    return catchup(io, node, position, nd, _lastidx+1)
+    return Int(catchup(io, node, position, nd, _lastidx+1))
 end
 
 # should we print a type-annotation?


### PR DESCRIPTION
Fixes #524.

`_lastidx` is a `UInt32`, so the result of `catchup` ends up a `UInt32`. This then gets assigned to `position` (line 80) which is expected to be an `Int`. I didn't convert `_lastidx` to an `Int` because I thought converting the return value might minimise the chances of an InexactError.