### PR TITLE
Redesign downstream integration with Cthulhu

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,24 +1,10 @@
-authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
 version = "2.17.5"
-
-[compat]
-CodeTracking = "0.5, 1"
-Compiler = "0.1"
-FoldingTrees = "1"
-InteractiveUtils = "1.9"
-JuliaSyntax = "0.4"
-PrecompileTools = "1"
-Preferences = "1"
-REPL = "1.9"
-TypedSyntax = "1.3.0"
-UUIDs = "1.9"
-Unicode = "1.9"
-WidthLimitedIO = "1"
-julia = "1.12"
+authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 
 [deps]
+Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"
 FoldingTrees = "1eca21be-9b9b-4ed8-839a-6d8ae26b1781"
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
@@ -35,7 +21,23 @@ WidthLimitedIO = "b8c1c048-cf81-46c6-9da0-18c1d99e41f2"
 Compiler = "807dbc54-b67e-4c79-8afb-eafe4df6f2e1"
 
 [extensions]
-CthulhuCompilerExt = "Compiler"
+# CthulhuCompilerExt = "Compiler"
+
+[compat]
+Accessors = "0.1.42"
+CodeTracking = "0.5, 1"
+Compiler = "0.1"
+FoldingTrees = "1"
+InteractiveUtils = "1.9"
+JuliaSyntax = "0.4"
+PrecompileTools = "1"
+Preferences = "1"
+REPL = "1.9"
+TypedSyntax = "1.3.0"
+UUIDs = "1.9"
+Unicode = "1.9"
+WidthLimitedIO = "1"
+julia = "1.12"
 
 [extras]
 CthulhuCompilerExt = "a0401a94-d28a-5d0d-bd4d-a83640b62d95"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
-version = "2.17.5"
+version = "3.0"
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 
 [deps]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 authors = ["Valentin Churavy <v.churavy@gmail.com> and contributors"]
 name = "Cthulhu"
 uuid = "f68482b8-f384-11e8-15f7-abe071a5a75f"
-version = "2.17.4"
+version = "2.17.5"
 
 [compat]
 CodeTracking = "0.5, 1"

--- a/ext/CthulhuCompilerExt.jl
+++ b/ext/CthulhuCompilerExt.jl
@@ -6,7 +6,7 @@ using Cthulhu: Cthulhu
 
 function __init__()
     Cthulhu.CTHULHU_MODULE[] = @__MODULE__
-    read_config!(CONFIG)
+    read_config!()
 end
 
 include("../src/CthulhuBase.jl")

--- a/src/Cthulhu.jl
+++ b/src/Cthulhu.jl
@@ -1,14 +1,15 @@
 module Cthulhu
 
 export @descend, @descend_code_typed, @descend_code_warntype,
-    descend, descend_code_typed, descend_code_warntype, ascend
+    descend, descend_code_typed, descend_code_warntype, ascend,
+    AbstractProvider
 
 const CC = Base.Compiler
 const IRShow = Base.IRShow
 
 const CTHULHU_MODULE = Ref{Module}(@__MODULE__)
 
-__init__() = read_config!(CONFIG)
+__init__() = read_config!()
 
 include("CthulhuBase.jl")
 include("testing.jl")
@@ -193,11 +194,11 @@ using PrecompileTools
 @setup_workload begin
     try
         @compile_workload begin
-            terminal = Testing.FakeTerminal()
-            task = @async @descend terminal=terminal.tty gcd(1, 2)
-            write(terminal, 'q')
-            wait(task)
-            finalize(terminal)
+            # terminal = Testing.FakeTerminal()
+            # task = @async @descend terminal=terminal.tty gcd(1, 2)
+            # write(terminal, 'q')
+            # wait(task)
+            # finalize(terminal)
         end
     catch err
         @error "Errorred while running the precompile workload, the package may or may not work but latency will be long" exeption=(err,catch_backtrace())

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -17,7 +17,7 @@ using .CC: AbstractInterpreter, CallMeta, ApplyCallInfo, CallInfo as CCCallInfo,
     NativeInterpreter, NoCallInfo, OptimizationParams, OptimizationState,
     UnionSplitApplyCallInfo, UnionSplitInfo, WorldRange, WorldView, get_inference_world,
     argextype, argtypes_to_type, compileable_specialization, ignorelimited, singleton_type,
-    specialize_method, sptypes_from_meth_instance, widenconst
+    specialize_method, sptypes_from_meth_instance, widenconst, method_table, findsup
 using Base: @constprop, default_tt, isvarargtype, unwrapva, unwrap_unionall, rewrap_unionall
 const mapany = Base.mapany
 
@@ -87,13 +87,16 @@ end
 using .DInfo: DebugInfo
 const AnyDebugInfo = Union{DebugInfo,Symbol}
 
-include("interpreter.jl")
 include("callsite.jl")
 include("interface.jl")
+include("interpreter.jl")
+include("provider.jl")
 include("reflection.jl")
 include("ui.jl")
 include("codeview.jl")
 include("backedges.jl")
