### PR TITLE
Adapt to `CC.finish!(...)` signature changes

### DIFF
--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -124,7 +124,15 @@ function create_cthulhu_source(@nospecialize(opt), effects::Effects)
     return OptimizedSource(ir, opt.src, opt.src.inlineable, effects)
 end
 
-@static if VERSION ≥ v"1.12.0-DEV.1823"
+@static if VERSION ≥ v"1.13.0-DEV.20" || VERSION ≥ v"1.12.0"
+CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finishinfer!, state, interp)
+function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState, validation_world::UInt)
+    result = caller.result
+    result.src = create_cthulhu_source(result.src, result.ipo_effects)
+    return @invoke CC.finish!(interp::AbstractInterpreter, caller::InferenceState, validation_world::UInt)
+end
+
+elseif VERSION ≥ v"1.12.0-DEV.1823"
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finishinfer!, state, interp)
 function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState)
     result = caller.result


### PR DESCRIPTION
The change in https://github.com/JuliaLang/julia/pull/57248 caused the `CC.finish!(::CthulhuInterpreter, ...)` override to be ignored, skipping the creation of the `OptimizedSource`.

The following testset fails: https://github.com/JuliaDebug/Cthulhu.jl/blob/a8fcae8e5d84fa77660a82f208dad732915a5492/test/test_Cthulhu.jl#L381-L412

because the code now contains calls to `getproperty`:
```julia
julia> callsites = find_callsites_by_ftt(; optimize=false) do
                   t1 = CC._return_type(only_ints, Tuple{Int})     # successful `return_type`
                   t2 = CC._return_type(only_ints, Tuple{Float64}) # failed `return_type`
                   t1, t2
               end
4-element Vector{Cthulhu.Callsite}:
 %2 = runtime < getproperty(::Any,::Core.Const(:_return_type))::Any >
 %7 = runtime < Any(::Core.Const(Main.only_ints),::Core.Const(Tuple{Int64}))::… …
 %9 = runtime < getproperty(::Any,::Core.Const(:_return_type))::Any >
 %14 = runtime < Any(::Core.Const(Main.only_ints),::Core.Const(Tuple{Float64})) …
```

Not sure if we want to update the testset or have a rule to ignore `getproperty` calls, but in any case this can be merged to have nightly working.