### PR TITLE
lookup: fix semiconcrete calls with annotate_types=true

### DIFF
--- a/src/CthulhuBase.jl
+++ b/src/CthulhuBase.jl
@@ -264,14 +264,14 @@ function lookup_constproped_unoptimized(interp::CthulhuInterpreter, override::In
     return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf)
 end
 
-function lookup_semiconcrete(interp::CthulhuInterpreter, override::SemiConcreteCallInfo, optimize::Bool)
+function lookup_semiconcrete(interp::CthulhuInterpreter, ci::CodeInstance, override::SemiConcreteCallInfo, optimize::Bool)
     src = CC.copy(override.ir)
     rt = get_rt(override)
     exct = Any # TODO
     infos = src.stmts.info
     slottypes = src.argtypes
     effects = get_effects(override)
-    codeinf = nothing # TODO try to find `CodeInfo` for the regular inference?
+    (; exct, codeinf) = lookup(interp, ci, optimize)
     return LookupResult(src, rt, exct, infos, slottypes, effects, codeinf)
 end
 

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -31,8 +31,8 @@ lookup_semiconcrete(interp::AbstractInterpreter, curs::AbstractCursor, override:
 missing `$AbstractCursor` API:
 `$(typeof(curs))` is required to implement the `$lookup_semicocnrete(interp::$(typeof(interp)), curs::$(typeof(curs)), override::SemiConcreteCallInfo, optimize::Bool)` interface.
 """)
-lookup_semiconcrete(interp::CthulhuInterpreter, ::CthulhuCursor, override::SemiConcreteCallInfo, optimize::Bool) =
-    lookup_semiconcrete(interp, override, optimize)
+lookup_semiconcrete(interp::CthulhuInterpreter, curs::CthulhuCursor, override::SemiConcreteCallInfo, optimize::Bool) =
+    lookup_semiconcrete(interp, get_ci(curs), override, optimize)
 
 get_ci(curs::AbstractCursor) = error(lazy"""
 missing `$AbstractCursor` API:


### PR DESCRIPTION
Currently an error occurs when descending into semi-concrete interpreted calls with `annotate_types=true`. This happens because the current implementation of `lookup_semiconcrete` does not handle the `!optimize` case at all.

This commit resolves the issue by passing `ci::CodeInstance` to `lookup_semiconcrete`, allowing it to call `lookup()` from there.

MRE:
```julia
julia> callsincos(x, y) = sin(x), cos(y);

julia> descend((Int,); annotate_types=true) do x
           callsincos(x, 42.)
       end # then descend into `callsincos`
```