+include("descend.jl")
+include("ascend.jl")
 
 """
     @interp
@@ -103,52 +106,6 @@ For debugging. Returns a CthulhuInterpreter from the appropriate entrypoint.
 macro interp(ex0...)
     InteractiveUtils.gen_call_with_extracted_types_and_kwargs(__module__, :mkinterp, ex0)
 end
-
-descend_code_typed_impl(@nospecialize(args...); kwargs...) =
-    _descend_with_error_handling(args...; annotate_source=false, iswarn=false, kwargs...)
-
-descend_code_warntype_impl(@nospecialize(args...); kwargs...) =
-    _descend_with_error_handling(args...; annotate_source=false, iswarn=true, optimize=false, kwargs...)
-
-function _descend_with_error_handling(@nospecialize(f), @nospecialize(argtypes = default_tt(f)); kwargs...)
-    ft = Core.Typeof(f)
-    if isa(argtypes, Type)
-        u = unwrap_unionall(argtypes)
-        tt = rewrap_unionall(Tuple{ft, u.parameters...}, argtypes)
-    else
-        tt = Tuple{ft, argtypes...}
-    end
-    __descend_with_error_handling(tt; kwargs...)
-end
-_descend_with_error_handling(mi::MethodInstance; kwargs...) =
-    __descend_with_error_handling(mi; kwargs...)
-_descend_with_error_handling(@nospecialize(tt::Type{<:Tuple}); kwargs...) =
-    __descend_with_error_handling(tt; kwargs...)
-_descend_with_error_handling(interp::AbstractInterpreter, mi::MethodInstance; kwargs...) =
-    __descend_with_error_handling(interp, mi; kwargs...)
-function __descend_with_error_handling(args...; terminal=default_terminal(), kwargs...)
-    @nospecialize
-    try
-        _descend(terminal, args...; kwargs...)
-    catch x
-        TypedSyntax.clear_all_vscode()
-        if x isa InterruptException
-            return nothing
-        else
-            rethrow(x)
-        end
-    end
-    return nothing
-end
-
-function default_terminal()
-    term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")
-    term = REPL.Terminals.TTYTerminal(term_env, stdin, stdout, stderr)
-    return term
-end
-
-descend_impl(@nospecialize(args...); kwargs...) =
-    _descend_with_error_handling(args...; iswarn=true, kwargs...)
 
 using .CC: cached_return_type
 
@@ -162,494 +119,6 @@ get_effects(result::CC.ConstPropResult) = get_effects(result.result)
 get_effects(result::CC.ConcreteResult) = result.effects
 get_effects(result::CC.SemiConcreteResult) = result.effects
 
-struct LookupResult
-    src::Union{CodeInfo,IRCode,Nothing}
-    rt
-    exct
-    infos::Vector{CCCallInfo}
-    slottypes::Vector{Any}
-    effects::Effects
-    codeinf::Union{Nothing,CodeInfo}
-    function LookupResult(src::Union{CodeInfo,IRCode,Nothing}, @nospecialize(rt), @nospecialize(exct),
-                          infos::Vector{CCCallInfo}, slottypes::Vector{Any},
-                          effects::Effects, codeinf::Union{Nothing,CodeInfo})
-        return new(src, rt, exct, infos, slottypes, effects, codeinf)
-    end
-end
-
-# `@constprop :aggressive` here in order to make sure the constant propagation of `allow_no_src`
-@constprop :aggressive function lookup(interp::CthulhuInterpreter, ci::CodeInstance, optimize::Bool; allow_no_src::Bool=false)
-    if optimize
-        return lookup_optimized(interp, ci, allow_no_src)
-    else
-        return lookup_unoptimized(interp, ci)
-    end
-end
-
-function lookup_optimized(interp::CthulhuInterpreter, ci::CodeInstance, allow_no_src::Bool=false)
-    rt = cached_return_type(ci)
-    exct = cached_exception_type(ci)
-    opt = ci.inferred
-    if opt !== nothing
-        opt = opt::OptimizedSource
-        src = CC.copy(opt.ir)
-        codeinf = opt.src
-        infos = src.stmts.info
-        slottypes = src.argtypes
-    elseif allow_no_src
-        # This doesn't showed up as covered, but it is (see the CI test with `coverage=false`).
-        # But with coverage on, the empty function body isn't empty due to :code_coverage_effect expressions.
-        codeinf = src = nothing
-        infos = CCCallInfo[]
-        slottypes = Any[Base.unwrap_unionall(ci.def.specTypes).parameters...]
-    else
-        Core.eval(Main, quote
-            interp = $interp
-            ci = $ci
-        end)
-        error("couldn't find the source; inspect `Main.interp` and `Main.mi`")
-    end
-    effects = get_effects(ci)
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf)
-end
-
-function lookup_unoptimized(interp::CthulhuInterpreter, ci::CodeInstance)
-    unopt = interp.unopt[ci]
-    codeinf = src = copy(unopt.src)
-    (; rt, exct) = unopt
-    infos = unopt.stmt_info
-    effects = unopt.effects
-    slottypes = src.slottypes
-    if isnothing(slottypes)
-        slottypes = Any[ Any for i = 1:length(src.slotflags) ]
-    end
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf)
-end
-
-function lookup_constproped(interp::CthulhuInterpreter, override::InferenceResult, optimize::Bool)
-    if optimize
-        return lookup_constproped_optimized(interp, override)
-    else
-        return lookup_constproped_unoptimized(interp, override)
-    end
-end
-
-function lookup_constproped_optimized(interp::CthulhuInterpreter, override::InferenceResult)
-    opt = override.src
-    isa(opt, OptimizedSource) || error("couldn't find the source")
-    # `(override::InferenceResult).src` might has been transformed to OptimizedSource already,
-    # e.g. when we switch from constant-prop' unoptimized source
-    src = CC.copy(opt.ir)
-    rt = override.result
-    exct = override.exc_result
-    infos = src.stmts.info
-    slottypes = src.argtypes
-    codeinf = opt.src
-    effects = opt.effects
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf)
-end
-
-function lookup_constproped_unoptimized(interp::CthulhuInterpreter, override::InferenceResult)
-    unopt = interp.unopt[override]
-    codeinf = src = copy(unopt.src)
-    (; rt, exct) = unopt
-    infos = unopt.stmt_info
-    effects = get_effects(unopt)
-    slottypes = src.slottypes
-    if isnothing(slottypes)
-        slottypes = Any[ Any for i = 1:length(src.slotflags) ]
-    end
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf)
-end
-
-function lookup_semiconcrete(interp::CthulhuInterpreter, override::SemiConcreteCallInfo, optimize::Bool)
-    src = CC.copy(override.ir)
-    rt = get_rt(override)
-    exct = Any # TODO
-    infos = src.stmts.info
-    slottypes = src.argtypes
-    effects = get_effects(override)
-    codeinf = nothing # TODO try to find `CodeInfo` for the regular inference?
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf)
-end
-
-function get_override(@nospecialize(info))
-    isa(info, ConstPropCallInfo) && return info.result
-    isa(info, SemiConcreteCallInfo) && return info
-    isa(info, OCCallInfo) && return get_override(info.ci)
-    return nothing
-end
-
-##
-# _descend is the main driver function.
-# src/reflection.jl has the tools to discover methods
-# src/ui.jl provides the user facing interface to which _descend responds
-##
-function _descend(term::AbstractTerminal, interp::AbstractInterpreter, curs::AbstractCursor;
-    override::Union{Nothing,InferenceResult,SemiConcreteCallInfo} = nothing,
-    debuginfo::Union{Symbol,DebugInfo}    = CONFIG.debuginfo,                     # default is compact debuginfo
-    optimize::Bool                        = CONFIG.optimize,                      # default is true
-    interruptexc::Bool                    = CONFIG.interruptexc,
-    iswarn::Bool                          = CONFIG.iswarn,                        # default is false
-    hide_type_stable::Union{Nothing,Bool} = CONFIG.hide_type_stable,
-    verbose::Union{Nothing,Bool}          = nothing,
-    remarks::Bool                         = CONFIG.remarks&!CONFIG.optimize,      # default is false
-    with_effects::Bool                    = CONFIG.with_effects,                  # default is false
-    exception_type::Bool                  = CONFIG.exception_type,                # default is false
-    inline_cost::Bool                     = CONFIG.inline_cost&CONFIG.optimize,   # default is false
-    type_annotations::Bool                = CONFIG.type_annotations,              # default is true
-    annotate_source::Bool                 = CONFIG.annotate_source,               # default is true
-    inlay_types_vscode::Bool              = CONFIG.inlay_types_vscode,            # default is true
-    diagnostics_vscode::Bool              = CONFIG.diagnostics_vscode,            # default is true
-    jump_always::Bool                     = CONFIG.jump_always,                   # default is false
-    )
-
-    if isnothing(hide_type_stable)
-        hide_type_stable = something(verbose, false)
-    end
-    isnothing(verbose) || Base.depwarn("The `verbose` keyword argument to `Cthulhu.descend` is deprecated. Use `hide_type_stable` instead.")
-    if isa(debuginfo, Symbol)
-        debuginfo = getfield(DInfo, debuginfo)::DebugInfo
-    end
-
-    menu_options = (; cursor = '•', scroll_wrap = true)
-    display_CI = true
-    view_cmd = cthulhu_typed
-    iostream = term.out_stream::IO
-    function additional_descend(new_ci::CodeInstance)
-        new_interp = CthulhuInterpreter(interp)
-        _descend(term, new_interp, new_ci;
-                 debuginfo, optimize, interruptexc, iswarn, hide_type_stable, remarks,
-                 with_effects, exception_type,
-                 inline_cost, type_annotations, annotate_source,
-                 inlay_types_vscode, diagnostics_vscode)
-    end
-    custom_toggles = (@__MODULE__).custom_toggles(interp)
-    if !(custom_toggles isa Vector{CustomToggle})
-        error(lazy"""
-        invalid `$AbstractInterpreter` API:
-        `$(Cthulhu.custom_toggles)(interp::$(typeof(interp))` is expected to return `Vector{CustomToggle}` object.
-        """)
-    end
-    while true
-        if isa(override, InferenceResult)
-            (; src, rt, exct, infos, slottypes, codeinf, effects) = lookup_constproped(interp, curs, override, optimize & !annotate_source)
-        elseif isa(override, SemiConcreteCallInfo)
-                (; src, rt, exct, infos, slottypes, codeinf, effects) = lookup_semiconcrete(interp, curs, override, optimize & !annotate_source)
-        else
-            if optimize && !annotate_source
-                codeinst = get_ci(curs)
-                if codeinst.inferred === nothing
-                    if isdefined(codeinst, :rettype_const)
-                        # TODO use `codeinfo_for_const`
-                        # This was inferred to a pure constant - we have no code to show,
-                        # but make something up that looks plausible.
-                        callsites = Callsite[]
-                        if display_CI
-                            exct = cached_exception_type(codeinst)
-                            callsite = Callsite(-1, EdgeCallInfo(codeinst, codeinst.rettype, get_effects(codeinst), exct), :invoke)
-                            println(iostream)
-                            println(iostream, "│ ─ $callsite")
-                            println(iostream, "│  return ", Const(codeinst.rettype_const))
-                            println(iostream)
-                        end
-                        mi = get_mi(codeinst)
-                        @goto show_menu
-                    else
-                        @info """
-                        Inference discarded the source for this call because of recursion:
-                        Cthulhu nevertheless is trying to retrieve the source for further inspection.
-                        """
-                        ci = get_ci(curs)
-                        if !haskey(interp.unopt, ci)
-                            additional_descend(ci)
-                            break
-                        else
-                            (; src, rt, exct, infos, slottypes, effects, codeinf) = lookup_unoptimized(interp, ci)
-                            optimize = false
-                            @goto lookup_complete
-                        end
-                    end
-                end
-            end
-            (; src, rt, exct, infos, slottypes, effects, codeinf) = lookup(interp, curs, optimize & !annotate_source)
-        end
-        @label lookup_complete
-        ci = get_ci(curs)
-        mi = get_mi(ci)
-        infkey = override isa InferenceResult ? override : ci
-        pc2excts = exception_type ? get_pc_exct(interp, infkey) : nothing
-        callsites, sourcenodes = find_callsites(interp, src, infos, ci, slottypes, optimize & !annotate_source, annotate_source, pc2excts)
-
-        if jump_always
-            if isdefined(Main, :VSCodeServer) && Main.VSCodeServer isa Module && isdefined(Main.VSCodeServer, :openfile)
-                Main.VSCodeServer.openfile(whereis(mi.def::Method)...; preserve_focus=true)
-            else
-                edit(whereis(mi.def::Method)...)
-            end
-        end
-
-        if display_CI
-            pc2remarks = remarks ? get_pc_remarks(interp, infkey) : nothing
-            pc2effects = with_effects ? get_pc_effects(interp, infkey) : nothing
-            printstyled(IOContext(iostream, :limit=>true), mi.def, '\n'; bold=true)
-            if debuginfo == DInfo.compact
-                str = let debuginfo=debuginfo, src=src, codeinf=codeinf, rt=rt,
-                          iswarn=iswarn, hide_type_stable=hide_type_stable,
-                          pc2remarks=pc2remarks, pc2effects=pc2effects, inline_cost=inline_cost, type_annotations=type_annotations
-                    ioctx = IOContext(iostream,
-                        :color => true,
-                        :displaysize => displaysize(iostream), # displaysize doesn't propagate otherwise
-                        :SOURCE_SLOTNAMES => codeinf === nothing ? false : Base.sourceinfo_slotnames(codeinf),
-                        :with_effects => with_effects,
-                        :exception_type => exception_type)
-                    stringify(ioctx) do lambda_io
-                        cthulhu_typed(lambda_io, debuginfo, annotate_source ? codeinf : src, rt, exct, effects, ci;
-                                      iswarn, optimize, hide_type_stable,
-                                      pc2remarks, pc2effects, pc2excts,
-                                      inline_cost, type_annotations, annotate_source, inlay_types_vscode, diagnostics_vscode,
-                                      jump_always, interp)
-                    end
-                end
-                # eliminate trailing indentation (see first item in bullet list in PR #189)
-                rmatch = findfirst(r"\u001B\[90m\u001B\[(\d+)G( *)\u001B\[1G\u001B\[39m\u001B\[90m( *)\u001B\[39m$", str)
-                if rmatch !== nothing
-                    str = str[begin:prevind(str, first(rmatch))]
-                end
-                print(iostream, str)
-            else
-                lambda_io = IOContext(iostream,
-                    :SOURCE_SLOTNAMES => codeinf === nothing ? false : Base.sourceinfo_slotnames(codeinf),
-                    :with_effects => with_effects,
-                    :exception_type => exception_type)
-                cthulhu_typed(lambda_io, debuginfo, src, rt, exct, effects, ci;
-                              iswarn, optimize, hide_type_stable,
-                              pc2remarks, pc2effects, pc2excts,
-                              inline_cost, type_annotations, annotate_source, inlay_types_vscode, diagnostics_vscode,
-                              jump_always, interp)
-            end
-            view_cmd = cthulhu_typed
-        else
-            display_CI = true
-        end
-
-        @label show_menu
-
-        shown_callsites = annotate_source ? sourcenodes : callsites
-        menu = CthulhuMenu(shown_callsites, with_effects, exception_type,
-                           optimize & !annotate_source,
-                           iswarn&get(iostream, :color, false)::Bool,
-                           hide_type_stable, custom_toggles; menu_options...)
-        usg = usage(view_cmd, annotate_source, optimize, iswarn, hide_type_stable,
-                    debuginfo, remarks, with_effects, exception_type, inline_cost,
-                    type_annotations, CONFIG.enable_highlighter, inlay_types_vscode,
-                    diagnostics_vscode, jump_always, custom_toggles)
-        cid = request(term, usg, menu)
-        toggle = menu.toggle
-
-        if toggle === nothing
-            if cid == length(callsites) + 1
-                break
-            end
-            if cid == -1
-                interruptexc ? throw(InterruptException()) : break
-            end
-            callsite = callsites[cid]
-            sourcenode = !isempty(sourcenodes) ? sourcenodes[cid] : nothing
-
-            info = callsite.info
-            if info isa MultiCallInfo
-                show_sub_callsites = sub_callsites = let callsite=callsite
-                    map(ci->Callsite(callsite.id, ci, callsite.head), info.callinfos)
-                end
-                if isempty(sub_callsites)
-                    Core.eval(Main, quote
-                        interp = $interp
-                        mi = $mi
-                        info = $info
-                    end)
-                    @error "Expected multiple callsites, but found none. Please fill an issue with a reproducing example."
-                    continue
-                end
-                if sourcenode !== nothing
-                    show_sub_callsites = let callsite=callsite
-                        map(info.callinfos) do ci
-                            p = Base.unwrap_unionall(get_ci(ci).def.specTypes).parameters
-                            if isa(sourcenode, TypedSyntax.MaybeTypedSyntaxNode) && length(p) == length(JuliaSyntax.children(sourcenode)) + 1
-                                newnode = copy(sourcenode)
-                                for (i, child) in enumerate(JuliaSyntax.children(newnode))
-                                    child.typ = p[i+1]
-                                end
-                                newnode
-                            else
-                                Callsite(callsite.id, ci, callsite.head)
-                            end
-                        end
-                    end
-                end
-                menu = CthulhuMenu(show_sub_callsites, with_effects, exception_type,
-                                   optimize & !annotate_source, false, false, custom_toggles;
-                                   sub_menu=true, menu_options...)
-                cid = request(term, "", menu)
-                if cid == length(sub_callsites) + 1
-                    continue
-                end
-                if cid == -1
-                    interruptexc ? throw(InterruptException()) : break
-                end
-
-                callsite = sub_callsites[cid]
-                info = callsite.info
-            end
-
-            # forcibly enter and inspect the frame, although the native interpreter gave up
-            if info isa TaskCallInfo
-                @info """
-                Inference didn't analyze this call because it is a dynamic call:
-                Cthulhu nevertheless is trying to descend into it for further inspection.
-                """
-                additional_descend(get_ci(info)::CodeInstance)
-                continue
-            elseif info isa RTCallInfo
-                @info """
-                This is a runtime call. You cannot descend into it.
-                """
-                @goto show_menu
-            end
-
-            # recurse
-            next_cursor = navigate(curs, callsite)::Union{AbstractCursor,Nothing}
-            if next_cursor === nothing
-                continue
-            end
-
-            _descend(term, interp, next_cursor;
-                     override = get_override(info), debuginfo,
-                     optimize, interruptexc,
-                     iswarn, hide_type_stable,
-                     remarks, with_effects, exception_type, inline_cost,
-                     type_annotations, annotate_source,
-                     inlay_types_vscode, diagnostics_vscode,
-                     jump_always)
-
-        elseif toggle === :warn
-            iswarn ⊻= true
-        elseif toggle === :with_effects
-            with_effects ⊻= true
-        elseif toggle === :exception_type
-            exception_type ⊻= true
-        elseif toggle === :hide_type_stable
-            hide_type_stable ⊻= true
-        elseif toggle === :inlay_types_vscode
-            inlay_types_vscode ⊻= true
-            TypedSyntax.clear_inlay_hints_vscode()
-        elseif toggle === :diagnostics_vscode
-            diagnostics_vscode ⊻= true
-            TypedSyntax.clear_diagnostics_vscode()
-        elseif toggle === :optimize
-            optimize ⊻= true
-            if remarks && optimize
-                @warn "Disable optimization to see the inference remarks."
-            end
-        elseif toggle === :debuginfo
-            debuginfo = DebugInfo((Int(debuginfo) + 1) % 3)
-        elseif toggle === :remarks
-            remarks ⊻= true
-            if remarks && optimize
-                @warn "Disable optimization to see the inference remarks."
-            end
-        elseif toggle === :inline_cost
-            inline_cost ⊻= true
-            if inline_cost && !optimize
-                @warn "Enable optimization to see the inlining costs."
-            end
-        elseif toggle === :type_annotations
-            type_annotations ⊻= true
-        elseif toggle === :highlighter
-            CONFIG.enable_highlighter ⊻= true
-            if CONFIG.enable_highlighter
-                @info "Using syntax highlighter $(CONFIG.highlighter)."
-            else
-                @info "Turned off syntax highlighter for Julia, LLVM and native code."
-            end
-            display_CI = false
-        elseif toggle === :dump_params
-            @info "Dumping inference cache."
-            Core.show(mapany(((i, x),) -> (i, x.result, x.linfo), enumerate(CC.get_inference_cache(interp))))
-            Core.println()
-            display_CI = false
-        elseif toggle === :bookmark
-            push!(BOOKMARKS, Bookmark(mi, interp))
-            @info "The method is pushed at the end of `Cthulhu.BOOKMARKS`."
-            display_CI = false
-        elseif toggle === :revise
-            # Call Revise.revise() without introducing a dependency on Revise
-            id = Base.PkgId(UUID("295af30f-e4ad-537b-8983-00126c2a3abe"), "Revise")
-            mod = get(Base.loaded_modules, id, nothing)
-            if mod !== nothing
-                revise = getfield(mod, :revise)::Function
-                revise()
-                ci = do_typeinf!(interp, mi)
-                curs = update_cursor(curs, ci)
-            else
-                @warn "Failed to load Revise."
-            end
-        elseif toggle === :edit
-            edit(whereis(mi.def::Method)...)
-            display_CI = false
-        elseif toggle === :jump_always
-            jump_always ⊻= true
-        elseif toggle === :typed
-            view_cmd = cthulhu_typed
-            annotate_source = false
-            display_CI = true
-        elseif toggle === :source
-            view_cmd = cthulhu_typed
-            annotate_source = true
-            display_CI = true
-        elseif toggle === :ast || toggle === :llvm || toggle === :native
-            view_cmd = CODEVIEWS[toggle]
-            world = get_inference_world(interp)
-            println(iostream)
-            src = CC.typeinf_code(interp, mi, true)
-            view_cmd(iostream, mi, src, optimize, debuginfo, world, CONFIG)
-            display_CI = false
-        else
-            local i = findfirst(ct->ct.toggle === toggle, custom_toggles)
-            @assert i !== nothing
-            ct = custom_toggles[i]
-            onoff = ct.onoff ⊻= true
-            if onoff
-                curs = ct.callback_on(curs)
-            else
-                curs = ct.callback_off(curs)
-            end
-            if !(curs isa AbstractCursor)
-                local f = onoff ? "callback_on" : "callback_off"
-                error(lazy"""
-                invalid `$AbstractInterpreter` API:
-                `f` callback is expected to return `AbstractCursor` object.
-                """)
-            end
-        end
-        println(iostream)
-    end
-
-    TypedSyntax.clear_all_vscode()
-end
-
-function do_typeinf!(interp::AbstractInterpreter, mi::MethodInstance)
-    result = InferenceResult(mi)
-    ci = CC.engine_reserve(interp, mi)
-    result.ci = ci
-    # we may want to handle the case when `InferenceState(...)` returns `nothing`,
-    # which indicates code generation of a `@generated` has been failed,
-    # and show it in the UI in some way?
-    frame = InferenceState(result, #=cache_mode=#:global, interp)::InferenceState
-    CC.typeinf(interp, frame)
-    return ci
-end
-
 get_specialization(@nospecialize(f), @nospecialize(tt=default_tt(f))) =
     get_specialization(Base.signature_type(f, tt))
 get_specialization(@nospecialize tt::Type{<:Tuple}) =
@@ -658,86 +127,36 @@ get_specialization(@nospecialize tt::Type{<:Tuple}) =
 function mkinterp(interp::AbstractInterpreter, @nospecialize(args...))
     interp′ = CthulhuInterpreter(interp)
     mi = get_specialization(args...)
-    ci = do_typeinf!(interp′, mi)
+    ci = run_type_inference(interp′, mi)
     return interp′, ci
 end
 mkinterp(@nospecialize(args...); interp::AbstractInterpreter=NativeInterpreter()) = mkinterp(interp, args...)
 
-function _descend(@nospecialize(args...);
-    interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
-    (interp′, ci) = mkinterp(interp, args...)
-    _descend(interp′, ci; kwargs...)
+_descend(term::AbstractTerminal, provider::AbstractProvider, ci::CodeInstance; kwargs...) =
+    _descend(term, provider, AbstractCursor(provider, ci); kwargs...)
+function _descend(term::AbstractTerminal, provider::AbstractProvider, mi::MethodInstance; kwargs...)
+    ci = generate_code_instance(provider, mi)
+    _descend(term, provider, ci)
 end
-_descend(interp::AbstractInterpreter, ci::CodeInstance; terminal=default_terminal(), kwargs...) =
-    _descend(terminal, interp, ci; kwargs...)
-_descend(term::AbstractTerminal, interp::AbstractInterpreter, ci::CodeInstance; kwargs...) =
-    _descend(term, interp, AbstractCursor(interp, ci); kwargs...)
-function _descend(term::AbstractTerminal, mi::MethodInstance;
-    interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
-    interp′ = CthulhuInterpreter(interp)
-    ci = do_typeinf!(interp′, mi)
-    _descend(term, interp′, ci; kwargs...)
+function _descend(term::AbstractTerminal, provider::AbstractProvider, @nospecialize(args...); kwargs...)
+    mi = find_method_instance(provider, args...)
+    isa(mi, MethodInstance) || error("No method instance found for $(join(args, ", "))")
+    _descend(term, provider, mi; kwargs...)
 end
-function _descend(term::AbstractTerminal, @nospecialize(args...);
-    interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
-    (interp′, ci) = mkinterp(interp, args...)
-    _descend(term, interp′, ci; kwargs...)
+
+function _descend(term::AbstractTerminal, interp::AbstractInterpreter, @nospecialize(args...); kwargs...)
+    provider = DefaultProvider(interp)
+    _descend(term, provider, args...; kwargs...)
 end
+
+_descend(term::AbstractTerminal, @nospecialize(args...); kwargs...) =
+    _descend(term, NativeInterpreter(), args...)
+_descend(@nospecialize(args...); terminal=default_terminal(), kwargs...) =
+    _descend(terminal, args...; kwargs...)
+
 descend_code_typed_impl(b::Bookmark; kw...) =
     _descend_with_error_handling(b.interp, b.ci.def; iswarn=false, kw...)
 descend_code_warntype_impl(b::Bookmark; kw...) =
     _descend_with_error_handling(b.interp, b.ci.def; iswarn=true, kw...)
 
 FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.writeoption(buf, data.callstr, charsused)
-
-function ascend_impl(term, mi; interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
-    root = treelist(mi)
-    root === nothing && return
-    menu = TreeMenu(root)
-    choice = menu.current
-    while choice !== nothing
-        menu.chosen = false
-        choice = TerminalMenus.request(term, "Choose a call for analysis (q to quit):", menu; cursor=menu.currentidx)
-        browsecodetyped = true
-        if choice !== nothing
-            node = menu.current
-            mi = instance(node.data.nd)
-            if !isroot(node)
-                # Help user find the sites calling the parent
-                miparent = instance(node.parent.data.nd)
-                ulocs = find_caller_of(interp, miparent, mi; allow_unspecialized=true)
-                if !isempty(ulocs)
-                    ulocs = [(k[1], maybe_fix_path(String(k[2])), k[3]) => v for (k, v) in ulocs]
-                    strlocs = [string(" "^k[3] * '"', k[2], "\", ", k[1], ": lines ", v) for (k, v) in ulocs]
-                    explain_inlining = length(ulocs) > 1 ? "(including inlined callers represented by indentation) " : ""
-                    push!(strlocs, "Browse typed code")
-                    linemenu = TerminalMenus.RadioMenu(strlocs; charset=:ascii)
-                    browsecodetyped = false
-                    choice2 = 1
-                    while choice2 != -1
-                        promptstr = sprint(miparent, explain_inlining; context=:color=>get(term, :color, false)) do iobuf, mip, exi
-                            printstyled(iobuf, "\nOpen an editor at a possible caller of\n  "; color=:light_cyan)
-                            print(iobuf, miparent)
-                            printstyled(iobuf, "\n$(explain_inlining)or browse typed code:"; color=:light_cyan)
-                        end
-                        choice2 = TerminalMenus.request(term, promptstr, linemenu; cursor=choice2)
-                        if 0 < choice2 < length(strlocs)
-                            loc, lines = ulocs[choice2]
-                            edit(loc[2], first(lines))
-                        elseif choice2 == length(strlocs)
-                            browsecodetyped = true
-                            break
-                        end
-                    end
-                end
-            end
-            if !isa(mi, MethodInstance)
-                error("You can only descend into known calls. If you tried to descend into a runtime-dispatched signature, try its caller instead.")
-            end
-            # The main application of `ascend` is finding cases of non-inferrability, so the
-            # warn highlighting is useful.
-            browsecodetyped && _descend(term, mi; interp, annotate_source=true, iswarn=true, optimize=false, interruptexc=false, kwargs...)
-        end
-    end
-end
-ascend_impl(mi; kwargs...) = ascend_impl(default_terminal(), mi; kwargs...)

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -34,9 +34,9 @@ include("config.jl")
 include("preferences.jl")
 
 include("interface.jl")
+include("callsite.jl")
 include("compiler.jl")
 include("state.jl")
-include("callsite.jl")
 include("interpreter.jl")
 include("provider.jl")
 include("reflection.jl")
@@ -94,12 +94,9 @@ function _descend(term::AbstractTerminal, provider::AbstractProvider, @nospecial
     _descend(term, provider, mi; kwargs...)
 end
 
-function _descend(term::AbstractTerminal, interp::AbstractInterpreter, @nospecialize(args...); kwargs...)
-    provider = DefaultProvider(interp)
-    _descend(term, provider, args...; kwargs...)
+function _descend(term::AbstractTerminal, @nospecialize(args...); interp=NativeInterpreter(), provider=AbstractProvider(interp), kwargs...)
+    _descend(term, provider, args...)
 end
 
-_descend(term::AbstractTerminal, @nospecialize(args...); kwargs...) =
-    _descend(term, NativeInterpreter(), args...)
 _descend(@nospecialize(args...); terminal=default_terminal(), kwargs...) =
     _descend(terminal, args...; kwargs...)

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -46,15 +46,6 @@ include("backedges.jl")
 include("descend.jl")
 include("ascend.jl")
 
-"""
-    @interp
-
-For debugging. Returns a CthulhuInterpreter from the appropriate entrypoint.
-"""
-macro interp(ex0...)
-    InteractiveUtils.gen_call_with_extracted_types_and_kwargs(__module__, :mkinterp, ex0)
-end
-
 using .CC: cached_return_type
 
 cached_exception_type(code::CodeInstance) = code.exctype

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -95,7 +95,7 @@ function _descend(term::AbstractTerminal, provider::AbstractProvider, @nospecial
 end
 
 function _descend(term::AbstractTerminal, @nospecialize(args...); interp=NativeInterpreter(), provider=AbstractProvider(interp), kwargs...)
-    _descend(term, provider, args...)
+    _descend(term, provider, args...; kwargs...)
 end
 
 _descend(@nospecialize(args...); terminal=default_terminal(), kwargs...) =

--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -1,5 +1,6 @@
 Base.Experimental.@compiler_options compile=min optimize=1
 
+using Accessors
 using CodeTracking: CodeTracking, definition, whereis, maybe_fix_path
 using InteractiveUtils
 using UUIDs
@@ -28,67 +29,14 @@ using Base: get_world_counter
 get_mi(ci::CodeInstance) = CC.get_ci_mi(ci)
 get_mi(mi::MethodInstance) = mi
 
-Base.@kwdef mutable struct CthulhuConfig
-    enable_highlighter::Bool = false
-    highlighter::Cmd = `pygmentize -l`
-    asm_syntax::Symbol = :att
-    pretty_ast::Bool = false
-    interruptexc::Bool = true
-    debuginfo::Symbol = :compact
-    optimize::Bool = true
-    iswarn::Bool = false
-    hide_type_stable::Bool = false
-    remarks::Bool = false
-    with_effects::Bool = false
-    exception_type::Bool = false
-    inline_cost::Bool = false
-    type_annotations::Bool = true
-    annotate_source::Bool = true   # overrides optimize, although the current setting is preserved
-    inlay_types_vscode::Bool = true
-    diagnostics_vscode::Bool = true
-    jump_always::Bool = false
-end
-
-"""
-    Cthulhu.CONFIG
-
-# Options
-- `enable_highlighter::Bool`: Use command line `highlighter` to syntax highlight
-  Julia, LLVM and native code.
-- `highlighter::Cmd`: A command line program that receives "julia" as an argument and julia
-   code as stdin. Defaults to `$(CthulhuConfig().highlighter)`.
-- `asm_syntax::Symbol`: Set the syntax of assembly code being used.
-  Defaults to `$(CthulhuConfig().asm_syntax)`.
-- `pretty_ast::Bool`: Use a pretty printer for the ast dump. Defaults to `false`.
-- `interruptexc::Bool`: Use <q>-key to quit or ascend. Defaults to `false`.
-- `debuginfo::Symbol`: Initial state of "debuginfo" toggle. Defaults to `:compact`.
-  Options:. `:none`, `:compact`, `:source`
-- `optimize::Bool`: Initial state of "optimize" toggle. Defaults to `true`.
-- `hide_type_stable::Bool`: Initial state of "hide_type_stable" toggle. Defaults to `false`.
-- `iswarn::Bool`: Initial state of "warn" toggle. Defaults to `false`.
-- `remarks::Bool` Initial state of "remarks" toggle. Defaults to `false`.
-- `with_effects::Bool` Intial state of "effects" toggle. Defaults to `false`.
-- `exception_type::Bool` `Intial state of "exception type" toggle. Defaults to `false`.
-- `inline_cost::Bool` Initial state of "inlining costs" toggle. Defaults to `false`.
-- `type_annotations::Bool` Initial state of "type annnotations" toggle. Defaults to `true`.
-- `annotate_source::Bool` Initial state of "Source". Defaults to `true`.
-- `inlay_types_vscode::Bool` Initial state of "vscode: inlay types" toggle. Defaults to `true`
-- `diagnostics_vscode::Bool` Initial state of "Vscode: diagnostics" toggle. Defaults to `true`
-- `jump_always::Bool` Initial state of "jump to source always" toggle. Defaults to `false`.
-"""
-const CONFIG = CthulhuConfig()
-
 using Preferences
+include("config.jl")
 include("preferences.jl")
 
-module DInfo
-    @enum DebugInfo none compact source
-end
-using .DInfo: DebugInfo
-const AnyDebugInfo = Union{DebugInfo,Symbol}
-
-include("callsite.jl")
 include("interface.jl")
+include("compiler.jl")
+include("state.jl")
+include("callsite.jl")
 include("interpreter.jl")
 include("provider.jl")
 include("reflection.jl")
@@ -124,22 +72,24 @@ get_specialization(@nospecialize(f), @nospecialize(tt=default_tt(f))) =
 get_specialization(@nospecialize tt::Type{<:Tuple}) =
     specialize_method(Base._which(tt))
 
-function mkinterp(interp::AbstractInterpreter, @nospecialize(args...))
-    interp′ = CthulhuInterpreter(interp)
-    mi = get_specialization(args...)
-    ci = run_type_inference(interp′, mi)
-    return interp′, ci
-end
-mkinterp(@nospecialize(args...); interp::AbstractInterpreter=NativeInterpreter()) = mkinterp(interp, args...)
+# function mkinterp(interp::AbstractInterpreter, @nospecialize(args...))
+#     interp′ = CthulhuInterpreter(interp)
+#     mi = get_specialization(args...)
+#     ci = run_type_inference(interp′, mi)
+#     return interp′, ci
+# end
+# mkinterp(@nospecialize(args...); interp::AbstractInterpreter=NativeInterpreter()) = mkinterp(interp, args...)
 
-_descend(term::AbstractTerminal, provider::AbstractProvider, ci::CodeInstance; kwargs...) =
-    _descend(term, provider, AbstractCursor(provider, ci); kwargs...)
-function _descend(term::AbstractTerminal, provider::AbstractProvider, mi::MethodInstance; kwargs...)
+# _descend(term::AbstractTerminal, provider::AbstractProvider, ci::CodeInstance; kwargs...) =
+#     _descend(term, provider, AbstractCursor(provider, ci); kwargs...)
+function _descend(terminal::AbstractTerminal, provider::AbstractProvider, mi::MethodInstance; kwargs...)
     ci = generate_code_instance(provider, mi)
-    _descend(term, provider, ci)
+    config = setproperties(CONFIG, NamedTuple(kwargs))
+    state = CthulhuState(provider; terminal, config, mi, ci)
+    descend!(state)
 end
-function _descend(term::AbstractTerminal, provider::AbstractProvider, @nospecialize(args...); kwargs...)
-    mi = find_method_instance(provider, args...)
+function _descend(term::AbstractTerminal, provider::AbstractProvider, @nospecialize(args...); world = Base.tls_world_age(), kwargs...)
+    mi = find_method_instance(provider, args..., world)
     isa(mi, MethodInstance) || error("No method instance found for $(join(args, ", "))")
     _descend(term, provider, mi; kwargs...)
 end
@@ -153,10 +103,3 @@ _descend(term::AbstractTerminal, @nospecialize(args...); kwargs...) =
     _descend(term, NativeInterpreter(), args...)
 _descend(@nospecialize(args...); terminal=default_terminal(), kwargs...) =
     _descend(terminal, args...; kwargs...)
-
-descend_code_typed_impl(b::Bookmark; kw...) =
-    _descend_with_error_handling(b.interp, b.ci.def; iswarn=false, kw...)
-descend_code_warntype_impl(b::Bookmark; kw...) =
-    _descend_with_error_handling(b.interp, b.ci.def; iswarn=true, kw...)
-
-FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.writeoption(buf, data.callstr, charsused)

--- a/src/ascend.jl
+++ b/src/ascend.jl
@@ -44,7 +44,7 @@ function ascend_impl(term, mi; interp::AbstractInterpreter=NativeInterpreter(), 
             end
             # The main application of `ascend` is finding cases of non-inferrability, so the
             # warn highlighting is useful.
-            browsecodetyped && _descend(term, mi; interp, annotate_source=true, iswarn=true, optimize=false, interruptexc=false, kwargs...)
+            browsecodetyped && _descend(term, mi; interp, view=:source, iswarn=true, optimize=false, interruptexc=false, kwargs...)
         end
     end
 end

--- a/src/ascend.jl
+++ b/src/ascend.jl
@@ -1,0 +1,51 @@
+function ascend_impl(term, mi; interp::AbstractInterpreter=NativeInterpreter(), kwargs...)
+    root = treelist(mi)
+    root === nothing && return
+    menu = TreeMenu(root)
+    choice = menu.current
+    while choice !== nothing
+        menu.chosen = false
+        choice = TerminalMenus.request(term, "Choose a call for analysis (q to quit):", menu; cursor=menu.currentidx)
+        browsecodetyped = true
+        if choice !== nothing
+            node = menu.current
+            mi = instance(node.data.nd)
+            if !isroot(node)
+                # Help user find the sites calling the parent
+                miparent = instance(node.parent.data.nd)
+                ulocs = find_caller_of(interp, miparent, mi; allow_unspecialized=true)
+                if !isempty(ulocs)
+                    ulocs = [(k[1], maybe_fix_path(String(k[2])), k[3]) => v for (k, v) in ulocs]
+                    strlocs = [string(" "^k[3] * '"', k[2], "\", ", k[1], ": lines ", v) for (k, v) in ulocs]
+                    explain_inlining = length(ulocs) > 1 ? "(including inlined callers represented by indentation) " : ""
+                    push!(strlocs, "Browse typed code")
+                    linemenu = TerminalMenus.RadioMenu(strlocs; charset=:ascii)
+                    browsecodetyped = false
+                    choice2 = 1
+                    while choice2 != -1
+                        promptstr = sprint(miparent, explain_inlining; context=:color=>get(term, :color, false)) do iobuf, mip, exi
+                            printstyled(iobuf, "\nOpen an editor at a possible caller of\n  "; color=:light_cyan)
+                            print(iobuf, miparent)
+                            printstyled(iobuf, "\n$(explain_inlining)or browse typed code:"; color=:light_cyan)
+                        end
+                        choice2 = TerminalMenus.request(term, promptstr, linemenu; cursor=choice2)
+                        if 0 < choice2 < length(strlocs)
+                            loc, lines = ulocs[choice2]
+                            edit(loc[2], first(lines))
+                        elseif choice2 == length(strlocs)
+                            browsecodetyped = true
+                            break
+                        end
+                    end
+                end
+            end
+            if !isa(mi, MethodInstance)
+                error("You can only descend into known calls. If you tried to descend into a runtime-dispatched signature, try its caller instead.")
+            end
+            # The main application of `ascend` is finding cases of non-inferrability, so the
+            # warn highlighting is useful.
+            browsecodetyped && _descend(term, mi; interp, annotate_source=true, iswarn=true, optimize=false, interruptexc=false, kwargs...)
+        end
+    end
+end
+ascend_impl(mi; kwargs...) = ascend_impl(default_terminal(), mi; kwargs...)

--- a/src/backedges.jl
+++ b/src/backedges.jl
@@ -204,3 +204,5 @@ function treelist(exstk::Base.ExceptionStack)
     @error "exception stack contains $(length(exstk.stack)) exceptions, pick one with `ascend(err.stack[i].backtrace)`"
     return nothing
 end
+
+FoldingTrees.writeoption(buf::IO, data::Data, charsused::Int) = FoldingTrees.writeoption(buf, data.callstr, charsused)

--- a/src/codeview.jl
+++ b/src/codeview.jl
@@ -82,15 +82,9 @@ function is_type_unstable(code::Union{IRCode, CodeInfo}, idx::Int, used::BitSet)
 end
 is_type_unstable(@nospecialize(type)) = type isa Type && (!Base.isdispatchelem(type) || type == Core.Box)
 
-cthulhu_warntype(args...; kwargs...) = cthulhu_warntype(stdout::IO, args...; kwargs...)
-function cthulhu_warntype(io::IO, provider::AbstractProvider, debuginfo::Symbol,
-    src::Union{CodeInfo,IRCode}, @nospecialize(rt), effects::Effects, codeinst::Union{Nothing,CodeInstance}=nothing;
-    hide_type_stable::Bool=false, inline_cost::Bool=false, optimize::Bool=false)
-    if inline_cost
-        isa(mi, MethodInstance) || error("Need a MethodInstance to show inlining costs. Call `cthulhu_typed` directly instead.")
-    end
-    cthulhu_typed(io, provider, debuginfo, src, rt, nothing, effects, codeinst; iswarn=true, optimize, hide_type_stable, inline_cost, interp)
-    return nothing
+function cthulhu_warntype(io::IO, provider::AbstractProvider, state::CthulhuState, result::LookupResult)
+    @reset state.config.iswarn = true
+    return cthulhu_typed(io, provider, state, result)
 end
 
 function cthulhu_source(io::IO, provider::AbstractProvider, state::CthulhuState, result::LookupResult)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1,0 +1,74 @@
+function find_method_instance(interp::AbstractInterpreter, @nospecialize(tt::Type{<:Tuple}), world::UInt)
+    mt = method_table(interp)
+    match, valid_worlds = findsup(tt, mt)
+    match === nothing && return nothing
+    mi = specialize_method(match)
+    return mi
+end
+
+function generate_code_instance(interp::AbstractInterpreter, mi::MethodInstance)
+    ci = run_type_inference(interp, mi)
+    return ci
+end
+
+function find_caller_of(interp::AbstractInterpreter, callee::Union{MethodInstance,Type}, caller::MethodInstance, allow_unspecialized::Bool)
+    interp′ = CthulhuInterpreter(interp)
+    codeinst = generate_code_instance(interp′, caller)
+    @assert codeinst.def === caller
+    locs = Tuple{Core.LineInfoNode,Int}[]
+    for optimize in (true, false)
+        (; src, rt, infos, slottypes) = LookupResult(interp′, codeinst, optimize)
+        callsites, _ = find_callsites(interp′, src, infos, codeinst, slottypes, optimize)
+        callsites = allow_unspecialized ? filter(cs->maybe_callsite(cs, callee), callsites) :
+        filter(cs->is_callsite(cs, callee), callsites)
+        foreach(cs -> add_sourceline!(locs, src, cs.id, caller), callsites)
+    end
+    # Consolidate by method, but preserve the order
+    prlookup = Dict{Tuple{Symbol,Symbol},Int}()
+    ulocs = Pair{Tuple{Symbol,Symbol,Int},Vector{Int}}[]
+    if !isempty(locs)
+        for (loc, depth) in locs
+            locname = loc.method
+            if isa(locname, MethodInstance)
+                locname = locname.def.name
+            end
+            idx = get(prlookup, (locname, loc.file), nothing)
+            if idx === nothing
+                push!(ulocs, (locname, loc.file, depth) => Int[])
+                prlookup[(locname, loc.file)] = idx = length(ulocs)
+            end
+            lines = ulocs[idx][2]
+            line = loc.line
+            if line ∉ lines
+                push!(lines, line)
+            end
+        end
+    end
+    return ulocs
+end
+
+function get_inline_costs(interp::AbstractInterpreter, mi::MethodInstance, src::Union{CodeInfo, IRCode})
+    code = isa(src, IRCode) ? src.stmts.stmt : src.code
+    costs = zeros(Int, length(code))
+    params = CC.OptimizationParams(interp)
+    sparams = CC.VarState[CC.VarState(sparam, false) for sparam in mi.sparam_vals]
+    CC.statement_costs!(costs, code, src, sparams, params)
+end
+
+show_parameters(io::IO, interp::AbstractInterpreter) = show_inference_cache(io, interp)
+
+function show_inference_cache(io::IO, interp::AbstractInterpreter)
+    @info "Dumping inference cache."
+    cache = CC.get_inference_cache(interp)
+    for (i, (; linfo, result)) in enumerate(cache)
+        println(io, i, ": ", linfo, "::", result)
+    end
+end
+
+AbstractProvider(interp::NativeInterpreter) = DefaultProvider(interp)
+
+function AbstractProvider(interp::AbstractInterpreter)
+    error(lazy"""missing `$AbstractInterpreter` API:
+    `$(typeof(interp))` is required to implement `$AbstractProvider(interp::$(typeof(interp)))) -> AbstractProvider`.
+    """)
+end

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -60,6 +60,7 @@ function get_inline_costs(provider::AbstractProvider, interp::AbstractInterprete
     params = CC.OptimizationParams(interp)
     sparams = CC.VarState[CC.VarState(sparam, false) for sparam in mi.sparam_vals]
     CC.statement_costs!(costs, code, src, sparams, params)
+    return costs
 end
 
 show_parameters(io::IO, provider::AbstractProvider, interp::AbstractInterpreter) = show_inference_cache(io, interp)

--- a/src/compiler.jl
+++ b/src/compiler.jl
@@ -1,4 +1,12 @@
-function find_method_instance(interp::AbstractInterpreter, @nospecialize(tt::Type{<:Tuple}), world::UInt)
+AbstractProvider(interp::NativeInterpreter) = DefaultProvider(interp)
+
+function AbstractProvider(interp::AbstractInterpreter)
+    error(lazy"""missing `$AbstractInterpreter` API:
+    `$(typeof(interp))` is required to implement `$AbstractProvider(interp::$(typeof(interp)))) -> AbstractProvider`.
+    """)
+end
+
+function find_method_instance(provider::AbstractProvider, interp::AbstractInterpreter, @nospecialize(tt::Type{<:Tuple}), world::UInt)
     mt = method_table(interp)
     match, valid_worlds = findsup(tt, mt)
     match === nothing && return nothing
@@ -6,19 +14,18 @@ function find_method_instance(interp::AbstractInterpreter, @nospecialize(tt::Typ
     return mi
 end
 
-function generate_code_instance(interp::AbstractInterpreter, mi::MethodInstance)
-    ci = run_type_inference(interp, mi)
+function generate_code_instance(provider::AbstractProvider, interp::AbstractInterpreter, mi::MethodInstance)
+    ci = run_type_inference(provider, interp, mi)
     return ci
 end
 
-function find_caller_of(interp::AbstractInterpreter, callee::Union{MethodInstance,Type}, caller::MethodInstance, allow_unspecialized::Bool)
-    interp′ = CthulhuInterpreter(interp)
-    codeinst = generate_code_instance(interp′, caller)
+function find_caller_of(provider::AbstractProvider, interp::AbstractInterpreter, callee::Union{MethodInstance,Type}, caller::MethodInstance, allow_unspecialized::Bool)
+    codeinst = generate_code_instance(provider, interp, caller)
     @assert codeinst.def === caller
     locs = Tuple{Core.LineInfoNode,Int}[]
     for optimize in (true, false)
-        (; src, rt, infos, slottypes) = LookupResult(interp′, codeinst, optimize)
-        callsites, _ = find_callsites(interp′, src, infos, codeinst, slottypes, optimize)
+        (; src, rt, infos, slottypes) = LookupResult(interp, codeinst, optimize)
+        callsites, _ = find_callsites(interp, src, infos, codeinst, slottypes, optimize)
         callsites = allow_unspecialized ? filter(cs->maybe_callsite(cs, callee), callsites) :
         filter(cs->is_callsite(cs, callee), callsites)
         foreach(cs -> add_sourceline!(locs, src, cs.id, caller), callsites)
@@ -47,7 +54,7 @@ function find_caller_of(interp::AbstractInterpreter, callee::Union{MethodInstanc
     return ulocs
 end
 
-function get_inline_costs(interp::AbstractInterpreter, mi::MethodInstance, src::Union{CodeInfo, IRCode})
+function get_inline_costs(provider::AbstractProvider, interp::AbstractInterpreter, mi::MethodInstance, src::Union{CodeInfo, IRCode})
     code = isa(src, IRCode) ? src.stmts.stmt : src.code
     costs = zeros(Int, length(code))
     params = CC.OptimizationParams(interp)
@@ -55,7 +62,7 @@ function get_inline_costs(interp::AbstractInterpreter, mi::MethodInstance, src::
     CC.statement_costs!(costs, code, src, sparams, params)
 end
 
-show_parameters(io::IO, interp::AbstractInterpreter) = show_inference_cache(io, interp)
+show_parameters(io::IO, provider::AbstractProvider, interp::AbstractInterpreter) = show_inference_cache(io, interp)
 
 function show_inference_cache(io::IO, interp::AbstractInterpreter)
     @info "Dumping inference cache."
@@ -65,10 +72,135 @@ function show_inference_cache(io::IO, interp::AbstractInterpreter)
     end
 end
 
-AbstractProvider(interp::NativeInterpreter) = DefaultProvider(interp)
+function LookupResult(provider::AbstractProvider, interp::AbstractInterpreter, ci::CodeInstance, optimize::Bool)
+    if optimize
+        result = lookup_optimized(provider, interp, ci)
+        if result === nothing
+            @info """
+            Inference discarded the source for this call because of recursion:
+            Cthulhu nevertheless is trying to retrieve the source for further inspection.
+            """
+            result = lookup_unoptimized(provider, interp, ci)
+        end
+        return result
+    end
+    return lookup_unoptimized(provider, interp, ci)
+end
 
-function AbstractProvider(interp::AbstractInterpreter)
-    error(lazy"""missing `$AbstractInterpreter` API:
-    `$(typeof(interp))` is required to implement `$AbstractProvider(interp::$(typeof(interp)))) -> AbstractProvider`.
-    """)
+function LookupResult(provider::AbstractProvider, interp::AbstractInterpreter, result::InferenceResult, optimize::Bool)
+    optimize && return lookup_constproped_optimized(provider, interp, result)
+    return lookup_constproped_unoptimized(provider, interp, result)
+end
+
+function LookupResult(provider::AbstractProvider, call::SemiConcreteCallInfo, optimize::Bool)
+    return lookup_semiconcrete(provider, interp, call)
+end
+
+struct InferredSource
+    src::CodeInfo
+    stmt_info::Vector{CCCallInfo}
+    effects::Effects
+    rt::Any
+    exct::Any
+    InferredSource(src::CodeInfo, stmt_info::Vector{CCCallInfo}, effects, @nospecialize(rt),
+                   @nospecialize(exct)) =
+        new(src, stmt_info, effects, rt, exct)
+end
+
+struct OptimizedSource
+    ir::IRCode
+    src::CodeInfo
+    isinlineable::Bool
+    effects::Effects
+end
+
+const InferenceKey = Union{CodeInstance,InferenceResult} # TODO make this `CodeInstance` fully
+const InferenceDict{InferenceValue} = IdDict{InferenceKey, InferenceValue}
+const PC2Remarks = Vector{Pair{Int, String}}
+const PC2CallMeta = Dict{Int, CallMeta}
+const PC2Effects = Dict{Int, Effects}
+const PC2Excts = Dict{Int, Any}
+
+get_pc_remarks(provider::AbstractProvider, key::InferenceKey) = nothing
+get_pc_effects(provider::AbstractProvider, key::InferenceKey) = nothing
+get_pc_exct(provider::AbstractProvider, key::InferenceKey) = nothing
+
+function lookup_optimized(provider::AbstractProvider, interp::AbstractInterpreter, ci::CodeInstance)
+    rt = cached_return_type(ci)
+    exct = cached_exception_type(ci)
+    effects = get_effects(ci)
+    if CC.use_const_api(ci) && ci.inferred === nothing
+        @assert isdefined(ci, :rettype_const)
+        const_ci = CC.codeinfo_for_const(interp, get_mi(ci), ci.rettype_const)
+        return lookup_optimized(provider, interp, const_ci)
+    end
+    opt = OptimizedSource(provider, interp, ci)
+    src = CC.copy(opt.ir)
+    codeinf = opt.src
+    infos = src.stmts.info
+    slottypes = src.argtypes
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
+end
+
+function lookup_unoptimized(provider::AbstractProvider, interp::AbstractInterpreter, ci::CodeInstance)
+    unopt = InferredSource(provider, interp, ci)
+    codeinf = src = copy(unopt.src)
+    (; rt, exct) = unopt
+    infos = unopt.stmt_info
+    effects = unopt.effects
+    slottypes = src.slottypes
+    if isnothing(slottypes)
+        slottypes = Any[ Any for i = 1:length(src.slotflags) ]
+    end
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, false)
+end
+
+function lookup_constproped_optimized(provider::AbstractProvider, interp::AbstractInterpreter, override::InferenceResult)
+    opt = OptimizedSource(provider, interp, override)
+    # `override.src` might has been transformed to OptimizedSource already,
+    # e.g. when we switch from constant-prop' unoptimized source
+    src = CC.copy(opt.ir)
+    rt = override.result
+    exct = override.exc_result
+    infos = src.stmts.info
+    slottypes = src.argtypes
+    codeinf = opt.src
+    effects = opt.effects
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
+end
+
+function lookup_constproped_unoptimized(provider::AbstractProvider, interp::AbstractInterpreter, override::InferenceResult)
+    unopt = InferredSource(provider, interp, override)
+    codeinf = src = copy(unopt.src)
+    (; rt, exct) = unopt
+    infos = unopt.stmt_info
+    effects = get_effects(unopt)
+    slottypes = src.slottypes
+    if isnothing(slottypes)
+        slottypes = Any[ Any for i = 1:length(src.slotflags) ]
+    end
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, false)
+end
+
+function lookup_semiconcrete(provider::AbstractProvider, interp::AbstractInterpreter, override::SemiConcreteCallInfo)
+    src = CC.copy(override.ir)
+    rt = get_rt(override)
+    exct = Any # TODO
+    infos = src.stmts.info
+    slottypes = src.argtypes
+    effects = get_effects(override)
+    codeinf = nothing # TODO try to find `CodeInfo` for the regular inference?
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
+end
+
+function run_type_inference(provider::AbstractProvider, interp::AbstractInterpreter, mi::MethodInstance)
+    result = InferenceResult(mi)
+    ci = CC.engine_reserve(interp, mi)
+    result.ci = ci
+    # we may want to handle the case when `InferenceState(...)` returns `nothing`,
+    # which indicates code generation of a `@generated` has been failed,
+    # and show it in the UI in some way?
+    frame = InferenceState(result, #=cache_mode=#:global, interp)::InferenceState
+    CC.typeinf(interp, frame)
+    return ci
 end

--- a/src/config.jl
+++ b/src/config.jl
@@ -1,0 +1,56 @@
+Base.@kwdef struct CthulhuConfig
+    enable_highlighter::Bool = false
+    highlighter::Cmd = `pygmentize -l`
+    asm_syntax::Symbol = :att
+    pretty_ast::Bool = false
+    interruptexc::Bool = true
+    debuginfo::Symbol = :compact
+    optimize::Bool = true
+    iswarn::Bool = false
+    hide_type_stable::Bool = false
+    remarks::Bool = false
+    with_effects::Bool = false
+    exception_type::Bool = false
+    inline_cost::Bool = false
+    type_annotations::Bool = true
+    inlay_types_vscode::Bool = true
+    diagnostics_vscode::Bool = true
+    jump_always::Bool = false
+    view::Symbol = :source
+    function CthulhuConfig(enable_highlighter, highlighter, asm_syntax, pretty_ast, interruptexc, debuginfo, optimize, iswarn, hide_type_stable, remarks, with_effects, exception_type, inline_cost, type_annotations, inlay_types_vscode, diagnostics_vscode, jump_always, view)
+        diagnostics_vscode &= iswarn # if warnings are off, then no diagnostics are shown
+        diagnostics_vscode &= TypedSyntax.diagnostics_available_vscode()
+        inlay_types_vscode &= TypedSyntax.inlay_hints_available_vscode()
+        optimize &= view !== :source
+        return new(enable_highlighter, highlighter, asm_syntax, pretty_ast, interruptexc, debuginfo, optimize, iswarn, hide_type_stable, remarks, with_effects, exception_type, inline_cost, type_annotations, inlay_types_vscode, diagnostics_vscode, jump_always, view)
+    end
+end
+
+"""
+    Cthulhu.CONFIG
+
+# Options
+- `enable_highlighter::Bool`: Use command line `highlighter` to syntax highlight
+  Julia, LLVM and native code.
+- `highlighter::Cmd`: A command line program that receives "julia" as an argument and julia
+   code as stdin. Defaults to `$(CthulhuConfig().highlighter)`.
+- `asm_syntax::Symbol`: Set the syntax of assembly code being used.
+  Defaults to `$(CthulhuConfig().asm_syntax)`.
+- `pretty_ast::Bool`: Use a pretty printer for the ast dump. Defaults to `false`.
+- `interruptexc::Bool`: Use <q>-key to quit or ascend. Defaults to `false`.
+- `debuginfo::Symbol`: Initial state of "debuginfo" toggle. Defaults to `:compact`.
+  Options:. `:none`, `:compact`, `:source`
+- `optimize::Bool`: Initial state of "optimize" toggle. Defaults to `true`.
+- `hide_type_stable::Bool`: Initial state of "hide_type_stable" toggle. Defaults to `false`.
+- `iswarn::Bool`: Initial state of "warn" toggle. Defaults to `false`.
+- `remarks::Bool` Initial state of "remarks" toggle. Defaults to `false`.
+- `with_effects::Bool` Intial state of "effects" toggle. Defaults to `false`.
+- `exception_type::Bool` `Intial state of "exception type" toggle. Defaults to `false`.
+- `inline_cost::Bool` Initial state of "inlining costs" toggle. Defaults to `false`.
+- `type_annotations::Bool` Initial state of "type annnotations" toggle. Defaults to `true`.
+- `view::Symbol` Initial state of the view. Defaults to `:source`.
+- `inlay_types_vscode::Bool` Initial state of "vscode: inlay types" toggle. Defaults to `true`
+- `diagnostics_vscode::Bool` Initial state of "Vscode: diagnostics" toggle. Defaults to `true`
+- `jump_always::Bool` Initial state of "jump to source always" toggle. Defaults to `false`.
+"""
+global CONFIG::CthulhuConfig = CthulhuConfig()

--- a/src/descend.jl
+++ b/src/descend.jl
@@ -1,0 +1,381 @@
+descend_code_typed_impl(@nospecialize(args...); kwargs...) =
+    descend_with_error_handling(args...; annotate_source=false, iswarn=false, kwargs...)
+
+descend_code_warntype_impl(@nospecialize(args...); kwargs...) =
+    descend_with_error_handling(args...; annotate_source=false, iswarn=true, optimize=false, kwargs...)
+
+function descend_with_error_handling(args...; terminal=default_terminal(), kwargs...)
+    @nospecialize
+    try
+        _descend(terminal, args...; kwargs...)
+    catch x
+        TypedSyntax.clear_all_vscode()
+        if x isa InterruptException
+            return nothing
+        else
+            rethrow(x)
+        end
+    end
+    return nothing
+end
+
+function default_terminal()
+    term_env = get(ENV, "TERM", @static Sys.iswindows() ? "" : "dumb")
+    term = REPL.Terminals.TTYTerminal(term_env, stdin, stdout, stderr)
+    return term
+end
+
+descend_impl(@nospecialize(args...); kwargs...) =
+    descend_with_error_handling(args...; iswarn=true, kwargs...)
+
+##
+# _descend is the main driver function.
+# src/reflection.jl has the tools to discover methods
+# src/ui.jl provides the user facing interface to which _descend responds
+##
+function _descend(term::AbstractTerminal, provider::AbstractProvider, curs::AbstractCursor;
+    override = nothing,
+    debuginfo::Union{Symbol,DebugInfo}    = CONFIG.debuginfo,                     # default is compact debuginfo
+    optimize::Bool                        = CONFIG.optimize,                      # default is true
+    interruptexc::Bool                    = CONFIG.interruptexc,
+    iswarn::Bool                          = CONFIG.iswarn,                        # default is false
+    hide_type_stable::Union{Nothing,Bool} = CONFIG.hide_type_stable,
+    verbose::Union{Nothing,Bool}          = nothing,
+    remarks::Bool                         = CONFIG.remarks&!CONFIG.optimize,      # default is false
+    with_effects::Bool                    = CONFIG.with_effects,                  # default is false
+    exception_type::Bool                  = CONFIG.exception_type,                # default is false
+    inline_cost::Bool                     = CONFIG.inline_cost&CONFIG.optimize,   # default is false
+    type_annotations::Bool                = CONFIG.type_annotations,              # default is true
+    annotate_source::Bool                 = CONFIG.annotate_source,               # default is true
+    inlay_types_vscode::Bool              = CONFIG.inlay_types_vscode,            # default is true
+    diagnostics_vscode::Bool              = CONFIG.diagnostics_vscode,            # default is true
+    jump_always::Bool                     = CONFIG.jump_always,                   # default is false
+    )
+
+    if isnothing(hide_type_stable)
+        hide_type_stable = something(verbose, false)
+    end
+    isnothing(verbose) || Base.depwarn("The `verbose` keyword argument to `Cthulhu.descend` is deprecated. Use `hide_type_stable` instead.")
+    if isa(debuginfo, Symbol)
+        debuginfo = getfield(DInfo, debuginfo)::DebugInfo
+    end
+
+    menu_options = (; cursor = '•', scroll_wrap = true)
+    display_CI = true
+    view_cmd = cthulhu_typed
+    iostream = term.out_stream::IO
+    function additional_descend(new_ci::CodeInstance)
+        _descend(term, provider, new_ci;
+                 debuginfo, optimize, interruptexc, iswarn, hide_type_stable, remarks,
+                 with_effects, exception_type,
+                 inline_cost, type_annotations, annotate_source,
+                 inlay_types_vscode, diagnostics_vscode)
+    end
+    custom_toggles = (@__MODULE__).custom_toggles(provider)
+    if !(custom_toggles isa Vector{CustomToggle})
+        error(lazy"""
+        invalid `$AbstractProvider` API:
+        `$(Cthulhu.custom_toggles)(provider::$(typeof(provider))` is expected to return `Vector{CustomToggle}` object.
+        """)
+    end
+    while true
+        src = @something(override, get_ci(curs))
+        do_optimize = optimize & !annotate_source
+        result = lookup(provider, src, do_optimize)
+        if result === nothing
+            if should_regenerate_code_instance(provider, src)
+                additional_descend(src)
+                break
+            end
+        end
+        # if is_constant(result)
+        #     # This was inferred to a pure constant - we have no code to show,
+        #     # but make something up that looks plausible.
+        #     # TODO use `codeinfo_for_const`
+        #     constant = extract_constant(result, src)
+        #     callsites = Callsite[]
+        #     if display_CI
+        #         exct = cached_exception_type(codeinst)
+        #         callsite = Callsite(-1, EdgeCallInfo(codeinst, codeinst.rettype, get_effects(codeinst), exct), :invoke)
+        #         println(iostream)
+        #         println(iostream, "│ ─ $callsite")
+        #         println(iostream, "│  return ", Const(codeinst.rettype_const))
+        #         println(iostream)
+        #     end
+        #     mi = get_mi(codeinst)
+        #     @goto show_menu
+        # end
+        ci = get_ci(curs)
+        mi = get_mi(ci)
+        infkey = override isa InferenceResult ? override : ci
+        pc2excts = exception_type ? get_pc_exct(provider, infkey) : nothing
+        callsites, sourcenodes = find_callsites(provider, result, ci, annotate_source, pc2excts)
+
+        if jump_always
+            if isdefined(Main, :VSCodeServer) && Main.VSCodeServer isa Module && isdefined(Main.VSCodeServer, :openfile)
+                Main.VSCodeServer.openfile(whereis(mi.def::Method)...; preserve_focus=true)
+            else
+                edit(whereis(mi.def::Method)...)
+            end
+        end
+
+        if display_CI
+            pc2remarks = remarks ? get_pc_remarks(provider, infkey) : nothing
+            pc2effects = with_effects ? get_pc_effects(provider, infkey) : nothing
+            printstyled(IOContext(iostream, :limit=>true), mi.def, '\n'; bold=true)
+            if debuginfo == DInfo.compact
+                str = let debuginfo=debuginfo, src=result.src, codeinf=result.codeinf, rt=result.rt,
+                          iswarn=iswarn, hide_type_stable=hide_type_stable,
+                          pc2remarks=pc2remarks, pc2effects=pc2effects, inline_cost=inline_cost, type_annotations=type_annotations
+                    ioctx = IOContext(iostream,
+                        :color => true,
+                        :displaysize => displaysize(iostream), # displaysize doesn't propagate otherwise
+                        :SOURCE_SLOTNAMES => source_slotnames(result),
+                        :with_effects => with_effects,
+                        :exception_type => exception_type)
+                    stringify(ioctx) do lambda_io
+                        cthulhu_typed(lambda_io, provider, debuginfo, annotate_source ? codeinf : src, rt, result.exct, result.effects, ci;
+                                      iswarn, optimize, hide_type_stable,
+                                      pc2remarks, pc2effects, pc2excts,
+                                      inline_cost, type_annotations, annotate_source, inlay_types_vscode, diagnostics_vscode,
+                                      jump_always)
+                    end
+                end
+                # eliminate trailing indentation (see first item in bullet list in PR #189)
+                rmatch = findfirst(r"\u001B\[90m\u001B\[(\d+)G( *)\u001B\[1G\u001B\[39m\u001B\[90m( *)\u001B\[39m$", str)
+                if rmatch !== nothing
+                    str = str[begin:prevind(str, first(rmatch))]
+                end
+                print(iostream, str)
+            else
+                lambda_io = IOContext(iostream,
+                    :SOURCE_SLOTNAMES => source_slotnames(result),
+                    :with_effects => with_effects,
+                    :exception_type => exception_type)
+                cthulhu_typed(lambda_io, provider, debuginfo, result.src, result.rt, result.exct, result.effects, ci;
+                              iswarn, optimize, hide_type_stable,
+                              pc2remarks, pc2effects, pc2excts,
+                              inline_cost, type_annotations, annotate_source, inlay_types_vscode, diagnostics_vscode,
+                              jump_always)
+            end
+            view_cmd = cthulhu_typed
+        else
+            display_CI = true
+        end
+
+        @label show_menu
+
+        shown_callsites = annotate_source ? sourcenodes : callsites
+        menu = CthulhuMenu(shown_callsites, with_effects, exception_type,
+                           optimize & !annotate_source,
+                           iswarn&get(iostream, :color, false)::Bool,
+                           hide_type_stable, custom_toggles; menu_options...)
+        usg = usage(view_cmd, annotate_source, optimize, iswarn, hide_type_stable,
+                    debuginfo, remarks, with_effects, exception_type, inline_cost,
+                    type_annotations, CONFIG.enable_highlighter, inlay_types_vscode,
+                    diagnostics_vscode, jump_always, custom_toggles)
+        cid = request(term, usg, menu)
+        toggle = menu.toggle
+
+        if toggle === nothing
+            if cid == length(callsites) + 1
+                break
+            end
+            if cid == -1
+                interruptexc ? throw(InterruptException()) : break
+            end
+            callsite = callsites[cid]
+            sourcenode = !isempty(sourcenodes) ? sourcenodes[cid] : nothing
+
+            info = callsite.info
+            if info isa MultiCallInfo
+                show_sub_callsites = sub_callsites = let callsite=callsite
+                    map(ci->Callsite(callsite.id, ci, callsite.head), info.callinfos)
+                end
+                if isempty(sub_callsites)
+                    Core.eval(Main, quote
+                        provider = $provider
+                        mi = $mi
+                        info = $info
+                    end)
+                    @error "Expected multiple callsites, but found none. Please fill an issue with a reproducing example."
+                    continue
+                end
+                if sourcenode !== nothing
+                    show_sub_callsites = let callsite=callsite
+                        map(info.callinfos) do ci
+                            p = Base.unwrap_unionall(get_ci(ci).def.specTypes).parameters
+                            if isa(sourcenode, TypedSyntax.MaybeTypedSyntaxNode) && length(p) == length(JuliaSyntax.children(sourcenode)) + 1
+                                newnode = copy(sourcenode)
+                                for (i, child) in enumerate(JuliaSyntax.children(newnode))
+                                    child.typ = p[i+1]
+                                end
+                                newnode
+                            else
+                                Callsite(callsite.id, ci, callsite.head)
+                            end
+                        end
+                    end
+                end
+                menu = CthulhuMenu(show_sub_callsites, with_effects, exception_type,
+                                   optimize & !annotate_source, false, false, custom_toggles;
+                                   sub_menu=true, menu_options...)
+                cid = request(term, "", menu)
+                if cid == length(sub_callsites) + 1
+                    continue
+                end
+                if cid == -1
+                    interruptexc ? throw(InterruptException()) : break
+                end
+
+                callsite = sub_callsites[cid]
+                info = callsite.info
+            end
+
+            # forcibly enter and inspect the frame, although the native interpreter gave up
+            if info isa TaskCallInfo
+                @info """
+                Inference didn't analyze this call because it is a dynamic call:
+                Cthulhu nevertheless is trying to descend into it for further inspection.
+                """
+                additional_descend(get_ci(info)::CodeInstance)
+                continue
+            elseif info isa RTCallInfo
+                @info """
+                This is a runtime call. You cannot descend into it.
+                """
+                @goto show_menu
+            end
+
+            # recurse
+            next_cursor = navigate(curs, callsite)::Union{AbstractCursor,Nothing}
+            if next_cursor === nothing
+                continue
+            end
+
+            _descend(term, provider, next_cursor;
+                     override = get_override(provider, info), debuginfo,
+                     optimize, interruptexc,
+                     iswarn, hide_type_stable,
+                     remarks, with_effects, exception_type, inline_cost,
+                     type_annotations, annotate_source,
+                     inlay_types_vscode, diagnostics_vscode,
+                     jump_always)
+
+        elseif toggle === :warn
+            iswarn ⊻= true
+        elseif toggle === :with_effects
+            with_effects ⊻= true
+        elseif toggle === :exception_type
+            exception_type ⊻= true
+        elseif toggle === :hide_type_stable
+            hide_type_stable ⊻= true
+        elseif toggle === :inlay_types_vscode
+            inlay_types_vscode ⊻= true
+            TypedSyntax.clear_inlay_hints_vscode()
+        elseif toggle === :diagnostics_vscode
+            diagnostics_vscode ⊻= true
+            TypedSyntax.clear_diagnostics_vscode()
+        elseif toggle === :optimize
+            optimize ⊻= true
+            if remarks && optimize
+                @warn "Disable optimization to see the inference remarks."
+            end
+        elseif toggle === :debuginfo
+            debuginfo = DebugInfo((Int(debuginfo) + 1) % 3)
+        elseif toggle === :remarks
+            remarks ⊻= true
+            if remarks && optimize
+                @warn "Disable optimization to see the inference remarks."
+            end
+        elseif toggle === :inline_cost
+            inline_cost ⊻= true
+            if inline_cost && !optimize
+                @warn "Enable optimization to see the inlining costs."
+            end
+        elseif toggle === :type_annotations
+            type_annotations ⊻= true
+        elseif toggle === :highlighter
+            CONFIG.enable_highlighter ⊻= true
+            if CONFIG.enable_highlighter
+                @info "Using syntax highlighter $(CONFIG.highlighter)."
+            else
+                @info "Turned off syntax highlighter for Julia, LLVM and native code."
+            end
+            display_CI = false
+        elseif toggle === :dump_params
+            show_parameters(stdout, provider) # XXX: show to terminal instead?
+            display_CI = false
+        elseif toggle === :bookmark
+            push!(BOOKMARKS, Bookmark(mi, interp))
+            @info "The method is pushed at the end of `Cthulhu.BOOKMARKS`."
+            display_CI = false
+        elseif toggle === :revise
+            # Call Revise.revise() without introducing a dependency on Revise
+            id = Base.PkgId(UUID("295af30f-e4ad-537b-8983-00126c2a3abe"), "Revise")
+            mod = get(Base.loaded_modules, id, nothing)
+            if mod !== nothing
+                revise = getfield(mod, :revise)::Function
+                revise()
+                ci = generate_code_instance(interp, mi)
+                curs = update_cursor(curs, ci)
+            else
+                @warn "Failed to load Revise."
+            end
+        elseif toggle === :edit
+            edit(whereis(mi.def::Method)...)
+            display_CI = false
+        elseif toggle === :jump_always
+            jump_always ⊻= true
+        elseif toggle === :typed
+            view_cmd = cthulhu_typed
+            annotate_source = false
+            display_CI = true
+        elseif toggle === :source
+            view_cmd = cthulhu_typed
+            annotate_source = true
+            display_CI = true
+        elseif toggle === :ast || toggle === :llvm || toggle === :native
+            view_cmd = CODEVIEWS[toggle]
+            world = get_inference_world(provider)
+            ci = generate_code_instance(provider, mi)
+            result = lookup(provider, ci, #=optimize=#true)
+            println(iostream)
+            view_cmd(iostream, mi, result.codeinf, result.optimized, debuginfo, world, CONFIG)
+            display_CI = false
+        else
+            local i = findfirst(ct->ct.toggle === toggle, custom_toggles)
+            @assert i !== nothing
+            ct = custom_toggles[i]
+            onoff = ct.onoff ⊻= true
+            if onoff
+                curs = ct.callback_on(curs)
+            else
+                curs = ct.callback_off(curs)
+            end
+            if !(curs isa AbstractCursor)
+                local f = onoff ? "callback_on" : "callback_off"
+                error(lazy"""
+                invalid `$AbstractInterpreter` API:
+                `f` callback is expected to return `AbstractCursor` object.
+                """)
+            end
+        end
+        println(iostream)
+    end
+
+    TypedSyntax.clear_all_vscode()
+end
+
+function is_constant(result::LookupResult)
+    return result.src === nothing
+end
+
+function extract_constant(result::LookupResult, ci::CodeInstance)
+    return result.src === nothing
+end
+
+function source_slotnames(result::LookupResult)
+    result.codeinf === nothing && return false
+    return Base.sourceinfo_slotnames(result.codeinf)
+end

--- a/src/descend.jl
+++ b/src/descend.jl
@@ -1,8 +1,8 @@
 descend_code_typed_impl(@nospecialize(args...); kwargs...) =
-    descend_with_error_handling(args...; annotate_source=false, iswarn=false, kwargs...)
+    descend_with_error_handling(args...; view = :typed, iswarn=false, kwargs...)
 
 descend_code_warntype_impl(@nospecialize(args...); kwargs...) =
-    descend_with_error_handling(args...; annotate_source=false, iswarn=true, optimize=false, kwargs...)
+    descend_with_error_handling(args...; view = :typed, iswarn=true, optimize=false, kwargs...)
 
 function descend_with_error_handling(args...; terminal=default_terminal(), kwargs...)
     @nospecialize
@@ -29,59 +29,28 @@ descend_impl(@nospecialize(args...); kwargs...) =
     descend_with_error_handling(args...; iswarn=true, kwargs...)
 
 ##
-# _descend is the main driver function.
-# src/reflection.jl has the tools to discover methods
-# src/ui.jl provides the user facing interface to which _descend responds
+# descend! is the main driver function.
+# src/reflection.jl has the tools to discover methods.
+# src/state.jl provides the state that is mutated by `descend!`.
+# src/ui.jl provides the user facing interface to which `descend!` responds.
 ##
-function _descend(term::AbstractTerminal, provider::AbstractProvider, curs::AbstractCursor;
-    override = nothing,
-    debuginfo::Union{Symbol,DebugInfo}    = CONFIG.debuginfo,                     # default is compact debuginfo
-    optimize::Bool                        = CONFIG.optimize,                      # default is true
-    interruptexc::Bool                    = CONFIG.interruptexc,
-    iswarn::Bool                          = CONFIG.iswarn,                        # default is false
-    hide_type_stable::Union{Nothing,Bool} = CONFIG.hide_type_stable,
-    verbose::Union{Nothing,Bool}          = nothing,
-    remarks::Bool                         = CONFIG.remarks&!CONFIG.optimize,      # default is false
-    with_effects::Bool                    = CONFIG.with_effects,                  # default is false
-    exception_type::Bool                  = CONFIG.exception_type,                # default is false
-    inline_cost::Bool                     = CONFIG.inline_cost&CONFIG.optimize,   # default is false
-    type_annotations::Bool                = CONFIG.type_annotations,              # default is true
-    annotate_source::Bool                 = CONFIG.annotate_source,               # default is true
-    inlay_types_vscode::Bool              = CONFIG.inlay_types_vscode,            # default is true
-    diagnostics_vscode::Bool              = CONFIG.diagnostics_vscode,            # default is true
-    jump_always::Bool                     = CONFIG.jump_always,                   # default is false
-    )
-
-    if isnothing(hide_type_stable)
-        hide_type_stable = something(verbose, false)
-    end
-    isnothing(verbose) || Base.depwarn("The `verbose` keyword argument to `Cthulhu.descend` is deprecated. Use `hide_type_stable` instead.")
-    if isa(debuginfo, Symbol)
-        debuginfo = getfield(DInfo, debuginfo)::DebugInfo
-    end
-
+function descend!(state::CthulhuState)
     menu_options = (; cursor = '•', scroll_wrap = true)
-    display_CI = true
-    view_cmd = cthulhu_typed
-    iostream = term.out_stream::IO
-    function additional_descend(new_ci::CodeInstance)
-        _descend(term, provider, new_ci;
-                 debuginfo, optimize, interruptexc, iswarn, hide_type_stable, remarks,
-                 with_effects, exception_type,
-                 inline_cost, type_annotations, annotate_source,
-                 inlay_types_vscode, diagnostics_vscode)
-    end
-    custom_toggles = (@__MODULE__).custom_toggles(provider)
-    if !(custom_toggles isa Vector{CustomToggle})
-        error(lazy"""
-        invalid `$AbstractProvider` API:
-        `$(Cthulhu.custom_toggles)(provider::$(typeof(provider))` is expected to return `Vector{CustomToggle}` object.
-        """)
-    end
     while true
-        src = @something(override, get_ci(curs))
-        do_optimize = optimize & !annotate_source
-        result = lookup(provider, src, do_optimize)
+        (; config, mi, ci, provider) = state
+        iostream = state.terminal.out_stream::IO
+        commands = (@__MODULE__).commands(provider)
+        if !isa(commands, Vector{Command})
+            error(lazy"""
+            invalid `$AbstractProvider` API:
+            `$(Cthulhu.commands)(provider::$(typeof(provider))` is expected to return a `Vector{Command}` object.
+            """)
+        end
+
+        mi::MethodInstance, ci::CodeInstance
+
+        src = something(state.override, ci)
+        result = LookupResult(provider, src, config.optimize)
         if result === nothing
             if should_regenerate_code_instance(provider, src)
                 additional_descend(src)
@@ -92,9 +61,9 @@ function _descend(term::AbstractTerminal, provider::AbstractProvider, curs::Abst
         #     # This was inferred to a pure constant - we have no code to show,
         #     # but make something up that looks plausible.
         #     # TODO use `codeinfo_for_const`
-        #     constant = extract_constant(result, src)
+        #     constant = extract_constant(result, ci)
         #     callsites = Callsite[]
-        #     if display_CI
+        #     if state.display_code
         #         exct = cached_exception_type(codeinst)
         #         callsite = Callsite(-1, EdgeCallInfo(codeinst, codeinst.rettype, get_effects(codeinst), exct), :invoke)
         #         println(iostream)
@@ -105,132 +74,60 @@ function _descend(term::AbstractTerminal, provider::AbstractProvider, curs::Abst
         #     mi = get_mi(codeinst)
         #     @goto show_menu
         # end
-        ci = get_ci(curs)
-        mi = get_mi(ci)
-        infkey = override isa InferenceResult ? override : ci
-        pc2excts = exception_type ? get_pc_exct(provider, infkey) : nothing
-        callsites, sourcenodes = find_callsites(provider, result, ci, annotate_source, pc2excts)
 
-        if jump_always
+        # infkey = override isa InferenceResult ? override : ci
+
+        if config.jump_always
+            def = state.mi.def
+            isa(def, Method) || return @warn "Can't jump to source location because the definition is not a method."
             if isdefined(Main, :VSCodeServer) && Main.VSCodeServer isa Module && isdefined(Main.VSCodeServer, :openfile)
-                Main.VSCodeServer.openfile(whereis(mi.def::Method)...; preserve_focus=true)
+                Main.VSCodeServer.openfile(whereis(def)...; preserve_focus=true)
             else
-                edit(whereis(mi.def::Method)...)
+                edit(whereis(def)...)
             end
         end
 
-        if display_CI
-            pc2remarks = remarks ? get_pc_remarks(provider, infkey) : nothing
-            pc2effects = with_effects ? get_pc_effects(provider, infkey) : nothing
-            printstyled(IOContext(iostream, :limit=>true), mi.def, '\n'; bold=true)
-            if debuginfo == DInfo.compact
-                str = let debuginfo=debuginfo, src=result.src, codeinf=result.codeinf, rt=result.rt,
-                          iswarn=iswarn, hide_type_stable=hide_type_stable,
-                          pc2remarks=pc2remarks, pc2effects=pc2effects, inline_cost=inline_cost, type_annotations=type_annotations
-                    ioctx = IOContext(iostream,
+        if state.display_code
+            printstyled(IOContext(iostream, :limit => true), mi.def, '\n'; bold=true)
+            ioctx = IOContext(iostream,
                         :color => true,
                         :displaysize => displaysize(iostream), # displaysize doesn't propagate otherwise
                         :SOURCE_SLOTNAMES => source_slotnames(result),
-                        :with_effects => with_effects,
-                        :exception_type => exception_type)
-                    stringify(ioctx) do lambda_io
-                        cthulhu_typed(lambda_io, provider, debuginfo, annotate_source ? codeinf : src, rt, result.exct, result.effects, ci;
-                                      iswarn, optimize, hide_type_stable,
-                                      pc2remarks, pc2effects, pc2excts,
-                                      inline_cost, type_annotations, annotate_source, inlay_types_vscode, diagnostics_vscode,
-                                      jump_always)
-                    end
-                end
-                # eliminate trailing indentation (see first item in bullet list in PR #189)
-                rmatch = findfirst(r"\u001B\[90m\u001B\[(\d+)G( *)\u001B\[1G\u001B\[39m\u001B\[90m( *)\u001B\[39m$", str)
-                if rmatch !== nothing
-                    str = str[begin:prevind(str, first(rmatch))]
-                end
-                print(iostream, str)
-            else
-                lambda_io = IOContext(iostream,
-                    :SOURCE_SLOTNAMES => source_slotnames(result),
-                    :with_effects => with_effects,
-                    :exception_type => exception_type)
-                cthulhu_typed(lambda_io, provider, debuginfo, result.src, result.rt, result.exct, result.effects, ci;
-                              iswarn, optimize, hide_type_stable,
-                              pc2remarks, pc2effects, pc2excts,
-                              inline_cost, type_annotations, annotate_source, inlay_types_vscode, diagnostics_vscode,
-                              jump_always)
+                        :with_effects => config.with_effects,
+                        :exception_type => config.exception_type)
+            str = stringify(ioctx) do io
+                view_function(state)(io, provider, state, result)
             end
-            view_cmd = cthulhu_typed
-        else
-            display_CI = true
+            # eliminate trailing indentation (see first item in bullet list in PR #189)
+            rmatch = findfirst(r"\u001B\[90m\u001B\[(\d+)G( *)\u001B\[1G\u001B\[39m\u001B\[90m( *)\u001B\[39m$", str)
+            if rmatch !== nothing
+                str = str[begin:prevind(str, first(rmatch))]
+            end
+            print(iostream, str)
         end
+
+        callsites, source_nodes = find_callsites(provider, result, ci, config.view === :source)
 
         @label show_menu
 
-        shown_callsites = annotate_source ? sourcenodes : callsites
-        menu = CthulhuMenu(shown_callsites, with_effects, exception_type,
-                           optimize & !annotate_source,
-                           iswarn&get(iostream, :color, false)::Bool,
-                           hide_type_stable, custom_toggles; menu_options...)
-        usg = usage(view_cmd, annotate_source, optimize, iswarn, hide_type_stable,
-                    debuginfo, remarks, with_effects, exception_type, inline_cost,
-                    type_annotations, CONFIG.enable_highlighter, inlay_types_vscode,
-                    diagnostics_vscode, jump_always, custom_toggles)
-        cid = request(term, usg, menu)
+        shown_callsites = config.view === :source ? source_nodes : callsites
+
+        state.display_code = false
+        menu = CthulhuMenu(state, shown_callsites, config.with_effects, config.exception_type, config.optimize,
+                           config.iswarn & get(iostream, :color, false)::Bool,
+                           config.hide_type_stable, commands; menu_options...)
+        update_commands!(provider, commands, state)
+        usg = usage(config, commands)
+        cid = request(state.terminal, usg, menu)
         toggle = menu.toggle
 
         if toggle === nothing
-            if cid == length(callsites) + 1
-                break
-            end
-            if cid == -1
-                interruptexc ? throw(InterruptException()) : break
-            end
-            callsite = callsites[cid]
-            sourcenode = !isempty(sourcenodes) ? sourcenodes[cid] : nothing
-
-            info = callsite.info
-            if info isa MultiCallInfo
-                show_sub_callsites = sub_callsites = let callsite=callsite
-                    map(ci->Callsite(callsite.id, ci, callsite.head), info.callinfos)
-                end
-                if isempty(sub_callsites)
-                    Core.eval(Main, quote
-                        provider = $provider
-                        mi = $mi
-                        info = $info
-                    end)
-                    @error "Expected multiple callsites, but found none. Please fill an issue with a reproducing example."
-                    continue
-                end
-                if sourcenode !== nothing
-                    show_sub_callsites = let callsite=callsite
-                        map(info.callinfos) do ci
-                            p = Base.unwrap_unionall(get_ci(ci).def.specTypes).parameters
-                            if isa(sourcenode, TypedSyntax.MaybeTypedSyntaxNode) && length(p) == length(JuliaSyntax.children(sourcenode)) + 1
-                                newnode = copy(sourcenode)
-                                for (i, child) in enumerate(JuliaSyntax.children(newnode))
-                                    child.typ = p[i+1]
-                                end
-                                newnode
-                            else
-                                Callsite(callsite.id, ci, callsite.head)
-                            end
-                        end
-                    end
-                end
-                menu = CthulhuMenu(show_sub_callsites, with_effects, exception_type,
-                                   optimize & !annotate_source, false, false, custom_toggles;
-                                   sub_menu=true, menu_options...)
-                cid = request(term, "", menu)
-                if cid == length(sub_callsites) + 1
-                    continue
-                end
-                if cid == -1
-                    interruptexc ? throw(InterruptException()) : break
-                end
-
-                callsite = sub_callsites[cid]
-                info = callsite.info
-            end
+            callsite = select_callsite(state, callsites, source_nodes, cid)::Union{Symbol, Callsite}
+            callsite === :ascend && break
+            callsite === :interrupted && break
+            callsite === :failed && continue
+            callsite === :continue && continue
+            (; info) = callsite
 
             # forcibly enter and inspect the frame, although the native interpreter gave up
             if info isa TaskCallInfo
@@ -238,7 +135,8 @@ function _descend(term::AbstractTerminal, provider::AbstractProvider, curs::Abst
                 Inference didn't analyze this call because it is a dynamic call:
                 Cthulhu nevertheless is trying to descend into it for further inspection.
                 """
