### PR TITLE
Set enough lookback on tagbot to get back to last release

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       lookback:
-        default: 3
+        default: 100
 permissions:
   actions: read
   checks: read


### PR DESCRIPTION
The last release tagbot picked up was 96 days ago.
but since then a bunch of releases were missed and haven't showed up.

After merging this PR we should be able to give it time to run (or manually trigger it with the workflow dispatch) then change it back