### PR TITLE
Extend pager control to `descend`

### DIFF
--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -183,7 +183,10 @@ end
     ascend(bt; kwargs...)
 
 Follow a chain of calls (either through a backtrace `bt` or the backedges of a `MethodInstance` `mi`),
-with the option to `descend` into intermediate calls. `kwargs` are passed to [`descend`](@ref).
+with the option to `descend` into intermediate calls.
+
+Keyword arguments `pagesize, dynamic, maxsize` are passed to `Cthulhu.FoldingTrees.TreeMenu`.
+Any remaining `kwargs` are passed to [`descend`](@ref).
 """
 function ascend(@nospecialize(args...); kwargs...)
     CTHULHU_MODULE[].ascend_impl(args...; kwargs...)

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -75,6 +75,9 @@ end
 - `inlay_types_vscode::Bool` Initial state of "vscode: inlay types" toggle. Defaults to `true`
 - `diagnostics_vscode::Bool` Initial state of "Vscode: diagnostics" toggle. Defaults to `true`
 - `jump_always::Bool` Initial state of "jump to source always" toggle. Defaults to `false`.
+
+Other keyword arguments are passed to [`Cthulhu.CthulhuMenu`](@ref) and/or
+[`REPL.TerminalMenus`](https://docs.julialang.org/en/v1/stdlib/REPL/#Customization-/-Configuration).
 """
 const CONFIG = CthulhuConfig()
 
@@ -302,6 +305,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
     inlay_types_vscode::Bool              = CONFIG.inlay_types_vscode,            # default is true
     diagnostics_vscode::Bool              = CONFIG.diagnostics_vscode,            # default is true
     jump_always::Bool                     = CONFIG.jump_always,                   # default is false
+    kwargs...,                                                                    # additional kwargs passed to `menu_options`
     )
 
     if isnothing(hide_type_stable)
@@ -312,7 +316,7 @@ function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::Abs
         debuginfo = getfield(DInfo, debuginfo)::DebugInfo
     end
 
-    menu_options = (; cursor = '•', scroll_wrap = true)
+    menu_options = (; cursor = '•', scroll_wrap = true, kwargs...)
     display_CI = true
     view_cmd = cthulhu_typed
     iostream = term.out_stream::IO
@@ -739,7 +743,7 @@ function ascend_impl(
             end
             # The main application of `ascend` is finding cases of non-inferrability, so the
             # warn highlighting is useful.
-            browsecodetyped && _descend(term, mi; interp, annotate_source=true, iswarn=true, optimize=false, interruptexc=false, kwargs...)
+            browsecodetyped && _descend(term, mi; interp, annotate_source=true, iswarn=true, optimize=false, interruptexc=false, pagesize, kwargs...)
         end
     end
 end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -28,6 +28,17 @@ function show_as_line(callsite::Callsite, with_effects::Bool, exception_type::Bo
     end
 end
 
+"""
+    CthulhuMenu(args...; pagesize::Int=10, sub_menu = false, kwargs...)
+
+Set up the callsite menu with the given arguments. This is largely internal,
+but the main keywords to control the menu are:
+- `pagesize::Int` (default 10) Number of callsites to show at a time (without scrolling).
+- `sub_menu::Bool` (default false) if true, user can only pick a callsite, not change options.
+
+Others are passed to
+[`REPL.TerminalMenus.Config`](https://docs.julialang.org/en/v1/stdlib/REPL/#REPL.TerminalMenus.Config).
+"""
 function CthulhuMenu(callsites, with_effects::Bool, exception_type::Bool,
                      optimize::Bool, iswarn::Bool, hide_type_stable::Bool,
                      custom_toggles::Vector{CustomToggle}; pagesize::Int=10, sub_menu = false, kwargs...)


### PR DESCRIPTION
This extends #655 to the control of `descend`. It also expands the
docstrings and improves integration between `ascend` and `descend`.