-                additional_descend(get_ci(info)::CodeInstance)
+                state.ci = get_ci(info)::CodeInstance
+                descend!(state)
                 continue
             elseif info isa RTCallInfo
                 @info """
@@ -247,124 +145,80 @@ function _descend(term::AbstractTerminal, provider::AbstractProvider, curs::Abst
                 @goto show_menu
             end
 
-            # recurse
-            next_cursor = navigate(curs, callsite)::Union{AbstractCursor,Nothing}
-            if next_cursor === nothing
-                continue
-            end
+            ci = get_ci(callsite)
+            ci === nothing && continue
 
-            _descend(term, provider, next_cursor;
-                     override = get_override(provider, info), debuginfo,
-                     optimize, interruptexc,
-                     iswarn, hide_type_stable,
-                     remarks, with_effects, exception_type, inline_cost,
-                     type_annotations, annotate_source,
-                     inlay_types_vscode, diagnostics_vscode,
-                     jump_always)
+            # Recurse into the callsite.
 
-        elseif toggle === :warn
-            iswarn ⊻= true
-        elseif toggle === :with_effects
-            with_effects ⊻= true
-        elseif toggle === :exception_type
-            exception_type ⊻= true
-        elseif toggle === :hide_type_stable
-            hide_type_stable ⊻= true
-        elseif toggle === :inlay_types_vscode
-            inlay_types_vscode ⊻= true
-            TypedSyntax.clear_inlay_hints_vscode()
-        elseif toggle === :diagnostics_vscode
-            diagnostics_vscode ⊻= true
-            TypedSyntax.clear_diagnostics_vscode()
-        elseif toggle === :optimize
-            optimize ⊻= true
-            if remarks && optimize
-                @warn "Disable optimization to see the inference remarks."
-            end
-        elseif toggle === :debuginfo
-            debuginfo = DebugInfo((Int(debuginfo) + 1) % 3)
-        elseif toggle === :remarks
-            remarks ⊻= true
-            if remarks && optimize
-                @warn "Disable optimization to see the inference remarks."
-            end
-        elseif toggle === :inline_cost
-            inline_cost ⊻= true
-            if inline_cost && !optimize
-                @warn "Enable optimization to see the inlining costs."
-            end
-        elseif toggle === :type_annotations
-            type_annotations ⊻= true
-        elseif toggle === :highlighter
-            CONFIG.enable_highlighter ⊻= true
-            if CONFIG.enable_highlighter
-                @info "Using syntax highlighter $(CONFIG.highlighter)."
-            else
-                @info "Turned off syntax highlighter for Julia, LLVM and native code."
-            end
-            display_CI = false
-        elseif toggle === :dump_params
-            show_parameters(stdout, provider) # XXX: show to terminal instead?
-            display_CI = false
-        elseif toggle === :bookmark
-            push!(BOOKMARKS, Bookmark(mi, interp))
-            @info "The method is pushed at the end of `Cthulhu.BOOKMARKS`."
-            display_CI = false
-        elseif toggle === :revise
-            # Call Revise.revise() without introducing a dependency on Revise
-            id = Base.PkgId(UUID("295af30f-e4ad-537b-8983-00126c2a3abe"), "Revise")
-            mod = get(Base.loaded_modules, id, nothing)
-            if mod !== nothing
-                revise = getfield(mod, :revise)::Function
-                revise()
-                ci = generate_code_instance(interp, mi)
-                curs = update_cursor(curs, ci)
-            else
-                @warn "Failed to load Revise."
-            end
-        elseif toggle === :edit
-            edit(whereis(mi.def::Method)...)
-            display_CI = false
-        elseif toggle === :jump_always
-            jump_always ⊻= true
-        elseif toggle === :typed
-            view_cmd = cthulhu_typed
-            annotate_source = false
-            display_CI = true
-        elseif toggle === :source
-            view_cmd = cthulhu_typed
-            annotate_source = true
-            display_CI = true
-        elseif toggle === :ast || toggle === :llvm || toggle === :native
-            view_cmd = CODEVIEWS[toggle]
-            world = get_inference_world(provider)
-            ci = generate_code_instance(provider, mi)
-            result = lookup(provider, ci, #=optimize=#true)
-            println(iostream)
-            view_cmd(iostream, mi, result.codeinf, result.optimized, debuginfo, world, CONFIG)
-            display_CI = false
-        else
-            local i = findfirst(ct->ct.toggle === toggle, custom_toggles)
-            @assert i !== nothing
-            ct = custom_toggles[i]
-            onoff = ct.onoff ⊻= true
-            if onoff
-                curs = ct.callback_on(curs)
-            else
-                curs = ct.callback_off(curs)
-            end
-            if !(curs isa AbstractCursor)
-                local f = onoff ? "callback_on" : "callback_off"
-                error(lazy"""
-                invalid `$AbstractInterpreter` API:
-                `f` callback is expected to return `AbstractCursor` object.
-                """)
-            end
+            prev = save_descend_state(state)
+            state.ci = ci
+            state.override = get_override(provider, info)
+            state.display_code = true
+            descend!(state)
+            restore_descend_state!(state, prev)
+            state.display_code = true
         end
+
         println(iostream)
     end
 
     TypedSyntax.clear_all_vscode()
+end
+
+function select_callsite(state::CthulhuState, callsites::Vector{Callsite}, source_nodes, i::Int)
+    (; config) = state
+    i === length(callsites) + 1 && return :ascend
+    if i === -1
+        config.interruptexc && throw(InterruptException())
+        return :interrupted
+    end
+
+    callsite = callsites[i]
+    !isa(callsite.info, MultiCallInfo) && return callsite
+
+    (; info) = callsite
+    source_node = !isempty(source_nodes) ? source_nodes[i] : nothing
+    sub_callsites = map(ci -> Callsite(callsite.id, ci, callsite.head), info.callinfos)
+    if isempty(sub_callsites)
+        @eval Main begin
+            provider = $provider
+            mi = $mi
+            info = $info
+        end
+        @error "Expected multiple callsites, but found none. Please fill an issue with a reproducing example."
+        return :failed
+    end
+    menu_callsites = source_node === nothing ? sub_callsites : menu_callsites_from_source_node(callsite, source_node)
+    menu = CthulhuMenu(state, menu_callsites, config.with_effects, config.exception_type, config.optimize,
+                        false, false, commands;
+                        sub_menu=true, menu_options...)
+    i = request(term, "", menu)
+    i === length(callsites) + 1 && return :continue
+    if i === -1
+        config.interruptexc && throw(InterruptException())
+        return :interrupted
+    end
+
+    return sub_callsites[i]
+end
+
+function menu_callsites_from_source_node(callsite::Callsite, source_node)
+    callsites = Union{Callsite,TypedSyntax.MaybeTypedSyntaxNode}[]
+    for info in callsite.info.callinfos
+        ci = get_ci(info)
+        mi = get_mi(ci)
+        p = Base.unwrap_unionall(mi.specTypes).parameters
+        if isa(source_node, TypedSyntax.MaybeTypedSyntaxNode) && length(p) == length(JuliaSyntax.children(source_node)) + 1
+            new_node = copy(source_node)
+            for (i, child) in enumerate(JuliaSyntax.children(new_node))
+                child.typ = p[i+1]
+            end
+            push!(callsites, new_node)
+        else
+            push!(callsites, Callsite(callsite.id, info, callsite.head))
+        end
+    end
+    return callsites
 end
 
 function is_constant(result::LookupResult)
@@ -378,4 +232,8 @@ end
 function source_slotnames(result::LookupResult)
     result.codeinf === nothing && return false
     return Base.sourceinfo_slotnames(result.codeinf)
+end
+
+function update_commands!(provider::AbstractProvider, commands::Vector{Command}, state::CthulhuState)
+    return update_default_commands!(commands, state)
 end

--- a/src/descend.jl
+++ b/src/descend.jl
@@ -117,8 +117,7 @@ function descend!(state::CthulhuState)
         menu = CthulhuMenu(state, shown_callsites, config.with_effects, config.exception_type, config.optimize,
                            config.iswarn & get(iostream, :color, false)::Bool,
                            config.hide_type_stable, commands; menu_options...)
-        update_commands!(provider, commands, state)
-        usg = usage(config, commands)
+        usg = usage(provider, state, commands)
         cid = request(state.terminal, usg, menu)
         toggle = menu.toggle
 
@@ -159,9 +158,10 @@ function descend!(state::CthulhuState)
             descend!(state)
             restore_descend_state!(state, prev)
             state.display_code = true
+
+            println(iostream)
         end
 
-        println(iostream)
     end
 
     TypedSyntax.clear_all_vscode()

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -8,34 +8,25 @@ function CC.get_inference_world(provider::AbstractProvider)
     error(lazy"Not implemented for $provider")
 end
 
+function find_method_instance(provider::AbstractProvider, @nospecialize(f), world::UInt = Base.tls_world_age())
+    find_method_instance(provider, f, Base.default_tt(f), world)
+end
+
 function find_method_instance(provider::AbstractProvider, @nospecialize(f), @nospecialize(argtypes), world::UInt = Base.tls_world_age())
     tt = Base.signature_type(f, argtypes)
     return find_method_instance(provider, tt, world)
 end
 
-function find_method_instance(provider::AbstractProvider, @nospecialize(tt::Type), world::UInt)
+function find_method_instance(provider::AbstractProvider, @nospecialize(tt::Type{<:Tuple}), world::UInt)
     interp = get_abstract_interpreter(provider)
     interp !== nothing && return find_method_instance(interp, tt, world)
     error(lazy"Not implemented for $provider")
-end
-
-function find_method_instance(interp::AbstractInterpreter, @nospecialize(tt::Type), world::UInt)
-    mt = method_table(interp)
-    match, valid_worlds = findsup(tt, mt)
-    match === nothing && return nothing
-    mi = specialize_method(match)
-    return mi
 end
 
 function generate_code_instance(provider::AbstractProvider, mi::MethodInstance)
     interp = get_abstract_interpreter(provider)
     interp !== nothing && return generate_code_instance(interp, mi)
     error(lazy"Not implemented for $provider")
-end
-
-function generate_code_instance(interp::AbstractInterpreter, mi::MethodInstance)
-    ci = run_type_inference(interp, mi)
-    return ci
 end
 
 should_regenerate_code_instance(provider::AbstractProvider, ci::CodeInstance) = false
@@ -50,54 +41,10 @@ function find_caller_of(provider::AbstractProvider, callee::Union{MethodInstance
     error(lazy"Not implemented for $provider")
 end
 
-function find_caller_of(interp::AbstractInterpreter, callee::Union{MethodInstance,Type}, caller::MethodInstance, allow_unspecialized::Bool)
-    interp′ = CthulhuInterpreter(interp)
-    codeinst = generate_code_instance(interp′, caller)
-    @assert codeinst.def === caller
-    locs = Tuple{Core.LineInfoNode,Int}[]
-    for optimize in (true, false)
-        (; src, rt, infos, slottypes) = lookup(interp′, codeinst, optimize)
-        callsites, _ = find_callsites(interp′, src, infos, codeinst, slottypes, optimize)
-        callsites = allow_unspecialized ? filter(cs->maybe_callsite(cs, callee), callsites) :
-        filter(cs->is_callsite(cs, callee), callsites)
-        foreach(cs -> add_sourceline!(locs, src, cs.id, caller), callsites)
-    end
-    # Consolidate by method, but preserve the order
-    prlookup = Dict{Tuple{Symbol,Symbol},Int}()
-    ulocs = Pair{Tuple{Symbol,Symbol,Int},Vector{Int}}[]
-    if !isempty(locs)
-        for (loc, depth) in locs
-            locname = loc.method
-            if isa(locname, MethodInstance)
-                locname = locname.def.name
-            end
-            idx = get(prlookup, (locname, loc.file), nothing)
-            if idx === nothing
-                push!(ulocs, (locname, loc.file, depth) => Int[])
-                prlookup[(locname, loc.file)] = idx = length(ulocs)
-            end
-            lines = ulocs[idx][2]
-            line = loc.line
-            if line ∉ lines
-                push!(lines, line)
-            end
-        end
-    end
-    return ulocs
-end
-
 function get_inline_costs(provider::AbstractProvider, mi::MethodInstance, src::Union{CodeInfo, IRCode})
     interp = get_abstract_interpreter(provider)
     interp !== nothing && return get_inline_costs(interp, mi, src)
     error(lazy"Not implemented for $provider")
-end
-
-function get_inline_costs(interp::AbstractInterpreter, mi::MethodInstance, src::Union{CodeInfo, IRCode})
-    code = isa(src, IRCode) ? src.stmts.stmt : src.code
-    costs = zeros(Int, length(code))
-    params = CC.OptimizationParams(interp)
-    sparams = CC.VarState[CC.VarState(sparam, false) for sparam in mi.sparam_vals]
-    CC.statement_costs!(costs, code, src, sparams, params)
 end
 
 function show_parameters(io::IO, provider::AbstractProvider)
@@ -106,49 +53,61 @@ function show_parameters(io::IO, provider::AbstractProvider)
     error(lazy"Not implemented for $provider")
 end
 
-show_parameters(io::IO, interp::AbstractInterpreter) = show_inference_cache(io, interp)
+# """
+#     AbstractCursor
 
