### PR TITLE
Make it merely a warning for the precompile workload to fail

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -876,13 +876,17 @@ ascend
 
 using PrecompileTools
 @setup_workload begin
-    input = Base.link_pipe!(Pipe(), reader_supports_async=true, writer_supports_async=true)
-    term = REPL.Terminals.TTYTerminal("dumb", input.out, devnull, devnull)
-    write(input.in, 'q')
-    @compile_workload begin
-        descend(gcd, (Int, Int); terminal=term)
-        # declare we are done with streams
-        close(input.in)
+    try
+        input = Base.link_pipe!(Pipe(), reader_supports_async=true, writer_supports_async=true)
+        term = REPL.Terminals.TTYTerminal("dumb", input.out, devnull, devnull)
+        write(input.in, 'q')
+        @compile_workload begin
+            descend(gcd, (Int, Int); terminal=term)
+            # declare we are done with streams
+            close(input.in)
+        end
+    catch err
+        @error "Errorred while running the precompile workload, the package may or may not work but latency will be long" exeption=(err,catch_backtrace())
     end
 end
 


### PR DESCRIPTION
Cthulhu breaks easily on nightly, but not everyone uses all Cthulhu features.
So making it only a warning while we fix things may be useful.
In particular, right now Cthulu is broken on 1.11-alpha2, due to #343  though it is fixed at the head of the release-1.11 branch.


This in turn breaks Diffractor which has some Cthulhu integrations (reasonable) and also reuses some Cthulhu internals (not so reasonable).
But which actually works fine, its just #343 


cf https://github.com/JuliaLang/PrecompileTools.jl/pull/21