### PR TITLE
changes to adapt to compressed line table format

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -127,9 +127,6 @@ function cthulhu_typed(io::IO, debuginfo::Symbol,
             # We empty the body when filling kwargs
             istruncated = isempty(children(body))
             idxend = istruncated ? JuliaSyntax.last_byte(sig) : lastindex(tsn.source)
-            if any(iszero, src.codelocs)
-                @warn "Some line information is missing, type-assignment may be incomplete"
-            end
             if src.slottypes === nothing
                 @warn "Inference terminated in an incomplete state due to argument-type changes during recursion"
             end

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -153,7 +153,8 @@ function CC.src_inlining_policy(interp::CthulhuInterpreter,
             src::Any, info::CCCallInfo, stmt_flag::UInt32)
     end
 end
-CC.retrieve_ir_for_inlining(cached_result::CodeInstance, src::OptimizedSource) = CC.copy(src.ir)
+CC.retrieve_ir_for_inlining(cached_result::CodeInstance, src::OptimizedSource) =
+    CC.retrieve_ir_for_inlining(cached_result.def, src.ir::IRCode, true)
 CC.retrieve_ir_for_inlining(mi::MethodInstance, src::OptimizedSource, preserve_local_sources::Bool) =
     CC.retrieve_ir_for_inlining(mi, src.ir, preserve_local_sources)
 elseif VERSION ≥ v"1.11.0-DEV.879"

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -336,7 +336,12 @@ function find_caller_of(interp::AbstractInterpreter, callee::MethodInstance, cal
 end
 
 function add_sourceline!(locs, CI, stmtidx::Int)
-    if isa(CI, IRCode)
+    if isdefined(CI, :debuginfo) # VERSION >= v"1.12"
+        stack = Base.IRShow.buildLineInfoNode(CI.debuginfo, :var"n/a", i)
+        for (i, di) in enumerate(stack)
+            push!(locs, (di, i-1))
+        end
+    elseif isa(CI, IRCode)
         stack = Base.IRShow.compute_loc_stack(CI.linetable, CI.stmts.line[stmtidx])
         for (i, idx) in enumerate(stack)
             line = CI.linetable[idx]

--- a/test/test_Cthulhu.jl
+++ b/test/test_Cthulhu.jl
@@ -814,7 +814,6 @@ end
     @test lines == [line2]
 end
 
-
 @testset "ascend interface" begin
     m = Module()
     @eval m begin


### PR DESCRIPTION
This contains some updates needed to keep working with the optimized debuginfo format (https://github.com/JuliaLang/julia/pull/52415).

Also needs https://github.com/JuliaDebug/JuliaInterpreter.jl/pull/606