-function show_inference_cache(io::IO, interp::AbstractInterpreter)
-    @info "Dumping inference cache."
-    cache = CC.get_inference_cache(interp)
-    for (i, (; linfo, result)) in enumerate(cache)
-        println(io, i, ": ", linfo, "::", result)
+# Required overloads:
+# - `Cthulhu.LookupResult(interp::AbstractInterpreter, curs::AbstractCursor, optimize::Bool)`
+# - `Cthulhu.lookup_constproped(interp::AbstractInterpreter, curs::AbstractCursor, override::InferenceResult, optimize::Bool)`
+# - `Cthulhu.get_ci(curs::AbstractCursor) -> CodeInstance`
+# - `Cthulhu.update_cursor(curs::AbstractCursor, mi::MethodInstance)`
+# - `Cthulhu.navigate(curs::AbstractCursor, callsite::Callsite) -> AbstractCursor`
+# """
+# abstract type AbstractCursor end
+
+# get_ci(curs::AbstractCursor) = error(lazy"""
+# missing `$AbstractCursor` API:
+# `$(typeof(curs))` is required to implement the `$get_ci(curs::$(typeof(curs))) -> CodeInstance` interface.
+# """)
+
+struct LookupResult
+    src::Union{CodeInfo,IRCode,Nothing}
+    rt
+    exct
+    infos::Vector{CCCallInfo} # needed? -> Callsite?
+    slottypes::Vector{Any}
+    effects::Effects
+    codeinf::Union{Nothing,CodeInfo}
+    optimized::Bool
+    function LookupResult(src::Union{CodeInfo,IRCode,Nothing}, @nospecialize(rt), @nospecialize(exct),
+        infos::Vector{CCCallInfo}, slottypes::Vector{Any},
+        effects::Effects, codeinf::Union{Nothing,CodeInfo},
+        optimized::Bool)
+        return new(src, rt, exct, infos, slottypes, effects, codeinf, optimized)
     end
 end
 
