### PR TITLE
Allow control of terminal pager via kwargs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,9 @@ Choose a call for analysis (q to quit):
          union!(::Set{Symbol}, ::Set{Symbol}, ::Set{Symbol})
            union(::Set{Symbol}, ::Set{Symbol})
 ```
-You use the up/down arrows to navigate this menu, enter to select a call to `descend` into,
-and your space bar to toggle branch-folding.
+You use the up/down arrows to navigate this menu, enter to select a call to
+`descend` into, and your space bar to toggle branch-folding. `ascend(mi; pagesize=20)`
+allows you to show up to 20 lines at once.
 
 It also works on stacktraces. If your version of Julia stores the most recent error in the global `err` variable, you can use
 

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -690,10 +690,13 @@ descend_code_warntype_impl(b::Bookmark; kw...) =
 
 FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.writeoption(buf, data.callstr, charsused)
 
-function ascend_impl(term, mi; interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
+function ascend_impl(
+        term, mi; interp::AbstractInterpreter=NativeInterpreter(),
+        pagesize::Int=10, dynamic::Bool=false, maxsize::Int=pagesize, kwargs...
+    )
     root = treelist(mi)
     root === nothing && return
-    menu = TreeMenu(root)
+    menu = TreeMenu(root; pagesize, dynamic, maxsize)
     choice = menu.current
     while choice !== nothing
         menu.chosen = false

--- a/test/test_terminal.jl
+++ b/test/test_terminal.jl
@@ -292,7 +292,7 @@ end
         mi = _Cthulhu.get_specialization(inner3, Tuple{UInt16})
         terminal = FakeTerminal()
         task = @async @with_try_stderr output redirect_stderr(terminal.error) do
-            ascend(terminal, mi)
+            ascend(terminal, mi; pagesize=11)
         end
 
         write(terminal, keys[:down])


### PR DESCRIPTION
This accepts keywords from `FoldingTrees.TreeMenu`. The most useful
option is perhaps `ascend(obj; pagesize=20)`.

CC @fingolfin