### PR TITLE
Preserve `CallMeta` results during inference

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
-version = "2.17.2"
+version = "2.17.3"
 
 [compat]
 CodeTracking = "0.5, 1"

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -11,7 +11,7 @@ using WidthLimitedIO
 
 using Core: MethodInstance, MethodMatch
 using Core.IR
-using .CC: AbstractInterpreter, ApplyCallInfo, CallInfo as CCCallInfo, ConstCallInfo,
+using .CC: AbstractInterpreter, CallMeta, ApplyCallInfo, CallInfo as CCCallInfo, ConstCallInfo,
     EFFECTS_TOTAL, Effects, IncrementalCompact, InferenceParams, InferenceResult,
     InferenceState, IRCode, LimitedAccuracy, MethodMatchInfo, MethodResultPure,
     NativeInterpreter, NoCallInfo, OptimizationParams, OptimizationState,

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -469,7 +469,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
                 if sourcenode !== nothing
                     show_sub_callsites = let callsite=callsite
                         map(info.callinfos) do ci
-                            p = Base.unwrap_unionall(ci.def.specTypes).parameters
+                            p = Base.unwrap_unionall(get_ci(ci).def.specTypes).parameters
                             if isa(sourcenode, TypedSyntax.MaybeTypedSyntaxNode) && length(p) == length(JuliaSyntax.children(sourcenode)) + 1
                                 newnode = copy(sourcenode)
                                 for (i, child) in enumerate(JuliaSyntax.children(newnode))

--- a/src/callsite.jl
+++ b/src/callsite.jl
@@ -172,6 +172,14 @@ get_ci(gci::CuCallInfo) = get_ci(gci.ci)
 get_rt(gci::CuCallInfo) = get_rt(gci.ci)
 get_effects(gci::CuCallInfo) = get_effects(gci.ci)
 
+struct CthulhuCallInfo <: CCCallInfo
+    meta::CallMeta
+end
+CC.add_edges_impl(edges::Vector{Any}, info::CthulhuCallInfo) = CC.add_edges!(edges, info.meta.info)
+CC.nsplit_impl(info::CthulhuCallInfo) = CC.nsplit(info.meta.info)
+CC.getsplit_impl(info::CthulhuCallInfo, idx::Int) = CC.getsplit(info.meta.info, idx)
+CC.getresult_impl(info::CthulhuCallInfo, idx::Int) = CC.getresult(info.meta.info, idx)
+
 struct Callsite
     id::Int # ssa-id
     info::CallInfo

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -344,7 +344,7 @@ function add_callsites!(d::AbstractDict, visited_cis::AbstractSet, diagnostics::
     # e.g. if f(x) = x is called with different types we print nothing.
     key = (mi.def.file, mi.def.line)
     if haskey(d, key)
-        if !isnothing(d[key]) && mi != d[key].mi
+        if !isnothing(d[key]) && mi != d[key].ci.def
             d[key] = nothing
             push!(diagnostics,
                 TypedSyntax.Diagnostic(

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -150,6 +150,9 @@ function cthulhu_finish(@specialize(finishfunc), frame::InferenceState, interp::
     return res
 end
 
+# Rebuild a `CC.UnionSplitApplyCallInfo` structure where inner `ApplyCallInfo`s wrap a `CthulhuCallInfo`.
+# Note that technically, `rt`/`exct`/`effects`/`refinements` are incorrect for each apply call as they
+# apply to the union split as a whole, not to individual branches. The idea is simply to preserve them.
 function pack_cthulhuinfo_in_unionsplit(call::CallMeta, info::CC.UnionSplitApplyCallInfo)
     infos = CC.ApplyCallInfo[]
     for apply in info.infos
@@ -159,6 +162,7 @@ function pack_cthulhuinfo_in_unionsplit(call::CallMeta, info::CC.UnionSplitApply
     return CC.UnionSplitApplyCallInfo(infos)
 end
 
+# Build a `CthulhuCallInfo` structure wrapping `CC.UnionSplitApplyCallInfo`.
 function unpack_cthulhuinfo_from_unionsplit(info::CC.UnionSplitApplyCallInfo)
     isempty(info.infos) && return nothing
     apply = info.infos[1]


### PR DESCRIPTION
Store `CallMeta` information emitted as a result of call inference, so that we may use it during analysis once inference is done. It should theoretically provide more refined `rt`/`exct`/`effects` values, and it additionally contains `refinements` information should we ever want to support introspecting into that (which could prove helpful e.g. for https://github.com/JuliaLang/julia/pull/57651).

This is performed by defining `CthulhuCallInfo <: CC.CallInfo` which is used as a wrapper for (almost) all `CC.CallInfo` structures, applied right after inference and propagated throughout optimization (notably, through inlining). Special handling had to be done for `CC.UnionSplitApplyCallInfo`, but as far I as am aware this should not be limiting in any way.

We might be able to refactor and trim a few of our `CallInfo` structures with this change, I plan to tackle that next. In the current state, I think this can be merged safely to keep changes incremental and small, if we are willing to commit to this design.
I'd be happy to have any pointers on which example may bring to light the theoretical improvements of keeping `CallMeta` information for `rt`/`exct`/`effects`, so we can add a test and have this PR be a clear and net improvement overall.

Many thanks to @aviatesk for suggesting this approach and paving the way with explanations on how to integrate custom `CC.CallInfo` into the compilation pipeline.