-"""
-    AbstractCursor
+# LookupResult(provider::AbstractProvider, cursor::AbstractCursor, optimize::Bool) =
+#     LookupResult(provider, get_ci(cursor), optimize)
 
-Required overloads:
-- `Cthulhu.lookup(interp::AbstractInterpreter, curs::AbstractCursor, optimize::Bool)`
-- `Cthulhu.lookup_constproped(interp::AbstractInterpreter, curs::AbstractCursor, override::InferenceResult, optimize::Bool)`
-- `Cthulhu.get_ci(curs::AbstractCursor) -> CodeInstance`
-- `Cthulhu.update_cursor(curs::AbstractCursor, mi::MethodInstance)`
-- `Cthulhu.navigate(curs::AbstractCursor, callsite::Callsite) -> AbstractCursor`
-"""
-abstract type AbstractCursor end
-
-get_ci(curs::AbstractCursor) = error(lazy"""
-missing `$AbstractCursor` API:
-`$(typeof(curs))` is required to implement the `$get_ci(curs::$(typeof(curs))) -> CodeInstance` interface.
-""")
-
-function lookup(provider::AbstractProvider, curs::AbstractCursor, optimize::Bool)
+function LookupResult(provider::AbstractProvider, ci::CodeInstance, optimize::Bool)
     error(lazy"""
   missing `$AbstractCursor` API:
-  `$(typeof(curs))` is required to implement the `$lookup(provider::$(typeof(provider)), curs::$(typeof(curs)), optimize::Bool)` interface.
+  `$(typeof(curs))` is required to implement the `$LookupResult(provider::$(typeof(provider)), curs::$(typeof(curs)), optimize::Bool)` interface.
   """)
 end
 
