### PR TITLE
bump CodeTracking compatibility to v2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,7 +4,7 @@ uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 version = "2.17.5"
 
 [compat]
-CodeTracking = "0.5, 1"
+CodeTracking = "0.5, 1, 2"
 Compiler = "0.1"
 FoldingTrees = "1"
 InteractiveUtils = "1.9"


### PR DESCRIPTION
CodeTracking has been updated to the new major version v2, but since Cthulhu is not affected by the breaking changes, we can just bump our compat up to allow it.