### PR TITLE
run CI on interesting platforms only

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -12,21 +12,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version:
-          - '1'
-          - '1.10.0'
-          - '1.11-nightly'
-          - 'nightly'
-        os:
-          - ubuntu-latest
-          - macOS-latest
-          - windows-latest
-        arch:
-          - x64
-          - x86
-        exclude:
-          - os: macOS-latest
+        include:
+          - version: '1' # current stable
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.10.0' # lowerest version supported
+            os: ubuntu-latest
+            arch: x64
+          - version: '1.12-nightly' # next release
+            os: ubuntu-latest
+            arch: x64
+          - version: 'nightly' # dev
+            os: ubuntu-latest
+            arch: x64
+          - version: '1' # x86 ubuntu
+            os: ubuntu-latest
             arch: x86
+          - version: '1' # x86 windows
+            os: windows-latest
+            arch: x86
+          - version: '1' # x64 windows
+            os: windows-latest
+            arch: x64
+          - version: '1' # x64 macOS
+            os: macos-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Like JuliaInterpreter, I'd change the `matrix` to a list format to run CI more sparsely. There is little need to test exhaustively with a full `matrix`, and simply listing the platforms of actual interest will make CI finish faster and be more environmentally friendly.