-navigate(curs::AbstractCursor, callsite::Callsite) = error(lazy"""
-missing `$AbstractCursor` API:
-`$(typeof(curs))` is required to implement the `$navigate(curs::$(typeof(curs)), callsite::Callsite) -> AbstractCursor` interface.
-""")
+# navigate(curs::AbstractCursor, callsite::Callsite) = error(lazy"""
+# missing `$AbstractCursor` API:
+# `$(typeof(curs))` is required to implement the `$navigate(curs::$(typeof(curs)), callsite::Callsite) -> AbstractCursor` interface.
+# """)
 
-struct CthulhuCursor <: AbstractCursor
-    ci::CodeInstance
-end
+# struct CthulhuCursor <: AbstractCursor
+#     ci::CodeInstance
+# end
 
-AbstractCursor(provider::AbstractProvider, ci::CodeInstance) = CthulhuCursor(ci)
-get_ci(curs::CthulhuCursor) = curs.ci
-navigate(curs::CthulhuCursor, callsite::Callsite) = CthulhuCursor(get_ci(callsite))
+# AbstractCursor(provider::AbstractProvider, ci::CodeInstance) = CthulhuCursor(ci)
+# get_ci(curs::CthulhuCursor) = curs.ci
+# navigate(curs::CthulhuCursor, callsite::Callsite) = CthulhuCursor(get_ci(callsite))
+
+commands(provider::AbstractProvider) = default_commands()

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -1,3 +1,121 @@
+abstract type AbstractProvider end
+
+get_abstract_interpreter(provider::AbstractProvider) = nothing
+
+function CC.get_inference_world(provider::AbstractProvider)
+    interp = get_abstract_interpreter(provider)
+    interp !== nothing && return get_inference_world(interp)
+    error(lazy"Not implemented for $provider")
+end
+
+function find_method_instance(provider::AbstractProvider, @nospecialize(f), @nospecialize(argtypes), world::UInt = Base.tls_world_age())
+    tt = Base.signature_type(f, argtypes)
+    return find_method_instance(provider, tt, world)
+end
+
+function find_method_instance(provider::AbstractProvider, @nospecialize(tt::Type), world::UInt)
+    interp = get_abstract_interpreter(provider)
+    interp !== nothing && return find_method_instance(interp, tt, world)
+    error(lazy"Not implemented for $provider")
+end
+
+function find_method_instance(interp::AbstractInterpreter, @nospecialize(tt::Type), world::UInt)
+    mt = method_table(interp)
+    match, valid_worlds = findsup(tt, mt)
+    match === nothing && return nothing
+    mi = specialize_method(match)
+    return mi
+end
+
+function generate_code_instance(provider::AbstractProvider, mi::MethodInstance)
+    interp = get_abstract_interpreter(provider)
+    interp !== nothing && return generate_code_instance(interp, mi)
+    error(lazy"Not implemented for $provider")
+end
+
+function generate_code_instance(interp::AbstractInterpreter, mi::MethodInstance)
+    ci = run_type_inference(interp, mi)
+    return ci
+end
+
+should_regenerate_code_instance(provider::AbstractProvider, ci::CodeInstance) = false
+
+function get_effects(provider::AbstractProvider, ci::CodeInstance, optimized::Bool)
+    error(lazy"Not implemented for $provider")
+end
+
+function find_caller_of(provider::AbstractProvider, callee::Union{MethodInstance,Type}, mi::MethodInstance; allow_unspecialized::Bool=true)
+    interp = get_abstract_interpreter(provider)
+    interp !== nothing && return find_caller_of(interp, callee, caller, allow_unspecialized)
+    error(lazy"Not implemented for $provider")
+end
+
+function find_caller_of(interp::AbstractInterpreter, callee::Union{MethodInstance,Type}, caller::MethodInstance, allow_unspecialized::Bool)
+    interp′ = CthulhuInterpreter(interp)
+    codeinst = generate_code_instance(interp′, caller)
+    @assert codeinst.def === caller
+    locs = Tuple{Core.LineInfoNode,Int}[]
+    for optimize in (true, false)
+        (; src, rt, infos, slottypes) = lookup(interp′, codeinst, optimize)
+        callsites, _ = find_callsites(interp′, src, infos, codeinst, slottypes, optimize)
+        callsites = allow_unspecialized ? filter(cs->maybe_callsite(cs, callee), callsites) :
+        filter(cs->is_callsite(cs, callee), callsites)
+        foreach(cs -> add_sourceline!(locs, src, cs.id, caller), callsites)
+    end
+    # Consolidate by method, but preserve the order
+    prlookup = Dict{Tuple{Symbol,Symbol},Int}()
+    ulocs = Pair{Tuple{Symbol,Symbol,Int},Vector{Int}}[]
+    if !isempty(locs)
+        for (loc, depth) in locs
+            locname = loc.method
+            if isa(locname, MethodInstance)
+                locname = locname.def.name
+            end
+            idx = get(prlookup, (locname, loc.file), nothing)
+            if idx === nothing
+                push!(ulocs, (locname, loc.file, depth) => Int[])
+                prlookup[(locname, loc.file)] = idx = length(ulocs)
+            end
+            lines = ulocs[idx][2]
+            line = loc.line
+            if line ∉ lines
+                push!(lines, line)
+            end
+        end
+    end
+    return ulocs
+end
+
+function get_inline_costs(provider::AbstractProvider, mi::MethodInstance, src::Union{CodeInfo, IRCode})
+    interp = get_abstract_interpreter(provider)
+    interp !== nothing && return get_inline_costs(interp, mi, src)
+    error(lazy"Not implemented for $provider")
+end
+
+function get_inline_costs(interp::AbstractInterpreter, mi::MethodInstance, src::Union{CodeInfo, IRCode})
+    code = isa(src, IRCode) ? src.stmts.stmt : src.code
+    costs = zeros(Int, length(code))
+    params = CC.OptimizationParams(interp)
+    sparams = CC.VarState[CC.VarState(sparam, false) for sparam in mi.sparam_vals]
+    CC.statement_costs!(costs, code, src, sparams, params)
+end
+
+function show_parameters(io::IO, provider::AbstractProvider)
+    interp = get_abstract_interpreter(provider)
+    interp !== nothing && return show_parameters(io, interp)
+    error(lazy"Not implemented for $provider")
+end
+
+show_parameters(io::IO, interp::AbstractInterpreter) = show_inference_cache(io, interp)
+
+function show_inference_cache(io::IO, interp::AbstractInterpreter)
+    @info "Dumping inference cache."
+    cache = CC.get_inference_cache(interp)
+    for (i, (; linfo, result)) in enumerate(cache)
+        println(io, i, ": ", linfo, "::", result)
+    end
+end
+
 """
     AbstractCursor
 
@@ -8,90 +126,29 @@ Required overloads:
 - `Cthulhu.update_cursor(curs::AbstractCursor, mi::MethodInstance)`
 - `Cthulhu.navigate(curs::AbstractCursor, callsite::Callsite) -> AbstractCursor`
 """
-abstract type AbstractCursor; end
-struct CthulhuCursor <: AbstractCursor
-    ci::CodeInstance
-end
-
-lookup(interp::AbstractInterpreter, curs::AbstractCursor, optimize::Bool) = error(lazy"""
-missing `$AbstractCursor` API:
-`$(typeof(curs))` is required to implement the `$lookup(interp::$(typeof(interp)), curs::$(typeof(curs)), optimize::Bool)` interface.
-""")
-lookup(interp::CthulhuInterpreter, curs::CthulhuCursor, optimize::Bool) =
-    lookup(interp, get_ci(curs), optimize)
-
-lookup_constproped(interp::AbstractInterpreter, curs::AbstractCursor, override::InferenceResult, optimize::Bool) = error(lazy"""
-missing `$AbstractCursor` API:
-`$(typeof(curs))` is required to implement the `$lookup_constproped(interp::$(typeof(interp)), curs::$(typeof(curs)), override::InferenceResult, optimize::Bool)` interface.
-""")
-lookup_constproped(interp::CthulhuInterpreter, ::CthulhuCursor, override::InferenceResult, optimize::Bool) =
-    lookup_constproped(interp, override, optimize)
-
-lookup_semiconcrete(interp::AbstractInterpreter, curs::AbstractCursor, override::SemiConcreteCallInfo, optimize::Bool) = error(lazy"""
-missing `$AbstractCursor` API:
-`$(typeof(curs))` is required to implement the `$lookup_semicocnrete(interp::$(typeof(interp)), curs::$(typeof(curs)), override::SemiConcreteCallInfo, optimize::Bool)` interface.
-""")
-lookup_semiconcrete(interp::CthulhuInterpreter, ::CthulhuCursor, override::SemiConcreteCallInfo, optimize::Bool) =
-    lookup_semiconcrete(interp, override, optimize)
+abstract type AbstractCursor end
 
 get_ci(curs::AbstractCursor) = error(lazy"""
 missing `$AbstractCursor` API:
 `$(typeof(curs))` is required to implement the `$get_ci(curs::$(typeof(curs))) -> CodeInstance` interface.
 """)
-get_ci(curs::CthulhuCursor) = curs.ci
 
-update_cursor(curs::AbstractCursor, ::CodeInstance) = error(lazy"""
-missing `$AbstractCursor` API:
-`$(typeof(curs))` is required to implement the `$update_cursor(curs::$(typeof(curs)), mi::MethodInstance) -> $(typeof(curs))` interface.
-""")
-update_cursor(curs::CthulhuCursor, ci::CodeInstance) = CthulhuCursor(ci)
-
-# TODO: This interface is incomplete, should probably also take a current cursor,
-# or maybe be `CallSite based`
-can_descend(interp::AbstractInterpreter, @nospecialize(key), optimize::Bool) = error(lazy"""
-missing `$AbstractInterpreter` API:
-`$(typeof(interp))` is required to implement the `$can_descend(interp::$(typeof(interp)), @nospecialize(key), optimize::Bool) -> Bool` interface.
-""")
-can_descend(interp::CthulhuInterpreter, @nospecialize(key), optimize::Bool) =
-    haskey(optimize ? key isa CodeInstance : interp.unopt, key)
+function lookup(provider::AbstractProvider, curs::AbstractCursor, optimize::Bool)
+    error(lazy"""
+  missing `$AbstractCursor` API:
+  `$(typeof(curs))` is required to implement the `$lookup(provider::$(typeof(provider)), curs::$(typeof(curs)), optimize::Bool)` interface.
+  """)
+end
 
 navigate(curs::AbstractCursor, callsite::Callsite) = error(lazy"""
 missing `$AbstractCursor` API:
 `$(typeof(curs))` is required to implement the `$navigate(curs::$(typeof(curs)), callsite::Callsite) -> AbstractCursor` interface.
 """)
-navigate(curs::CthulhuCursor, callsite::Callsite) = CthulhuCursor(get_ci(callsite))
 
-get_pc_remarks(::AbstractInterpreter, ::InferenceKey) = nothing
-get_pc_remarks(interp::CthulhuInterpreter, key::InferenceKey) = get(interp.remarks, key, nothing)
-
-get_pc_effects(::AbstractInterpreter, ::InferenceKey) = nothing
-get_pc_effects(interp::CthulhuInterpreter, key::InferenceKey) = get(interp.effects, key, nothing)
-
-get_pc_exct(::AbstractInterpreter, ::InferenceKey) = nothing
-get_pc_exct(interp::CthulhuInterpreter, key::InferenceKey) = get(interp.exception_types, key, nothing)
-
-# This method is optional, but should be implemented if there is
-# a sensible default cursor for a MethodInstance
-AbstractCursor(interp::AbstractInterpreter, ci::CodeInstance) = CthulhuCursor(ci)
-
-mutable struct CustomToggle
-    onoff::Bool
-    key::UInt32
-    toggle::Symbol
-    description::String
-    callback_on
-    callback_off
-    function CustomToggle(onoff::Bool, key, description,
-        @nospecialize(callback_on), @nospecialize(callback_off))
-        key = convert(UInt32, key)
-        desc = convert(String, description)
-        toggle = Symbol(desc)
-        if haskey(TOGGLES, key)
-            error(lazy"invalid Cthulhu API: key `$key` is already used.")
-        elseif toggle in values(TOGGLES)
-            error(lazy"invalid Cthulhu API: toggle `$toggle` is already used.")
-        end
-        return new(onoff, key, toggle, desc, callback_on, callback_off)
-    end
+struct CthulhuCursor <: AbstractCursor
+    ci::CodeInstance
 end
-custom_toggles(interp::AbstractInterpreter) = CustomToggle[]
+
+AbstractCursor(provider::AbstractProvider, ci::CodeInstance) = CthulhuCursor(ci)
+get_ci(curs::CthulhuCursor) = curs.ci
+navigate(curs::CthulhuCursor, callsite::Callsite) = CthulhuCursor(get_ci(callsite))

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -37,7 +37,7 @@ end
 
 function find_caller_of(provider::AbstractProvider, callee::Union{MethodInstance,Type}, mi::MethodInstance; allow_unspecialized::Bool=true)
     interp = get_abstract_interpreter(provider)
-    interp !== nothing && return find_caller_of(provider, interp, callee, caller, allow_unspecialized)
+    interp !== nothing && return find_caller_of(provider, interp, callee, mi, allow_unspecialized)
     error(lazy"Not implemented for $provider")
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -118,5 +118,3 @@ end
 # AbstractCursor(provider::AbstractProvider, ci::CodeInstance) = CthulhuCursor(ci)
 # get_ci(curs::CthulhuCursor) = curs.ci
 # navigate(curs::CthulhuCursor, callsite::Callsite) = CthulhuCursor(get_ci(callsite))
-
-menu_commands(provider::AbstractProvider) = default_menu_commands()

--- a/src/interpreter.jl
+++ b/src/interpreter.jl
@@ -1,28 +1,3 @@
-struct InferredSource
-    src::CodeInfo
-    stmt_info::Vector{CCCallInfo}
-    effects::Effects
-    rt::Any
-    exct::Any
-    InferredSource(src::CodeInfo, stmt_info::Vector{CCCallInfo}, effects, @nospecialize(rt),
-                   @nospecialize(exct)) =
-        new(src, stmt_info, effects, rt, exct)
-end
-
-struct OptimizedSource
-    ir::IRCode
-    src::CodeInfo
-    isinlineable::Bool
-    effects::Effects
-end
-
-const InferenceKey = Union{CodeInstance,InferenceResult} # TODO make this `CodeInstance` fully
-const InferenceDict{InferenceValue} = IdDict{InferenceKey, InferenceValue}
-const PC2Remarks = Vector{Pair{Int, String}}
-const PC2CallMeta = Dict{Int, CallMeta}
-const PC2Effects = Dict{Int, Effects}
-const PC2Excts = Dict{Int, Any}
-
 mutable struct CthulhuCacheToken end
 
 struct CthulhuInterpreter <: AbstractInterpreter
@@ -46,7 +21,7 @@ function CthulhuInterpreter(interp::AbstractInterpreter=NativeInterpreter())
         InferenceDict{PC2Excts}())
 end
 
-Base.show(io::IO, interp::CthulhuInterpreter) = print(io, typeof(interp), "(...)")
+Base.show(io::IO, interp::CthulhuInterpreter) = print(io, typeof(interp), '(', interp.native, ')')
 
 CC.InferenceParams(interp::CthulhuInterpreter) = InferenceParams(interp.native)
 CC.OptimizationParams(interp::CthulhuInterpreter) =
@@ -64,6 +39,26 @@ CC.method_table(interp::CthulhuInterpreter) = CC.method_table(interp.native)
 # identifier for the internal code cache. However, the definition of `cache_owner` is
 # necessary for utilizing the default `CodeInstance` constructor, define the overload here.
 CC.cache_owner(interp::CthulhuInterpreter) = interp.cache_token
+
+function OptimizedSource(provider::AbstractProvider, interp::CthulhuInterpreter, override::InferenceResult)
+    isa(override.src, OptimizedSource) || error("couldn't find the source")
+    return override.src
+end
+
+function OptimizedSource(provider::AbstractProvider, interp::CthulhuInterpreter, ci::CodeInstance)
+    opt = ci.inferred
+    isa(opt, OptimizedSource) && return opt
+    @eval Main begin
+        interp = $interp
+        ci = $ci
+    end
+    error("couldn't find the source; inspect `Main.interp` and `Main.mi`")
+end
+
+function InferredSource(provider::AbstractProvider, interp::CthulhuInterpreter, src::Union{CodeInstance,InferenceResult})
+    unopt = interp.unopt[src]
+    return unopt
+end
 
 function get_inference_key(state::InferenceState)
     result = state.result

--- a/src/preferences.jl
+++ b/src/preferences.jl
@@ -33,26 +33,28 @@ function save_config!(config::CthulhuConfig=CONFIG)
         "with_effects" => config.with_effects,
         "inline_cost" => config.inline_cost,
         "type_annotations" => config.type_annotations,
