### PR TITLE
Use unoptimized lookup if source is not available

### DIFF
--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -301,7 +301,7 @@ function add_callsites!(d::AbstractDict, visited_cis::AbstractSet, diagnostics::
     callsites, src, rt = try
         (; src, rt, infos, slottypes, effects, codeinf) = lookup(interp, ci, optimize & !annotate_source)
 
-        src = preprocess_ci!(src, mi, optimize & !annotate_source, CONFIG)
+        src = preprocess_ci!(src, mi, optimize & !annotate_source, CONFIG, interp)
         if (optimize & !annotate_source) || isa(src, IRCode) # optimization might have deleted some statements
             infos = src.stmts.info
         else
@@ -429,7 +429,7 @@ end
 function InteractiveUtils.code_typed(b::Bookmark; optimize::Bool=true)
     (; interp, ci) = b
     (; src, rt, codeinf) = lookup(interp, ci, optimize)
-    src = preprocess_ci!(src, ci.def, optimize, CONFIG)
+    src = preprocess_ci!(src, ci.def, optimize, CONFIG, interp)
     if src isa IRCode
         CC.replace_code_newstyle!(codeinf, src)
     end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -264,17 +264,21 @@ function dce!(ir::IRCode)
     return ir
 end
 
-function preprocess_ci!(ci::CodeInfo, mi::MethodInstance, optimize, config::CthulhuConfig)
+function preprocess_ci!(ci::CodeInfo, mi::MethodInstance, optimize, config::CthulhuConfig, interp::AbstractInterpreter)
     if optimize && config.dead_code_elimination
-        argtypes = CC.matching_cache_argtypes(mi, nothing, false)[1]
+        𝕃ᵢ = CC.typeinf_lattice(interp)
+        argtypes = CC.matching_cache_argtypes(𝕃ᵢ, mi)
         ir = CC.inflate_ir(ci, sptypes_from_meth_instance(mi), argtypes)
         ir = dce!(ir)
-        ci = CC.replace_code_newstyle!(ci, ir)
+        if ir.debuginfo.def === nothing
+            ir.debuginfo.def = Symbol("")
+        end
+        CC.replace_code_newstyle!(ci, ir)
     end
     return ci
 end
 
-function preprocess_ci!(ir::IRCode, _::MethodInstance, optimize::Bool, config::CthulhuConfig)
+function preprocess_ci!(ir::IRCode, _::MethodInstance, optimize::Bool, config::CthulhuConfig, interp::AbstractInterpreter)
     if optimize && config.dead_code_elimination
         ir = dce!(ir)
     end
@@ -315,7 +319,7 @@ function find_caller_of(interp::AbstractInterpreter, callee::Union{MethodInstanc
     locs = Tuple{Core.LineInfoNode,Int}[]
     for optimize in (true, false)
         (; src, rt, infos, slottypes) = lookup(interp′, codeinst, optimize)
-        src = preprocess_ci!(src, caller, optimize, CONFIG)
+        src = preprocess_ci!(src, caller, optimize, CONFIG, interp)
         callsites, _ = find_callsites(interp′, src, infos, codeinst, slottypes, optimize)
         callsites = allow_unspecialized ? filter(cs->maybe_callsite(cs, callee), callsites) :
                                           filter(cs->is_callsite(cs, callee), callsites)

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -12,7 +12,7 @@ function cthulhu_info(@nospecialize(f), @nospecialize(tt=());
         Cthulhu.lookup(interp, codeinst, optimize; allow_no_src=true)
     if src !== nothing
         config = Cthulhu.CthulhuConfig(; dead_code_elimination=true)
-        src = Cthulhu.preprocess_ci!(src, codeinst.def, optimize, config)
+        src = Cthulhu.preprocess_ci!(src, codeinst.def, optimize, config, interp)
     end
     return (; interp, src, infos, codeinst, rt, exct, slottypes, effects)
 end


### PR DESCRIPTION
Fixes #642.

If we hit a `CodeInstance` that doesn't have inferred code, we now look up its unoptimized (but inferred) source. I think that's the behavior we want, because then we can look into why it wasn't kept (in the case of #642, we can see that lots of constprops were disabled due to `LimitedAccuracy`, for example). @topolarity feel free to `@descend` into https://github.com/JuliaDebug/Cthulhu.jl/issues/642#issuecomment-2950828428 and confirm that inspection provides what you would expect to see.

The DCE path for `preprocess_ci!(ci::CodeInfo, ...)` was apparently unused, I made a few fixes but I believe `CallInfo`s are almost guaranteed to get out of sync which would trigger an assertion error afterwards. Perhaps we should return the IR instead so we can then extract `ir.stmts.info`? Anyways, I ended up not requiring it and disabling optimization if we have to fall back to an unoptimized lookup, so that seems to remain unused at the moment.

I believe that testing that would require re-enabling the terminal tests, as we'd have to descend into a specific call. I suggest to put that off for now.