### PR TITLE
TypedSyntax: fix some failures on Julia 1.11

### DIFF
--- a/TypedSyntax/src/node.jl
+++ b/TypedSyntax/src/node.jl
@@ -613,7 +613,10 @@ function map_ssas_to_source(src::CodeInfo, mi::MethodInstance, rootnode::SyntaxN
         elseif isa(stmt, Core.ReturnNode)
             append_targets_for_line!(mapped, i, append_targets_for_arg!(argmapping, i, stmt.val))
         elseif isa(stmt, Expr)
-            if stmt.head == :(=) && is_slot(stmt.args[1])
+            targets = get_targets(stmt)
+            if targets !== nothing
+                append_targets_for_line!(mapped, i, targets)
+            elseif stmt.head == :(=) && is_slot(stmt.args[1])
                 # We defer setting up `symtyps` for the LHS because processing the RHS first might eliminate ambiguities
                 # # Update `symtyps` for this assignment
                 lhs = stmt.args[1]

--- a/TypedSyntax/test/runtests.jl
+++ b/TypedSyntax/test/runtests.jl
@@ -336,7 +336,8 @@ include("test_module.jl")
     @test has_name_typ(child(body, 2, 1, 1), :x, Float64)
     node = child(body, 2, 2, 1)
     @test kind(node) == K"+="
-    @test has_name_typ(child(node, 1), :s, Float64)   # if this line runs, the LHS now has type `Float64`
+    @test has_name_typ(child(node, 1), :s, Float64) ||   # if this line runs, the LHS now has type `Float64`
+          has_name_typ(child(node, 1), :s, Union{Float64, Int})   # but Julia 1.11 infers this still as the Union
     @test has_name_typ(child(node, 2), :x, Float64)
     @test has_name_typ(child(body, 3, 1), :s, Union{Float64, Int})
     tsn = TypedSyntaxNode(TSN.summer_iterate, (Vector{Float64},))


### PR DESCRIPTION
This brings the number of test failures from 7 down to 3.
Future work will be needed to fix the rest.