-        "annotate_source" => config.annotate_source,
+        "view" => config.view,
         "inlay_types_vscode" => config.inlay_types_vscode,
         "diagnostics_vscode" => config.diagnostics_vscode,
         "jump_always" => config.jump_always)
 end
 
-function read_config!(config::CthulhuConfig)
-    config.enable_highlighter = load_preference(Cthulhu, "enable_highlighter", config.enable_highlighter)
-    config.highlighter = Cmd(load_preference(Cthulhu, "highlighter", config.highlighter))
-    config.asm_syntax = Symbol(load_preference(Cthulhu, "asm_syntax", config.asm_syntax))
-    config.pretty_ast = load_preference(Cthulhu, "pretty_ast", config.pretty_ast)
-    config.debuginfo = Symbol(load_preference(Cthulhu, "debuginfo", config.debuginfo))
-    config.optimize = load_preference(Cthulhu, "optimize", config.optimize)
-    config.iswarn = load_preference(Cthulhu, "iswarn", config.iswarn)
-    config.remarks = load_preference(Cthulhu, "remarks", config.remarks)
-    config.with_effects = load_preference(Cthulhu, "with_effects", config.with_effects)
-    config.inline_cost = load_preference(Cthulhu, "inline_cost", config.inline_cost)
-    config.type_annotations = load_preference(Cthulhu, "type_annotations", config.type_annotations)
-    config.annotate_source = load_preference(Cthulhu, "annotate_source", config.annotate_source)
-    config.inlay_types_vscode = load_preference(Cthulhu, "inlay_types_vscode", config.inlay_types_vscode)
-    config.diagnostics_vscode = load_preference(Cthulhu, "diagnostics_vscode", config.diagnostics_vscode)
-    config.jump_always = load_preference(Cthulhu, "jump_always", config.jump_always)
+function read_config!()
+    global CONFIG
+    @reset CONFIG.enable_highlighter = load_preference(Cthulhu, "enable_highlighter", CONFIG.enable_highlighter)
+    @reset CONFIG.highlighter = Cmd(load_preference(Cthulhu, "highlighter", CONFIG.highlighter))
+    @reset CONFIG.asm_syntax = Symbol(load_preference(Cthulhu, "asm_syntax", CONFIG.asm_syntax))
+    @reset CONFIG.pretty_ast = load_preference(Cthulhu, "pretty_ast", CONFIG.pretty_ast)
+    @reset CONFIG.debuginfo = Symbol(load_preference(Cthulhu, "debuginfo", CONFIG.debuginfo))
+    @reset CONFIG.optimize = load_preference(Cthulhu, "optimize", CONFIG.optimize)
+    @reset CONFIG.iswarn = load_preference(Cthulhu, "iswarn", CONFIG.iswarn)
+    @reset CONFIG.remarks = load_preference(Cthulhu, "remarks", CONFIG.remarks)
+    @reset CONFIG.with_effects = load_preference(Cthulhu, "with_effects", CONFIG.with_effects)
+    @reset CONFIG.inline_cost = load_preference(Cthulhu, "inline_cost", CONFIG.inline_cost)
+    @reset CONFIG.type_annotations = load_preference(Cthulhu, "type_annotations", CONFIG.type_annotations)
+    @reset CONFIG.view = load_preference(Cthulhu, "view", CONFIG.view)
+    @reset CONFIG.inlay_types_vscode = load_preference(Cthulhu, "inlay_types_vscode", CONFIG.inlay_types_vscode)
+    @reset CONFIG.diagnostics_vscode = load_preference(Cthulhu, "diagnostics_vscode", CONFIG.diagnostics_vscode)
+    @reset CONFIG.jump_always = load_preference(Cthulhu, "jump_always", CONFIG.jump_always)
+    return CONFIG
 end

