### PR TITLE
Allow user to overload cfg_simplify!

### DIFF
--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -162,10 +162,13 @@ function CC.finish(state::InferenceState, interp::CthulhuInterpreter)
     return res
 end
 
+# Overload me to disable
+cfg_simplify!(ir) = CC.cfg_simplify!(ir)
+
 function create_cthulhu_source(@nospecialize(opt), effects::Effects)
     isa(opt, OptimizationState) || return opt
     # get the (theoretically) same effect as the jl_compress_ir -> jl_uncompress_ir -> inflate_ir round-trip
-    ir = CC.compact!(CC.cfg_simplify!(CC.copy(opt.ir::IRCode)))
+    ir = CC.compact!(cfg_simplify!(CC.copy(opt.ir::IRCode)))
     return OptimizedSource(ir, opt.src, opt.src.inlineable, effects)
 end
 


### PR DESCRIPTION
Allows users to overload the method `Cthulhu.cfg_simplify!`

(**NOTE** `Cthulhu.cfg_simplify! != CC.cfg_simplify!` so this isn't messing with internals of the compiler).

This is so that power users can just turn it off in their `startup.jl` and avoid this super annoying bug: https://github.com/JuliaDebug/Cthulhu.jl/issues/523 which seems like we are just waiting on Julia 1.11 for a fix.

Here's how to use it. In your `startup.jl` file:

```julia
using Cthulhu  # Regular import

# Rewrite buggy code:
import Cthulhu: cfg_simplify!
cfg_simplify!(ir) = ir
```
