### PR TITLE
TypedSyntax: Don't create empty children preemptively

### DIFF
--- a/TypedSyntax/Project.toml
+++ b/TypedSyntax/Project.toml
@@ -1,7 +1,7 @@
 name = "TypedSyntax"
 uuid = "d265eb64-f81a-44ad-a842-4247ee1503de"
 authors = ["Tim Holy <tim.holy@gmail.com> and contributors"]
-version = "1.5.1"
+version = "1.5.2"
 
 [deps]
 CodeTracking = "da1fd8a2-8d9e-5ec2-8556-3022fb5608a2"


### PR DESCRIPTION
This caused a breakage seen on #675, introduced in #661.

To properly test that, we'll need to re-enable the VSCode tests, but I can confirm locally that this PR fixes the issue.