--- a/src/provider.jl
+++ b/src/provider.jl
@@ -1,0 +1,160 @@
+struct DefaultProvider <: AbstractProvider
+    interp::CthulhuInterpreter
+end
+DefaultProvider(interp::CC.AbstractInterpreter = NativeInterpreter()) = DefaultProvider(CthulhuInterpreter(interp))
+
+get_abstract_interpreter(provider::DefaultProvider) = provider.interp
+
+struct LookupResult
+    src::Union{CodeInfo,IRCode,Nothing}
+    rt
+    exct
+    infos::Vector{CCCallInfo} # needed? -> Callsite?
+    slottypes::Vector{Any}
+    effects::Effects
+    codeinf::Union{Nothing,CodeInfo}
+    optimized::Bool
+    function LookupResult(src::Union{CodeInfo,IRCode,Nothing}, @nospecialize(rt), @nospecialize(exct),
+        infos::Vector{CCCallInfo}, slottypes::Vector{Any},
+        effects::Effects, codeinf::Union{Nothing,CodeInfo},
+        optimized::Bool)
+        return new(src, rt, exct, infos, slottypes, effects, codeinf, optimized)
+    end
+end
+
+# Interface.
+
+function lookup(provider::DefaultProvider, ci::CodeInstance, optimize::Bool)
+    if optimize
+        result = lookup_optimized(provider.interp, ci)
+        if result === nothing
+            @info """
+            Inference discarded the source for this call because of recursion:
+            Cthulhu nevertheless is trying to retrieve the source for further inspection.
+            """
+            result = lookup_unoptimized(provider.interp, ci)
+        end
+        return result
+    end
+    return lookup_unoptimized(provider.interp, ci)
+end
+
+function lookup(provider::DefaultProvider, result::InferenceResult, optimize::Bool)
+    optimize && return lookup_constproped_optimized(provider.interp, result)
+    return lookup_constproped_unoptimized(provider.interp, result)
+end
+
+function lookup(provider::DefaultProvider, call::SemiConcreteCallInfo, optimize::Bool)
+    return lookup_semiconcrete(provider.interp, call)
+end
+
+function get_override(provider::DefaultProvider, @nospecialize(info))
+    isa(info, ConstPropCallInfo) && return info.result
+    isa(info, SemiConcreteCallInfo) && return info
+    isa(info, OCCallInfo) && return get_override(info.ci)
+    return nothing
+end
+
+function should_regenerate_code_instance(provider::DefaultProvider, ci::CodeInstance)
+    return !haskey(provider.interp.unopt, ci)
+end
+
+get_pc_remarks(provider::AbstractProvider, key::InferenceKey) = nothing
+get_pc_remarks(provider::DefaultProvider, key::InferenceKey) = get(provider.interp.remarks, key, nothing)
+
+get_pc_effects(provider::AbstractProvider, key::InferenceKey) = nothing
+get_pc_effects(provider::DefaultProvider, key::InferenceKey) = get(provider.interp.effects, key, nothing)
+
+get_pc_exct(provider::AbstractProvider, key::InferenceKey) = nothing
+get_pc_exct(provider::DefaultProvider, key::InferenceKey) = get(provider.interp.exception_types, key, nothing)
+
+# Implementation.
+
+function lookup_optimized(interp::CthulhuInterpreter, ci::CodeInstance)
+    rt = cached_return_type(ci)
+    exct = cached_exception_type(ci)
+    opt = ci.inferred
+    if opt !== nothing
+        opt = opt::OptimizedSource
+        src = CC.copy(opt.ir)
+        codeinf = opt.src
+        infos = src.stmts.info
+        slottypes = src.argtypes
+    elseif CC.use_const_api(ci)
+        @assert isdefined(ci, :rettype_const)
+        const_ci = CC.codeinfo_for_const(interp, get_mi(ci), ci.rettype_const)
+        return lookup_optimized(interp, const_ci)
+    else
+        Core.eval(Main, quote
+            interp = $interp
+            ci = $ci
+        end)
+        error("couldn't find the source; inspect `Main.interp` and `Main.mi`")
+    end
+    effects = get_effects(ci)
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
+end
+
+function lookup_unoptimized(interp::CthulhuInterpreter, ci::CodeInstance)
+    unopt = interp.unopt[ci]
+    codeinf = src = copy(unopt.src)
+    (; rt, exct) = unopt
+    infos = unopt.stmt_info
+    effects = unopt.effects
+    slottypes = src.slottypes
+    if isnothing(slottypes)
+        slottypes = Any[ Any for i = 1:length(src.slotflags) ]
+    end
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, false)
+end
+
+function lookup_constproped_optimized(interp::CthulhuInterpreter, override::InferenceResult)
+    opt = override.src
+    isa(opt, OptimizedSource) || error("couldn't find the source")
+    # `(override::InferenceResult).src` might has been transformed to OptimizedSource already,
+    # e.g. when we switch from constant-prop' unoptimized source
+    src = CC.copy(opt.ir)
+    rt = override.result
+    exct = override.exc_result
+    infos = src.stmts.info
+    slottypes = src.argtypes
+    codeinf = opt.src
+    effects = opt.effects
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
+end
+
+function lookup_constproped_unoptimized(interp::CthulhuInterpreter, override::InferenceResult)
+    unopt = interp.unopt[override]
+    codeinf = src = copy(unopt.src)
+    (; rt, exct) = unopt
+    infos = unopt.stmt_info
+    effects = get_effects(unopt)
+    slottypes = src.slottypes
+    if isnothing(slottypes)
+        slottypes = Any[ Any for i = 1:length(src.slotflags) ]
+    end
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, false)
+end
+
+function lookup_semiconcrete(interp::CthulhuInterpreter, override::SemiConcreteCallInfo)
+    src = CC.copy(override.ir)
+    rt = get_rt(override)
+    exct = Any # TODO
+    infos = src.stmts.info
+    slottypes = src.argtypes
+    effects = get_effects(override)
+    codeinf = nothing # TODO try to find `CodeInfo` for the regular inference?
+    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
+end
+
+function run_type_inference(interp::AbstractInterpreter, mi::MethodInstance)
+    result = InferenceResult(mi)
+    ci = CC.engine_reserve(interp, mi)
+    result.ci = ci
+    # we may want to handle the case when `InferenceState(...)` returns `nothing`,
+    # which indicates code generation of a `@generated` has been failed,
+    # and show it in the UI in some way?
+    frame = InferenceState(result, #=cache_mode=#:global, interp)::InferenceState
+    CC.typeinf(interp, frame)
+    return ci
+end

--- a/src/provider.jl
+++ b/src/provider.jl
@@ -1,144 +1,15 @@
 struct DefaultProvider <: AbstractProvider
     interp::CthulhuInterpreter
 end
-DefaultProvider(interp::CC.AbstractInterpreter = NativeInterpreter()) = DefaultProvider(CthulhuInterpreter(interp))
+DefaultProvider(interp::AbstractInterpreter = NativeInterpreter()) = DefaultProvider(CthulhuInterpreter(interp))
 
 get_abstract_interpreter(provider::DefaultProvider) = provider.interp
 AbstractProvider(interp::CthulhuInterpreter) = DefaultProvider(interp)
-
-# Interface.
-
-function LookupResult(provider::DefaultProvider, ci::CodeInstance, optimize::Bool)
-    if optimize
-        result = lookup_optimized(provider.interp, ci)
-        if result === nothing
-            @info """
-            Inference discarded the source for this call because of recursion:
-            Cthulhu nevertheless is trying to retrieve the source for further inspection.
-            """
-            result = lookup_unoptimized(provider.interp, ci)
-        end
-        return result
-    end
-    return lookup_unoptimized(provider.interp, ci)
-end
-
-function LookupResult(provider::DefaultProvider, result::InferenceResult, optimize::Bool)
-    optimize && return lookup_constproped_optimized(result)
-    return lookup_constproped_unoptimized(provider.interp, result)
-end
-
-function LookupResult(provider::DefaultProvider, call::SemiConcreteCallInfo, optimize::Bool)
-    return lookup_semiconcrete(provider.interp, call)
-end
-
-function get_override(provider::AbstractProvider, @nospecialize(info))
-    isa(info, ConstPropCallInfo) && return info.result
-    isa(info, SemiConcreteCallInfo) && return info
-    isa(info, OCCallInfo) && return get_override(info.ci)
-    return nothing
-end
 
 function should_regenerate_code_instance(provider::DefaultProvider, ci::CodeInstance)
     return !haskey(provider.interp.unopt, ci)
 end
 
-get_pc_remarks(provider::AbstractProvider, key::InferenceKey) = nothing
 get_pc_remarks(provider::DefaultProvider, key::InferenceKey) = get(provider.interp.remarks, key, nothing)
-
-get_pc_effects(provider::AbstractProvider, key::InferenceKey) = nothing
 get_pc_effects(provider::DefaultProvider, key::InferenceKey) = get(provider.interp.effects, key, nothing)
-
-get_pc_exct(provider::AbstractProvider, key::InferenceKey) = nothing
 get_pc_exct(provider::DefaultProvider, key::InferenceKey) = get(provider.interp.exception_types, key, nothing)
-
-# Implementation.
-
-function lookup_optimized(interp::CthulhuInterpreter, ci::CodeInstance)
-    rt = cached_return_type(ci)
-    exct = cached_exception_type(ci)
-    opt = ci.inferred
-    if opt !== nothing
-        opt = opt::OptimizedSource
-        src = CC.copy(opt.ir)
-        codeinf = opt.src
-        infos = src.stmts.info
-        slottypes = src.argtypes
-    elseif CC.use_const_api(ci)
-        @assert isdefined(ci, :rettype_const)
-        const_ci = CC.codeinfo_for_const(interp, get_mi(ci), ci.rettype_const)
-        return lookup_optimized(interp, const_ci)
-    else
-        Core.eval(Main, quote
-            interp = $interp
-            ci = $ci
-        end)
-        error("couldn't find the source; inspect `Main.interp` and `Main.mi`")
-    end
-    effects = get_effects(ci)
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
-end
-
-function lookup_unoptimized(interp::CthulhuInterpreter, ci::CodeInstance)
-    unopt = interp.unopt[ci]
-    codeinf = src = copy(unopt.src)
-    (; rt, exct) = unopt
-    infos = unopt.stmt_info
-    effects = unopt.effects
-    slottypes = src.slottypes
-    if isnothing(slottypes)
-        slottypes = Any[ Any for i = 1:length(src.slotflags) ]
-    end
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, false)
-end
-
-function lookup_constproped_optimized(override::InferenceResult)
-    opt = override.src
-    isa(opt, OptimizedSource) || error("couldn't find the source")
-    # `override.src` might has been transformed to OptimizedSource already,
-    # e.g. when we switch from constant-prop' unoptimized source
-    src = CC.copy(opt.ir)
-    rt = override.result
-    exct = override.exc_result
-    infos = src.stmts.info
-    slottypes = src.argtypes
-    codeinf = opt.src
-    effects = opt.effects
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
-end
-
-function lookup_constproped_unoptimized(interp::CthulhuInterpreter, override::InferenceResult)
-    unopt = interp.unopt[override]
-    codeinf = src = copy(unopt.src)
-    (; rt, exct) = unopt
-    infos = unopt.stmt_info
-    effects = get_effects(unopt)
-    slottypes = src.slottypes
-    if isnothing(slottypes)
-        slottypes = Any[ Any for i = 1:length(src.slotflags) ]
-    end
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, false)
-end
-
-function lookup_semiconcrete(interp::CthulhuInterpreter, override::SemiConcreteCallInfo)
-    src = CC.copy(override.ir)
-    rt = get_rt(override)
-    exct = Any # TODO
-    infos = src.stmts.info
-    slottypes = src.argtypes
-    effects = get_effects(override)
-    codeinf = nothing # TODO try to find `CodeInfo` for the regular inference?
-    return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf, true)
-end
-
-function run_type_inference(interp::AbstractInterpreter, mi::MethodInstance)
-    result = InferenceResult(mi)
-    ci = CC.engine_reserve(interp, mi)
-    result.ci = ci
-    # we may want to handle the case when `InferenceState(...)` returns `nothing`,
-    # which indicates code generation of a `@generated` has been failed,
-    # and show it in the UI in some way?
-    frame = InferenceState(result, #=cache_mode=#:global, interp)::InferenceState
-    CC.typeinf(interp, frame)
-    return ci
-end

--- a/src/reflection.jl
+++ b/src/reflection.jl
@@ -243,7 +243,7 @@ function process_info(provider::AbstractProvider, lookup::LookupResult, @nospeci
             info = $info
             argtypes = $argtypes
             rt = $rt
-            optimized = $(lookup.optimize)
+            optimized = $(lookup.optimized)
         end
         error("inspect `Main.provider|info|argtypes|rt|optimized`")
     end

--- a/src/state.jl
+++ b/src/state.jl
@@ -180,6 +180,19 @@ end
 
 menu_commands(provider::AbstractProvider) = default_menu_commands()
 
+is_command_enabled(provider::AbstractProvider, state::CthulhuState, command::Command) =
+    is_default_command_enabled(provider, state, command)
+
+function is_default_command_enabled(provider::AbstractProvider, state::CthulhuState, command::Command)
+    command.name === :inlay_types_vscode && return TypedSyntax.inlay_hints_available_vscode()
+    command.name === :diagnostics_vscode && return TypedSyntax.diagnostics_available_vscode()
+    if state.config.view === :source
+        disabled_commands = (:optimize, :debuginfo, :remarks, :with_effects, :exception_type, :inline_cost)
+        return !in(command.name, disabled_commands)
+    end
+    return true
+end
+
 function show_command(io::IO, provider::AbstractProvider, state::CthulhuState, command::Command)
     (; description) = command
     key = Char(command.key)

--- a/src/state.jl
+++ b/src/state.jl
@@ -1,0 +1,177 @@
+mutable struct CthulhuState
+    terminal::AbstractTerminal
+    provider::AbstractProvider
+    config::CthulhuConfig
+    mi::Union{Nothing, MethodInstance}
+    ci::Union{Nothing, CodeInstance}
+    override::Any
+    display_code::Bool
+end
+function CthulhuState(provider::AbstractProvider; terminal = default_terminal(), config = CONFIG,
+                      mi = nothing, ci = nothing, override = nothing)
+    return CthulhuState(terminal, provider, config, mi, ci, override, true)
+end
+
+view_function(state::CthulhuState) = view_function(state.provider, state.config.view)
+function view_function(provider::AbstractProvider, view::Symbol)
+    view === :source && return cthulhu_source
+    view === :typed && return cthulhu_typed
+    view === :ast && return cthulhu_ast
+    view === :llvm && return cthulhu_llvm
+    view === :native && return cthulhu_native
+    throw_view_is_not_supported(provider, view)
+end
+
+throw_view_is_not_supported(provider, view) = throw(ArgumentError("View `$view` is not supported for provider $(typeof(provider))"))
+
+mutable struct Command
+    active::Union{Nothing, Bool}
+    key::UInt32
+    name::Symbol
+    description::String
+    category::Symbol
+    callback_on::Any
+    callback_off::Any
+    function Command(active::Union{Nothing, Bool}, key, description, category, @nospecialize(callback_on), @nospecialize(callback_off))
+        key = convert(UInt32, key)
+        description = convert(String, description)
+        name = Symbol(description)
+        return new(active, key, name, description, category, callback_on, callback_off)
+    end
+end
+
+function default_commands()
+    commands = Command[
+        set_option('w', :iswarn, :toggles, "warn"),
+        set_option('h', :hide_type_stable, :toggles, "hide type-stable statements"),
+        set_option('o', :optimize, :toggles),
+        set_option('d', :debuginfo, :toggles),
+        set_option('r', :remarks, :toggles),
+        set_option('e', :with_effects, :toggles, "effects"),
+        set_option('x', :exception_type, :toggles),
+        set_option('i', :inline_cost, :toggles, "inlining costs"),
+        set_option('t', :type_annotations, :toggles),
+        set_option('s', :enable_highlighter, :toggles, "syntax highlight for Source/LLVM/Native"),
+        set_option('v', :inlay_types_vscode, :toggles, "vscode: inlay types"),
+        set_option('V', :diagnostics_vscode, :toggles, "vscode: diagnostics"),
+        set_option('j', :jump_always, :toggles, "jump to source always"; redisplay = false),
+        set_view('S', :source, :show),
+        set_view('A', :ast, :show),
+        set_view('T', :typed, :show),
+        set_view('L', :llvm, :show),
+        set_view('N', :native, :show),
+        perform_action(edit_source_code, 'E', :edit, :actions, "Edit source code"),
+        perform_action(revise_and_redisplay!, 'R', :revise, :actions, "Revise and redisplay"),
+        perform_action(bookmark_method, 'b', :bookmark, :actions),
+        perform_action(dump_parameters, 'P', :dump_params, :actions, "dump params cache"),
+        perform_action(nothing, 'q', :quit, :actions),
+    ]
+    return commands
+end
+
+function perform_action(f, key::Char, name::Symbol, category, description = string(name))
+    return Command(nothing, key, description, category, f, nothing)
+end
+
+function set_option(key::Char, option::Symbol, category, description = string(option); redisplay = true)
+    return Command(false, key, description, category, state -> set_option!(state, option, true; redisplay), state -> set_option!(state, option, false; redisplay))
+end
+
+function set_view(key::Char, option::Symbol, category, description = string(option))
+    return Command(false, key, description, category, state -> set_option!(state, :view, option; redisplay = state.config.view !== option), nothing)
+end
+
+function set_option!(state::CthulhuState, option::Symbol, value; redisplay = false)
+    (; config) = state
+    hasproperty(config, option) || throw(ArgumentError("Unknown configuration option `$option`"))
+
+    if value === true
+        option === :remarks && config.optimize && @warn "Disable optimization to see the inference remarks."
+        option === :inline_cost && !optimize && @warn "Enable optimization to see the inlining costs."
+    end
+
+    if option === :highlighter
+        value === true && @info "Using syntax highlighter $(CONFIG.highlighter)."
+        value === false && @info "Turned off syntax highlighter for Julia, LLVM and native code."
+    end
+
+    if value === false
+        option === :inlay_types_vscode && TypedSyntax.clear_inlay_hints_vscode()
+        option === :diagnostics_vscode && TypedSyntax.clear_diagnostics_vscode()
+    end
+
+    redisplay && (state.display_code = true)
+    state.config = setproperties(config, NamedTuple((option => value,)))
+end
+
+function edit_source_code(state::CthulhuState)
+    def = state.mi.def
+    isa(def, Method) || return @warn "Can't go to the source location because the definition is not a method."
+    edit(whereis(def)...)
+end
+
+function revise_and_redisplay!(state::CthulhuState)
+    # Call Revise.revise() without introducing a dependency on Revise
+    id = Base.PkgId(UUID("295af30f-e4ad-537b-8983-00126c2a3abe"), "Revise")
+    mod = get(Base.loaded_modules, id, nothing)
+    mod === nothing && return @warn "Failed to load Revise."
+    revise = getfield(mod, :revise)::Function
+    revise()
+    state.ci = generate_code_instance(state.provider, state.mi)
+    state.display_code = true
+end
+
+function bookmark_method(state::CthulhuState)
+    push!(BOOKMARKS, Bookmark(state.mi, state.provider))
+    @info "The method is pushed at the end of `Cthulhu.BOOKMARKS`."
+end
+
+function dump_parameters(state::CthulhuState)
+    iostream = term.out_stream::IO
+    show_parameters(iostream, state.provider)
+end
+
+function split_by_category(commands::Vector{Command})
+    categories = Pair{Symbol,Vector{Command}}[]
+    for toggle in commands
+        i = findfirst(==(toggle.category) ∘ first, categories)
+        if i === nothing
+            push!(categories, toggle.category => [toggle])
+        else
+            _, list = categories[i]
+            push!(list, toggle)
+        end
+    end
+    return categories
+end
+
+function update_default_commands!(commands::Vector{Command}, state::CthulhuState)
+    (; config) = state
+    for command in commands
+        (; name) = command
+        name === :inlay_types_vscode && set_active!(command, state, TypedSyntax.inlay_hints_available_vscode()) && continue
+        name === :diagnostics_vscode && set_active!(command, state, TypedSyntax.diagnostics_available_vscode()) && continue
+        name === :optimize && set_active!(command, state, config.optimize)
+        name === :source && set_active!(command, state, config.view === :source)
+        name === :ast && set_active!(command, state, config.view === :ast)
+        name === :typed && set_active!(command, state, config.view === :typed)
+        name === :llvm && set_active!(command, state, config.view === :llvm)
+        name === :native && set_active!(command, state, config.view === :native)
+    end
+end
+
+function set_active!(command::Command, state::CthulhuState, value::Bool)
+    something(command.active, false) === value && return
+    callback = ifelse(command.active === true, command.callback_off, command.callback_on)
+    command.active !== nothing && (command.active = !command.active)
+    callback !== nothing && callback(state)
+end
+
+save_descend_state(state::CthulhuState) = (; state.mi, state.ci, state.override)
+
+function restore_descend_state!(state::CthulhuState, (; mi, ci, override)::NamedTuple)
+    state.mi = mi
+    state.ci = ci
+    state.override = override
+    return state
+end

--- a/src/state.jl
+++ b/src/state.jl
@@ -57,11 +57,11 @@ function default_menu_commands()
         set_view('T', :typed, :show),
         set_view('L', :llvm, :show),
         set_view('N', :native, :show),
+        perform_action(nothing, 'q', :quit, :actions),
+        perform_action(bookmark_method, 'b', :bookmark, :actions),
         perform_action(edit_source_code, 'E', :edit, :actions, "Edit source code"),
         perform_action(revise_and_redisplay!, 'R', :revise, :actions, "Revise and redisplay"),
-        perform_action(bookmark_method, 'b', :bookmark, :actions),
         perform_action(dump_parameters, 'P', :dump_params, :actions, "dump params cache"),
-        perform_action(nothing, 'q', :quit, :actions),
     ]
     return commands
 end

--- a/src/state.jl
+++ b/src/state.jl
@@ -220,6 +220,16 @@ function default_style_for_command_key(provider::AbstractProvider, state::Cthulh
     return default_style(value)
 end
 
+value_for_command(provider::AbstractProvider, state::CthulhuState, command::Command) =
+    value_for_default_command(provider, state, command)
+
+function value_for_default_command(provider::AbstractProvider, state::CthulhuState, command::Command)
+    command.category === :show && return state.config.view === command.name
+    command.category !== :toggles && return nothing
+    !hasproperty(state.config, command.name) && return nothing
+    return getproperty(state.config, command.name)
+end
+
 default_style(@nospecialize(value)) = NamedTuple()
 default_style(value::Nothing) = (; color=:cyan, bold=false)
 function default_style(value::Bool)
@@ -232,14 +242,4 @@ function debuginfo_style(value::Symbol)
     i === nothing && return NamedTuple()
     color = (:red, :light_black, :green)[i]
     return (; color, bold = color === :green)
-end
-
-value_for_command(provider::AbstractProvider, state::CthulhuState, command::Command) =
-    value_for_default_command(provider, state, command)
-
-function value_for_default_command(provider::AbstractProvider, state::CthulhuState, command::Command)
-    command.category === :show && return state.config.view === command.name
-    command.category !== :toggles && return nothing
-    !hasproperty(state.config, command.name) && return nothing
-    return getproperty(state.config, command.name)
 end

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -2,6 +2,28 @@ using REPL.TerminalMenus
 import REPL.TerminalMenus: request
 using FoldingTrees
 
+mutable struct CustomToggle
+    onoff::Bool
+    key::UInt32
+    toggle::Symbol
+    description::String
+    callback_on
+    callback_off
+    function CustomToggle(onoff::Bool, key, description,
+        @nospecialize(callback_on), @nospecialize(callback_off))
+        key = convert(UInt32, key)
+        desc = convert(String, description)
+        toggle = Symbol(desc)
+        if haskey(TOGGLES, key)
+            error(lazy"invalid Cthulhu API: key `$key` is already used.")
+        elseif toggle in values(TOGGLES)
+            error(lazy"invalid Cthulhu API: toggle `$toggle` is already used.")
+        end
+        return new(onoff, key, toggle, desc, callback_on, callback_off)
+    end
+end
+custom_toggles(provider::AbstractProvider) = CustomToggle[]
+
 mutable struct CthulhuMenu <: TerminalMenus.ConfiguredMenu{TerminalMenus.Config}
     options::Vector{String}
     pagesize::Int

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -111,16 +111,19 @@ function usage(provider::AbstractProvider, state::CthulhuState, commands::Vector
     printstyled(io, "Select a call to descend into or ↩ to ascend."; color = :blue)
     categories = split_by_category(commands)
     for (category, list) in categories
-        printstyled(io, '\n', uppercasefirst(string(category)); color=:cyan)
-        print(io, ": ")
-        is_first = true
+        did_print = false
         for command in list
-            is_default_command_enabled(provider, state, command) || continue
-            !is_first && print(io, ", ")
-            is_first = false
+            is_command_enabled(provider, state, command) || continue
+            if !did_print
+                printstyled(io, '\n', uppercasefirst(string(category)); color=:cyan)
+                print(io, ": ")
+                did_print = true
+            else
+                print(io, ", ")
+            end
             show_command(io, provider, state, command)
         end
-        print(io, '.')
+        did_print && print(io, '.')
     end
     println(io)
     return String(take!(buffer))

--- a/src/ui.jl
+++ b/src/ui.jl
@@ -112,7 +112,7 @@ function usage(config, commands::Vector{Command})
     buffer = IOBuffer()
     io = IOContext(buffer, :color => true)
 
-    println(io, "\rSelect a call to descend into or ↩ to ascend.")
+    println(io, "Select a call to descend into or ↩ to ascend.")
     # XXX: Add multi-color `debuginfo` printing (see `debugcolors`)
     categories = split_by_category(commands)
     for (category, list) in categories
@@ -134,7 +134,7 @@ function usage(config, commands::Vector{Command})
                 i = 1
                 description = "$key: $description"
             end
-            print(description[1:prevind(description, i)])
+            print(io, description[1:prevind(description, i)])
             print(io, '[', colorize(something(command.active, false), key), ']')
             print(io, description[nextind(description, i):end])
         end
@@ -149,7 +149,8 @@ function TerminalMenus.keypress(menu::CthulhuMenu, key::UInt32)
     i = findfirst(x -> x.key == key, menu.commands)
     i === nothing && return false
     command = menu.commands[i]
-    set_active!(command, menu.state, !something(command.active, false))
+    value = command.category === :show ? true : !something(command.active, false)
+    set_active!(command, menu.state, value)
     menu.toggle = command.name
     return true
 end

--- a/test/generate_irshow.jl
+++ b/test/generate_irshow.jl
@@ -13,9 +13,9 @@ function generate_test_cases(f, tt, fname=string(nameof(f)))
     for optimize in tf
         (; src, infos, codeinst, rt, exct, effects, slottypes) = cthulhu_info(f, tt; optimize);
         for (debuginfo, iswarn, hide_type_stable, inline_cost, type_annotations) in Iterators.product(
-            instances(Cthulhu.DInfo.DebugInfo), tf, tf, tf, tf,
+            (:none, :source, :compact), tf, tf, tf, tf,
         )
-            !optimize && debuginfo === Cthulhu.DInfo.compact && continue
+            !optimize && debuginfo === :compact && continue
             !optimize && inline_cost && continue
 
             s = sprint(; context=:color=>true) do io

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -9,14 +9,14 @@ function cthulhu_info(@nospecialize(f), @nospecialize(tt=());
                       optimize=true, interp=Cthulhu.CC.NativeInterpreter())
     (interp, codeinst) = Cthulhu.mkinterp(f, tt; interp)
     (; src, rt, exct, infos, slottypes, effects) =
-        Cthulhu.lookup(interp, codeinst, optimize)
+        Cthulhu.LookupResult(interp, codeinst, optimize)
     return (; interp, src, infos, codeinst, rt, exct, slottypes, effects)
 end
 
 function find_callsites_by_ftt(@nospecialize(f), @nospecialize(TT=Tuple{}); optimize=true)
     (; interp, src, infos, codeinst, slottypes) = cthulhu_info(f, TT; optimize)
     src === nothing && return Cthulhu.Callsite[]
-    callsites, _ = Cthulhu.find_callsites(interp, src, infos, codeinst, slottypes, optimize)
+    callsites, _ = Cthulhu.find_callsites(interp, src, infos, codeinst, slottypes)
     @test all(c -> Cthulhu.get_effects(c) isa Cthulhu.Effects, callsites)
     return callsites
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -1,4 +1,5 @@
 using Test, Cthulhu, InteractiveUtils
+using Cthulhu: AbstractProvider, CthulhuConfig, CthulhuState, find_method_instance, generate_code_instance, LookupResult
 if isdefined(parentmodule(@__MODULE__), :VSCodeServer)
     using ..VSCodeServer
 end
@@ -7,16 +8,17 @@ end
 
 function cthulhu_info(@nospecialize(f), @nospecialize(tt=());
                       optimize=true, interp=Cthulhu.CC.NativeInterpreter())
-    (interp, codeinst) = Cthulhu.mkinterp(f, tt; interp)
-    (; src, rt, exct, infos, slottypes, effects) =
-        Cthulhu.LookupResult(interp, codeinst, optimize)
-    return (; interp, src, infos, codeinst, rt, exct, slottypes, effects)
+    provider = AbstractProvider(interp)
+    mi = find_method_instance(provider, f, tt)
+    ci = generate_code_instance(provider, mi)
+    result = LookupResult(provider, ci, optimize)
+    return provider, mi, ci, result
 end
 
 function find_callsites_by_ftt(@nospecialize(f), @nospecialize(TT=Tuple{}); optimize=true)
-    (; interp, src, infos, codeinst, slottypes) = cthulhu_info(f, TT; optimize)
-    src === nothing && return Cthulhu.Callsite[]
-    callsites, _ = Cthulhu.find_callsites(interp, src, infos, codeinst, slottypes)
+    provider, mi, ci, result = cthulhu_info(f, TT; optimize)
+    result.src === nothing && return Cthulhu.Callsite[]
+    callsites, _ = Cthulhu.find_callsites(provider, result, ci)
     @test all(c -> Cthulhu.get_effects(c) isa Cthulhu.Effects, callsites)
     return callsites
 end

--- a/test/setup.jl
+++ b/test/setup.jl
@@ -9,7 +9,7 @@ function cthulhu_info(@nospecialize(f), @nospecialize(tt=());
                       optimize=true, interp=Cthulhu.CC.NativeInterpreter())
     (interp, codeinst) = Cthulhu.mkinterp(f, tt; interp)
     (; src, rt, exct, infos, slottypes, effects) =
-        Cthulhu.lookup(interp, codeinst, optimize; allow_no_src=true)
+        Cthulhu.lookup(interp, codeinst, optimize)
     return (; interp, src, infos, codeinst, rt, exct, slottypes, effects)
 end
 

--- a/test/test_Cthulhu.jl
+++ b/test/test_Cthulhu.jl
@@ -1,4 +1,4 @@
-module test_Cthulhu
+# module test_Cthulhu
 
 using Test, Cthulhu, StaticArrays, Random
 using Core: Const
@@ -886,8 +886,8 @@ end
 
 @testset "preferences" begin
     # Test that load and save are able to set state
-    Cthulhu.CONFIG.enable_highlighter = true
-    Cthulhu.CONFIG.debuginfo = :none
+    @reset Cthulhu.CONFIG.enable_highlighter = true
+    @reset Cthulhu.CONFIG.debuginfo = :none
     Cthulhu.save_config!(Cthulhu.CONFIG)
 
     Cthulhu.CONFIG.enable_highlighter = false
@@ -895,7 +895,7 @@ end
     @test Cthulhu.CONFIG.debuginfo === :compact
     @test !Cthulhu.CONFIG.enable_highlighter
 
-    Cthulhu.read_config!(Cthulhu.CONFIG)
+    Cthulhu.read_config!()
     @test Cthulhu.CONFIG.debuginfo === :none
     @test Cthulhu.CONFIG.enable_highlighter
 end
@@ -964,4 +964,4 @@ f515() = cglobal((:foo, bar))
     end
 end
 
-end # module test_Cthulhu
+# end # module test_Cthulhu

--- a/test/test_codeview.jl
+++ b/test/test_codeview.jl
@@ -18,7 +18,7 @@ Revise.track(TestCodeViewSandbox, normpath(@__DIR__, "TestCodeViewSandbox.jl"))
             codeview == Cthulhu.cthulhu_ast && continue
         end
         @testset "optimize: $optimize" for optimize in tf
-            @testset "debuginfo: $debuginfo" for debuginfo in instances(Cthulhu.DInfo.DebugInfo)
+            @testset "debuginfo: $debuginfo" for debuginfo in (:none, :source, :compact)
                 config = Cthulhu.CONFIG
 
                 io = IOBuffer()
@@ -29,7 +29,7 @@ Revise.track(TestCodeViewSandbox, normpath(@__DIR__, "TestCodeViewSandbox.jl"))
         end
     end
 
-    @testset "debuginfo: $debuginfo" for debuginfo in instances(Cthulhu.DInfo.DebugInfo)
+    @testset "debuginfo: $debuginfo" for debuginfo in (:none, :source, :compact)
         @testset "iswarn: $iswarn" for iswarn in tf
             @testset "hide_type_stable: $hide_type_stable" for hide_type_stable in tf
                 @testset "inline_cost: $inline_cost" for inline_cost in tf

--- a/test/test_irshow.jl
+++ b/test/test_irshow.jl
@@ -12,12 +12,12 @@ include("IRShowSandbox.jl")
     @testset "optimize: $optimize" for optimize in tf
         (; src, infos, codeinst, rt, exct, effects, slottypes) = cthulhu_info(IRShowSandbox.foo, (Int, Int); optimize);
 
-        @testset "debuginfo: $debuginfo" for debuginfo in instances(Cthulhu.DInfo.DebugInfo)
+        @testset "debuginfo: $debuginfo" for debuginfo in (:none, :source, :compact)
             @testset "iswarn: $iswarn" for iswarn in tf
                 @testset "hide_type_stable: $hide_type_stable" for hide_type_stable in tf
                     @testset "inline_cost: $inline_cost" for inline_cost in tf
                         @testset "type_annotations: $type_annotations" for type_annotations in tf
-                            !optimize && debuginfo === Cthulhu.DInfo.compact && continue
+                            !optimize && debuginfo === :compact && continue
                             !optimize && inline_cost && continue
 
                             s = sprint(; context=:color=>true) do io

--- a/test/test_provider.jl
+++ b/test/test_provider.jl
@@ -1,0 +1,17 @@
+# module test_provider
+
+using Test, Cthulhu, StaticArrays, Random
+using Core: Const
+const CC = Cthulhu.CTHULHU_MODULE[].CC
+using Cthulhu: DefaultProvider
+
+include("setup.jl")
+include("irutils.jl")
+
+provider = DefaultProvider()
+
+# descend(provider, +, (Int, Int))
+descend(provider, exp, (Float64,))
+@descend 1 + 1
+
+# end # module test_provider

--- a/test/test_terminal.jl
+++ b/test/test_terminal.jl
@@ -1,4 +1,4 @@
-module test_terminal
+# module test_terminal
 
 using Core: Const
 using Test, REPL, Cthulhu, Revise
@@ -364,4 +364,4 @@ end
     end
 end
 
-end # module test_terminal
+# end # module test_terminal


### PR DESCRIPTION
Implements #648.

This PR redesigns the way that downstream generators of `CodeInstance` (be it via `AbstractIntepreter` or other means) integrate with Cthulhu, defining an interface around a new `AbstractProvider` API. This `AbstractProvider` abstract type drives a dispatch-based interface, with most methods taking it as first argument (similarly to `AbstractInterpreter` in Compiler), allowing for a large amount of customization for users defining their own subtype implementation. The Cthulhu codebase was significantly overhauled as part of this work, with major refactors around the descend and UI parts aimed at facilitating the API changes.

Internals have been redesigned to operate on a `CthulhuState` struct that contains all of the information needed to drive the logic and the display of code. This greatly simplifies all of the data-flow that previously relied on the passing of many parameters and the assignment of various local variables throughout `descend` and other parts of the codebase, making internals conceptually simpler.

The architecture for the UI command system has been completely reworked. Built-in commands are no longer separate from user commands (which were previously implemented as `CustomToggle`s), they now use the same `Command` type. The only difference between the two is that built-in commands are implemented by default, being built-in (though they can be disabled or deleted). Furthermore, it is now possible to:
- Add UI categories besides the built-in `Toggles`, `Show` and `Actions` categories, which will be nicely printed and will group options under the same category.
- Remove built-in commands (they are no longer hardcoded in the control-flow), useful e.g. when the `llvm` or `native` view is not supported or when remarks are not processed for downstream `AbstractInterpreter`/`CodeInstance`s.
- Customize pretty much all of the printing, so that users have full control over how e.g. multi-modal commands (as with the `debuginfo` option) should be printed.

In addition do that, the `annotate_source` configuration option has been merged into a `view::Symbol` option, with the `:source|:ast|:typed|:llvm|:native` available views by default (more may be defined by users) all merged into the `CthulhuConfig`.

Here are a few user integrations that I prototyped to test this new API (1.12+):
- DAECompiler.jl: https://github.com/serenity4/DAECompiler.jl/blob/cthulhu/src/cthulhu.jl (you will need https://github.com/serenity4/Diffractor.jl/tree/cthulhu for that)
- SPIRV.jl: https://github.com/serenity4/SPIRV.jl/blob/main/ext/SPIRVCthulhuExt.jl

To do:
- [ ] Add docs and docstrings covering the new API.
- [ ] Document the main changes from the previous version (specifically for user-facing settings).
- [ ] Add small self-contained tests for integration with external `AbstractInterpreter`s (like SPIRV.jl and Diffractor.jl) and external `AbstractProvider`s (like DAECompiler.jl).
- [ ] Re-enable remark/effect annotation for statements.
- [ ] Re-enable VSCode-related diagnostics.
- [ ] Re-enable source mapping (via TypedSyntax).
- [ ] Take a deeper look at the bookmark functionality.
- [ ] Add tests for recently fixed issues (to ensure no major regressions occur).

Either before merge or as a follow-up, I'd like to take a deeper look at the interactions between `Base.Compiler` and `Compiler`. It should be easier than before to deal with that on the user side, though. Various parts of the codebase (the internal core logic, the UI, and anything compiler-related) were further decoupled as part of this refactor, so it should even be possible to only have to reevaluate part of the Cthulhu codebase in the extension, instead of re-including all of it. That requires further investigation though.

At this stage, I am still making changes across various areas, therefore precise reviews will have to wait a bit longer. Comments about the approach from a higher viewpoint are very much appreciated, however.