### PR TITLE
CthulhuCompilerExt: initialize `CONFIG` in `__init__`

### DIFF
--- a/ext/CthulhuCompilerExt.jl
+++ b/ext/CthulhuCompilerExt.jl
@@ -6,6 +6,7 @@ using Cthulhu: Cthulhu
 
 function __init__()
     Cthulhu.CTHULHU_MODULE[] = @__MODULE__
+    read_config!(CONFIG)
 end
 
 include("../src/CthulhuBase.jl")


### PR DESCRIPTION
Follows up JuliaDebug/Cthulhu.jl#649, and make it consistent configuration really.