### PR TITLE
Adapt to `finishinfer!` signature change

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
+Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 FoldingTrees = "1eca21be-9b9b-4ed8-839a-6d8ae26b1781"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
@@ -18,6 +19,7 @@ WidthLimitedIO = "b8c1c048-cf81-46c6-9da0-18c1d99e41f2"
 
 [compat]
 CodeTracking = "0.5, 1"
+Compiler = "0.0.3"
 FoldingTrees = "1"
 InteractiveUtils = "1.9"
 JuliaSyntax = "0.4"

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,10 @@
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
-version = "2.16.3"
+version = "2.16.4"
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
-Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 FoldingTrees = "1eca21be-9b9b-4ed8-839a-6d8ae26b1781"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaSyntax = "70703baa-626e-46a2-a12c-08ffd08c73b4"
@@ -19,7 +18,6 @@ WidthLimitedIO = "b8c1c048-cf81-46c6-9da0-18c1d99e41f2"
 
 [compat]
 CodeTracking = "0.5, 1"
-Compiler = "0.0.3"
 FoldingTrees = "1"
 InteractiveUtils = "1.9"
 JuliaSyntax = "0.4"

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -105,7 +105,7 @@ function InferredSource(state::InferenceState)
         exct)
 end
 
-@static if VERSION ≥ v"1.13.0-DEV.126"
+@static if VERSION ≥ v"1.13.0-DEV.126" || VERSION ≥ v"1.12.0-alpha1"
 function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int)
     res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int)
     key = CC.is_constproped(state) ? state.result : state.linfo
@@ -138,10 +138,12 @@ function set_cthulhu_source!(result::InferenceResult)
     result.src = create_cthulhu_source(result.src, result.ipo_effects)
 end
 
-@static if VERSION ≥ v"1.13.0-DEV.126"
-CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter, cycleid::Int) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid::Int)
-elseif VERSION ≥ v"1.12.0-DEV.1823"
+@static if VERSION ≥ v"1.12.0-DEV.1823"
+@static if VERSION ≥ v"1.13.0-DEV.126" || VERSION ≥ v"1.12.0-alpha1"
+CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter, cycleid::Int) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid)
+else
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finishinfer!, state, interp)
+end
 @static if VERSION ≥ v"1.12.0-DEV.1988"
 function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState, validation_world::UInt)
     set_cthulhu_source!(caller.result)

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -105,7 +105,7 @@ function InferredSource(state::InferenceState)
         exct)
 end
 
-@static if VERSION ≥ v"1.13.0-DEV.126" || v"1.12.0-alpha1" ≤ VERSION < v"1.13"
+@static if VERSION ≥ v"1.12.0-alpha1"
 function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int)
     res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int)
     key = CC.is_constproped(state) ? state.result : state.linfo
@@ -139,7 +139,7 @@ function set_cthulhu_source!(result::InferenceResult)
 end
 
 @static if VERSION ≥ v"1.12.0-DEV.1823"
-@static if VERSION ≥ v"1.13.0-DEV.126" || v"1.12.0-alpha1" ≤ VERSION < v"1.13"
+@static if VERSION ≥ v"1.12.0-alpha1"
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter, cycleid::Int) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid)
 else
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finishinfer!, state, interp)

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -105,7 +105,7 @@ function InferredSource(state::InferenceState)
         exct)
 end
 
-@static if VERSION ≥ v"1.13.0-DEV.126" || VERSION ≥ v"1.12.0-alpha1"
+@static if VERSION ≥ v"1.13.0-DEV.126" || v"1.12.0-alpha1" ≤ VERSION < v"1.13"
 function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int)
     res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int)
     key = CC.is_constproped(state) ? state.result : state.linfo
@@ -139,7 +139,7 @@ function set_cthulhu_source!(result::InferenceResult)
 end
 
 @static if VERSION ≥ v"1.12.0-DEV.1823"
-@static if VERSION ≥ v"1.13.0-DEV.126" || VERSION ≥ v"1.12.0-alpha1"
+@static if VERSION ≥ v"1.13.0-DEV.126" || v"1.12.0-alpha1" ≤ VERSION < v"1.13"
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter, cycleid::Int) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid)
 else
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finishinfer!, state, interp)

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -105,11 +105,21 @@ function InferredSource(state::InferenceState)
         exct)
 end
 
+@static if VERSION ≥ v"1.13.0-DEV.126"
+function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter, cycleid::Int)
+    res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter, cycleid::Int)
+    key = CC.is_constproped(state)
+    interp.unopt[key] = InferredSource(state)
+    return res
+end
+
+else
 function cthulhu_finish(@specialize(finishfunc), state::InferenceState, interp::CthulhuInterpreter)
     res = @invoke finishfunc(state::InferenceState, interp::AbstractInterpreter)
     key = (@static VERSION ≥ v"1.12.0-DEV.317" ? CC.is_constproped(state) : CC.any(state.result.overridden_by_const)) ? state.result : state.linfo
     interp.unopt[key] = InferredSource(state)
     return res
+end
 end
 
 function create_cthulhu_source(@nospecialize(opt), effects::Effects)
@@ -128,7 +138,9 @@ function set_cthulhu_source!(result::InferenceResult)
     result.src = create_cthulhu_source(result.src, result.ipo_effects)
 end
 
-@static if VERSION ≥ v"1.12.0-DEV.1823"
+@static if VERSION ≥ v"1.13.0-DEV.126"
+CC.finishinfer!(state::InferenceState, interp::ADInterpreter, cycleid::Int) = cthulhu_finish(CC.finishinfer!, state, interp, cycleid::Int)
+elseif VERSION ≥ v"1.12.0-DEV.1823"
 CC.finishinfer!(state::InferenceState, interp::CthulhuInterpreter) = cthulhu_finish(CC.finishinfer!, state, interp)
 @static if VERSION ≥ v"1.12.0-DEV.1988"
 function CC.finish!(interp::CthulhuInterpreter, caller::InferenceState, validation_world::UInt)


### PR DESCRIPTION
`finishinfer!` changed its signature with https://github.com/JuliaLang/julia/pull/57545, adding a `cycleid::Int` argument.